### PR TITLE
Changed 'Requester' to 'Beneficiary' when user hovers mouse over user…

### DIFF
--- a/src/pages/RequestDetails/RequestDetails.jsx
+++ b/src/pages/RequestDetails/RequestDetails.jsx
@@ -55,7 +55,7 @@ const RequestDetails = () => {
   const attributes = [
     {
       context: "Peter parker",
-      type: "Requester",
+      type: "Beneficiary",
       icon: <IoPersonCircle size={26} />,
     },
     {


### PR DESCRIPTION
The user's name currently shows '**Requester**' on hover.
This change modifies the tooltip text to display '**Beneficiary**' instead, as per the requirement.
Manually tested the tooltip behavior on hover to confirm the new text is shown as expected.