### PR TITLE
removing extra space from contact navlink

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -163,7 +163,7 @@ const Navbar = () => {
               </NavLink>
             </li>
             <li>
-              <NavLink to="/contact " name="contact">
+              <NavLink to="/contact" name="contact">
                 {t("contact")}
               </NavLink>
             </li>


### PR DESCRIPTION
There was extra space in contact navlink in Navbar.jsx file.  Removed the extra space to fix it.