### PR TITLE
Fix for organization details form to save data (#450)

### DIFF
--- a/src/pages/Profile/OrganizationDetails.jsx
+++ b/src/pages/Profile/OrganizationDetails.jsx
@@ -57,7 +57,7 @@ function OrganizationDetails({ setHasUnsavedChanges }) {
   }, []);
 
   const handleInputChange = (e) => {
-    const { name, code, value } = e.target;
+    const { name, value } = e.target;
 
     let errorMsg = "";
     if (name == "email") {
@@ -80,7 +80,7 @@ function OrganizationDetails({ setHasUnsavedChanges }) {
 
     setOrganizationInfo((prevInfo) => ({
       ...prevInfo,
-      [name]: code,
+      [name]: value,
     }));
     setHasUnsavedChanges(true);
   };
@@ -95,10 +95,10 @@ function OrganizationDetails({ setHasUnsavedChanges }) {
   };
 
   const handleSaveClick = () => {
-    let hasError = False;
+    let hasError = false;
     Object.values(errors).forEach((error) => {
       if (error !== "") {
-        hasError = True;
+        hasError = true;
       }
     });
     if (hasError) {
@@ -202,7 +202,7 @@ function OrganizationDetails({ setHasUnsavedChanges }) {
                   handleInputChange({
                     target: {
                       name: "phoneCountryCode",
-                      code: selectedOption.code,
+                      value: selectedOption.code,
                     },
                   })
                 }


### PR DESCRIPTION
Fixed an issue where changes made in the Organization Details form were not being saved after clicking the Save Changes button.
Replaced incorrect usage of True/False with proper JavaScript boolean values (true/false).
Updated handleInputChange to correctly use value instead of code for input fields.
Verified form data updates correctly and is saved to localStorage.

