### PR TITLE
Fix TOS page same tab on Sign Up

### DIFF
--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -363,8 +363,6 @@ const SignUp = () => {
             {t("TOS_AGREEMENT")}{" "}
             <a
               href="/terms-and-conditions"
-              target="_blank"
-              rel="noopener noreferrer"
               className="text-blue-500 underline"
             >
               {t("TERMS_AND_CONDITIONS")}


### PR DESCRIPTION
Updated the Terms and Conditions link on the Sign Up page to open in the same tab. 👍