### PR TITLE
Added back button for sitemap, privacy policy, terms and conditions pages

### DIFF
--- a/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
@@ -1,13 +1,23 @@
 import React from "react";
 import "./PrivacyPolicy.css";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 
 const PrivacyPolicy = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   return (
     <div className="privacy-policy-container">
       <div className="privacy-policy-inner">
+        <div className="w-full mb-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="text-blue-600 hover:text-blue-800 font-semibold text-lg flex items-center"
+          >
+            <span className="text-2xl mr-2">&lt;</span> Back
+          </button>
+        </div>
         <h1 className="privacy-policy-title">{t("PRIVACY_POLICY")}</h1>
         <p>
           {t("AT")} <strong>Saayam for All</strong> {t("PRIVACY_INTRO")}

--- a/src/pages/Sitemap/Sitemap.jsx
+++ b/src/pages/Sitemap/Sitemap.jsx
@@ -1,10 +1,21 @@
 import React from "react";
 import "./Sitemap.css";
+import { useNavigate } from "react-router-dom";
 
 const Sitemap = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="sitemap-container">
       <div className="sitemap-inner">
+        <div className="w-full mb-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="text-blue-600 hover:text-blue-800 font-semibold text-lg flex items-center"
+          >
+            <span className="text-2xl mr-2">&lt;</span> Back
+          </button>
+        </div>
         <h1 className="sitemap-title">Sitemap</h1>
         <div className="sitemap-content-wrapper">
           {/* Row 1: Home */}

--- a/src/pages/TermsAndConditions/TermsAndConditions.jsx
+++ b/src/pages/TermsAndConditions/TermsAndConditions.jsx
@@ -1,13 +1,23 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import "./TermsAndConditions.css";
+import { useNavigate } from "react-router-dom";
 
 const TermsAndConditions = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   return (
     <div className="terms-container">
       <div className="terms-inner">
+        <div className="w-full mb-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="text-blue-600 hover:text-blue-800 font-semibold text-lg flex items-center"
+          >
+            <span className="text-2xl mr-2">&lt;</span> Back
+          </button>
+        </div>
         <h1 className="terms-title">{t("TERMS_AND_CONDITIONS")}</h1>
         <p className="terms-intro">{t("TERMS_INTRO")}</p>
 


### PR DESCRIPTION
This PR resolves issue #825. Now users can navigate to previous pages from sitemap, privacy policy, terms and conditions pages.

**SiteMap**
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/2fe02ca5-ad38-4c6f-b886-b820b3e0f453" />

**Terms and Conditions**
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/0f2fb6df-a7cc-437b-b136-b4af5a121dd2" />

**Privacy Policy**
<img width="1224" height="757" alt="image" src="https://github.com/user-attachments/assets/a4dc2523-0c84-488c-8f3d-42bd6d6a613e" />

