### PR TITLE
Adding 'No' to the for self dropdown in create help request form

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -485,9 +485,10 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                 data-testid="dropdown"
                 className="appearance-none bg-white border p-2 w-full rounded-lg text-gray-700"
                 onChange={(e) => setSelfFlag(e.target.value === "yes")}
-                disabled
+                defaultValue="yes"
               >
                 <option value="yes">{t("YES")}</option>
+                <option value="no">{t("NO")}</option>
               </select>
             </div>
 


### PR DESCRIPTION
I updated the “For Self” dropdown to make it fully interactive by removing the disabled attribute. I also added a “No” option alongside the existing “Yes” option, while keeping “Yes” as the default selection using defaultValue="yes".