### PR TITLE
Add Thanks page redirect after Contact Us form submission - Issue 752

### DIFF
--- a/src/pages/Contact/ContactUs.jsx
+++ b/src/pages/Contact/ContactUs.jsx
@@ -240,6 +240,11 @@ const ContactUs = () => {
               name="phone"
               value={`${PHONECODESEN[countryCode]["secondary"]}${phone}`}
             />
+            <input
+              type="hidden"
+              name="_next"
+              value={`${window.location.origin}/thanks`}
+            />
 
             {/* Message */}
             <div className="mb-4">

--- a/src/pages/Thanks/Thanks.jsx
+++ b/src/pages/Thanks/Thanks.jsx
@@ -1,0 +1,24 @@
+import { useNavigate } from "react-router-dom";
+
+const Thanks = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="bg-gray-100 flex flex-col justify-center items-center m-5 p-5">
+      <h1 className="text-4xl font-bold px-5">Thanks!</h1>
+      <div className="flex flex-wrap items-center gap-2 m-4 justify-center items-center">
+        <span className="text-xl">
+          The email was sent successfully. Return back
+        </span>
+        <button
+          className="bg-blue-500 text-white py-2 px-4 rounded-full hover:bg-blue-600"
+          onClick={() => navigate("/")}
+        >
+          Home
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Thanks;

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -27,6 +27,7 @@ import BenevityInfo from "../pages/Benevity/BenevityInfo";
 import TermsAndConditions from "../pages/TermsAndConditions/TermsAndConditions";
 
 import PrivacyPolicy from "../pages/PrivacyPolicy/PrivacyPolicy";
+import Thanks from "../pages/Thanks/Thanks";
 
 const routes = [
   {
@@ -60,6 +61,10 @@ const routes = [
   {
     path: "contact",
     element: <ContactUs />,
+  },
+  {
+    path: "thanks",
+    element: <Thanks />,
   },
   {
     path: "sitemap",


### PR DESCRIPTION
Closes #752

Previously, the Contact Us form redirected to FormSubmit’s default thank you page.
**Before:**
<img width="596" height="262" alt="image" src="https://github.com/user-attachments/assets/e71f262d-4190-4c80-a877-01c7c1bef488" />

Added a custom `Thanks.jsx` and updated the form to redirect to it after submission.
**After:**
<img width="611" height="299" alt="image" src="https://github.com/user-attachments/assets/c5c166d5-1ba7-4f4a-9a73-7f5e0149355a" />
<img width="338" height="287" alt="image" src="https://github.com/user-attachments/assets/4d61057c-f522-4b54-a5be-135e2f9afa6b" />
