### PR TITLE
Add Scroll to top button

### DIFF
--- a/src/Layout/Layout.jsx
+++ b/src/Layout/Layout.jsx
@@ -7,6 +7,7 @@ import RightAds from "#components/RightAds/RightAds";
 import { Suspense } from "react";
 import { Outlet, useMatches } from "react-router-dom";
 import { NotificationProvider } from "../context/NotificationContext";
+import ScrollToTop from "../common/components/ScrollToTop/ScrollToTop";
 
 const Layout = () => {
   const matches = useMatches();
@@ -20,7 +21,7 @@ const Layout = () => {
         <NavigationGuard />
 
         {/* header includes Navbar which spans full width */}
-        <header className="sticky z-10">
+        <header className="sticky z-10" id="header">
           <Navbar />
         </header>
 
@@ -48,6 +49,7 @@ const Layout = () => {
         <footer className="">
           <Footer />
         </footer>
+        <ScrollToTop />
       </NotificationProvider>
     </div>
   );

--- a/src/common/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/common/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+const ScrollToTop = () => {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setShow(!entry.isIntersecting),
+      { threshold: 0.1 },
+    );
+    const header = document.getElementById("header");
+    if (header) observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <button
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-black/20 text-white rounded-full z-50 flex items-center justify-center text-lg sm:text-xl"
+    >
+      ↑
+    </button>
+  );
+};
+
+export default ScrollToTop;

--- a/src/common/components/ScrollToTop/ScrollToTop.test.js
+++ b/src/common/components/ScrollToTop/ScrollToTop.test.js
@@ -1,0 +1,50 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ScrollToTop from "./ScrollToTop";
+
+//Mock IntersectionObserver for Jest environment which is supported by React
+beforeAll(() => {
+  global.IntersectionObserver = class {
+    constructor(callback) {
+      this.callback = callback;
+    }
+    observe() {
+      this.callback([{ isIntersecting: false }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe("ScrollToTop", () => {
+  beforeEach(() => {
+    //dummy header element
+    const header = document.createElement("div");
+    header.setAttribute("id", "header");
+    document.body.appendChild(header);
+  });
+
+  afterEach(() => {
+    const header = document.getElementById("header");
+    if (header) header.remove();
+  });
+
+  //test case 1
+  it("renders the scroll button", () => {
+    render(<ScrollToTop />);
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+  });
+
+  //test case 2
+  it("scrolls to top on click", () => {
+    const scrollSpy = jest.spyOn(window, "scrollTo");
+    render(<ScrollToTop />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(scrollSpy).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+});


### PR DESCRIPTION
**This PR resolves Issue #779.**
Implements a responsive Scroll to Top button that appears when the header is out of view in layout
**Button preview:**

<img width="126" height="91" alt="image" src="https://github.com/user-attachments/assets/e1194a1e-778f-4098-bc9a-5a8d10290dec" />

**Whole page view:**

<img width="1884" height="928" alt="image" src="https://github.com/user-attachments/assets/7bc34bae-d480-40cb-a30e-30c4af5d9ac7" />
