### PR TITLE
Fix #783: Enlarged Volunteer Agreement box height

### DIFF
--- a/src/pages/Volunteer/steps/TermsConditions.jsx
+++ b/src/pages/Volunteer/steps/TermsConditions.jsx
@@ -47,7 +47,7 @@ const TermsConditions = ({ isAcknowledged, setIsAcknowledged }) => {
       <div
         ref={scrollBoxRef}
         className="scrolling-box mt-4 mb-4 p-4 border border-gray-300"
-        style={{ height: "150px", overflowY: "auto" }}
+        style={{ height: "400px", overflowY: "auto" }}
       >
         <h3 className="font-bold text-lg mb-2">{t("VOLUNTEER_AGREEMENT")}</h3>
         <div>


### PR DESCRIPTION
- Increased height of the Volunteer agreement box from 150px to 400px
- Now fills the empty vertical space between agreement and buttons
- Other UI components remain unaffected
