### PR TITLE
Changed color of scroll to top button for better visibility

### DIFF
--- a/src/Layout/__snapshots__/layout.test.js.snap
+++ b/src/Layout/__snapshots__/layout.test.js.snap
@@ -30,7 +30,7 @@ exports[`Layout renders correctly 1`] = `
           <mock-footer />
         </footer>
         <button
-          class="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-black/20 text-white rounded-full z-50 flex items-center justify-center text-lg sm:text-xl"
+          class="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-gray-200 text-black hover:bg-gray-300 rounded-full z-50 flex items-center justify-center text-xl sm:text-2xl font-extrabold"
         >
           ↑
         </button>
@@ -63,7 +63,7 @@ exports[`Layout renders correctly 1`] = `
         <mock-footer />
       </footer>
       <button
-        class="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-black/20 text-white rounded-full z-50 flex items-center justify-center text-lg sm:text-xl"
+        class="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-gray-200 text-black hover:bg-gray-300 rounded-full z-50 flex items-center justify-center text-xl sm:text-2xl font-extrabold"
       >
         ↑
       </button>

--- a/src/common/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/common/components/ScrollToTop/ScrollToTop.jsx
@@ -18,7 +18,7 @@ const ScrollToTop = () => {
   return (
     <button
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-      className="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-black/20 text-white rounded-full z-50 flex items-center justify-center text-lg sm:text-xl"
+      className="fixed bottom-4 right-4 w-8 h-8 sm:w-12 sm:h-12 bg-gray-200 text-black hover:bg-gray-300 rounded-full z-50 flex items-center justify-center text-xl sm:text-2xl font-extrabold"
     >
       ↑
     </button>


### PR DESCRIPTION
This PR improves the visibility of the Scroll to Top button by updating its color. Previously, the button’s semi-transparent black background lacked contrast against the black footer. It is now updated to use a white background with black text.

<img width="156" height="112" alt="image" src="https://github.com/user-attachments/assets/c5e4b2a4-e604-4c24-9a3e-383e14404cf0" />
<img width="154" height="119" alt="image" src="https://github.com/user-attachments/assets/c416c166-00dc-4765-97a2-985621692c43" />
