### PR TITLE
Fix: Validate all required fields on empty Sign Up form submission

### DIFF
--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -112,12 +112,6 @@ const SignUp = () => {
   const handleSignUp = async () => {
     try {
       setErrors({});
-      const fullPhoneNumber = `${PHONECODESEN[countryCode]["secondary"]}${phone}`;
-
-      if (!isValidPhoneNumber(fullPhoneNumber)) {
-        setErrors({ ...errors, phone: "Please enter a valid phone number" });
-        return;
-      }
 
       const result = signUpSchema.safeParse({
         firstName,
@@ -140,12 +134,27 @@ const SignUp = () => {
         return;
       }
 
-      if (passwordValue !== confirmPasswordValue) {
-        setPasswordsMatch(false);
-        setErrors({ ...errors, confirmPassword: "Passwords do not match" });
+      // Now, after basic field validation, check if phone number is really valid
+      const fullPhoneNumber = `${PHONECODESEN[countryCode]["secondary"]}${phone}`;
+
+      if (!isValidPhoneNumber(fullPhoneNumber)) {
+        setErrors((prevErrors) => ({
+          ...prevErrors,
+          phone: "Please enter a valid phone number",
+        }));
         return;
       }
 
+      if (passwordValue !== confirmPasswordValue) {
+        setPasswordsMatch(false);
+        setErrors((prevErrors) => ({
+          ...prevErrors,
+          confirmPassword: "Passwords do not match",
+        }));
+        return;
+      }
+
+      // Proceed with signup
       const user = await signUp({
         username: emailValue,
         password: passwordValue,


### PR DESCRIPTION
Fixed an issue where only the phone number field was being validated on empty Sign Up form submission. Now, all required fields are properly validated and show appropriate error messages when the form is submitted without input.