### PR TITLE
Trigger CICD for all 3 standard branches

### DIFF
--- a/.github/workflows/CICDPipeline.yaml
+++ b/.github/workflows/CICDPipeline.yaml
@@ -4,11 +4,11 @@ name: CI/CD
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  # Triggers the workflow on push or pull request events
   push:
-    branches: ["main"]
+    branches: ["test", "dev", "main"]
   pull_request:
-    branches: ["dev", "main"]
+    branches: ["test", "dev", "main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Trigger CICD for all 3 standard branches.  In particular:

* Add test branch for PRs so that CICD can be run and required to pass before merge.
* Add test and dev for pushes so that CICD can be run once a PR is merged and before the code is deployed.