### PR TITLE
fixed Close button not visible for 'More info' popup

### DIFF
--- a/src/common/components/Modal/Modal.jsx
+++ b/src/common/components/Modal/Modal.jsx
@@ -11,7 +11,11 @@ const Modal = ({
 
   return (
     <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl flex flex-col max-h-[90vh]">
+      <div
+        className="bg-white rounded-lg shadow-lg w-full max-w-2xl flex flex-col max-h-[90vh]"
+        role="dialog"
+        aria-modal="true"
+      >
         {/* Scrollable content area */}
         <div className="overflow-y-auto p-6 flex-1">{children}</div>
 

--- a/src/common/components/Modal/__snapshots__/modal.test.js.snap
+++ b/src/common/components/Modal/__snapshots__/modal.test.js.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal renders when show = true 1`] = `
-<div>
+<div
+  aria-modal="true"
+  class="bg-white rounded-lg shadow-lg w-full max-w-2xl flex flex-col max-h-[90vh]"
+  role="dialog"
+>
   <div
-    class="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+    class="overflow-y-auto p-6 flex-1"
   >
-    <div
-      class="bg-white p-6 rounded-lg shadow-lg max-w-2xl w-full"
-    >
-      <div>
-        child
-      </div>
-      <div
-        class="flex justify-end space-x-2 mt-6"
-      >
-        <button
-          class="bg-gray-400 text-white px-3 py-1 text-sm rounded hover:bg-gray-500 transition"
-        >
-          Close
-        </button>
-      </div>
+    <div>
+      child
     </div>
+  </div>
+  <div
+    class="flex justify-end space-x-2 p-4 border-t border-gray-200"
+  >
+    <button
+      class="bg-gray-400 text-white px-3 py-1 text-sm rounded hover:bg-gray-500 transition"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;

--- a/src/common/components/Modal/modal.test.js
+++ b/src/common/components/Modal/modal.test.js
@@ -12,12 +12,12 @@ describe("Modal", () => {
   });
 
   it("renders when show = true", () => {
-    const { container } = render(
+    render(
       <Modal show={true} onClose={onClose}>
         {children}
       </Modal>,
     );
-    expect(container).toMatchSnapshot();
+    expect(screen.getByRole("dialog")).toMatchSnapshot();
   });
 
   it("does not render when show = false", () => {

--- a/src/common/components/RequestButton/RequestButton.jsx
+++ b/src/common/components/RequestButton/RequestButton.jsx
@@ -108,7 +108,7 @@ const RequestButton = ({
     <>
       <button
         onClick={handleClick}
-        className={`${customStyle} h-12 flex items-center justify-center sm:justify-center lg:justify-start `}
+        className={`${customStyle} h-12 flex items-center justify-center sm:justify-center lg:justify-start`}
       >
         <span>{getIcon()}</span>
         <span className="hidden lg:inline">{text}</span>


### PR DESCRIPTION
- Implemented max-height and scroll in the Modal component to ensure the 'Close' button remains visible even when expanding 'Show More' content.
- Adjusted ExpandableMarkdown behavior to maintain popup size consistency.
- Resolved issue where long AI-generated text in requests REQ-00-000-000-0007 and 0008 caused the popup to overflow the viewport.
