### PR TITLE
Feature/srirama collaborators fix - fix: added Volunteer Match link and removed persistent focus styling from Volunteer Match link (Collaborators page)

### DIFF
--- a/src/pages/Collaborators/Collaborators.jsx
+++ b/src/pages/Collaborators/Collaborators.jsx
@@ -1,10 +1,24 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import VolunteerMatchLogo from "../../assets/Collab_logos/volunteer-match.png";
 import { Link } from "react-router-dom";
+import VolunteerMatchLogo from "../../assets/Collab_logos/volunteer-match.png";
 
 function Collaborators() {
   const { t } = useTranslation();
+  const volunteerLinkRef = useRef(null);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && volunteerLinkRef.current) {
+        volunteerLinkRef.current.blur();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
 
   return (
     <div className="flex flex-col items-center p-8 min-h-screen bg-white">
@@ -19,9 +33,14 @@ function Collaborators() {
           )}
         </p>
 
-        {/* Centered Volunteer Match section */}
         <div className="flex justify-center mb-16">
-          <div className="flex flex-col items-center max-w-md">
+          <a
+            ref={volunteerLinkRef}
+            href="https://www.volunteermatch.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-center max-w-md text-blue-700 hover:underline focus:outline-none"
+          >
             <img
               src={VolunteerMatchLogo}
               alt="Volunteer Match"
@@ -35,7 +54,7 @@ function Collaborators() {
                 "U.S based nonprofit organization which provides a national digital infrastructure to serve volunteers and nonprofits organization.",
               )}
             </p>
-          </div>
+          </a>
         </div>
 
         <div className="text-center mt-16 mb-16">


### PR DESCRIPTION
This pull request fixes the persistent focus styling issue for the Volunteer Match link on the Collaborators page.

Changes Made:
Converted the Volunteer Match section into an external link (<a>) that opens in a new tab.

Added a useRef and useEffect to remove focus from the link when the user returns to the page using the browser's back button.

Maintained existing Tailwind CSS styling (text-blue-700, hover:underline, focus:outline-none) for a consistent appearance.

Cleaned up the JSX structure by removing unnecessary wrapper elements.

Reason:
When users clicked on the Volunteer Match link and returned to the Collaborators page, the link remained visually focused (blue underline) until they clicked elsewhere. This update ensures the link doesn't stay highlighted, improving the user experience.

Contributor:
This change addresses issue https://github.com/saayam-for-all/webapp/issues/755
Implemented by Srirama Murthy Chellu
Branch: feature/srirama-collaborators-fix