### PR TITLE
Added required red asterisk to personal info tab

### DIFF
--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -360,6 +360,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
             {t("ADDRESS", { optional: "" })}
+            <span className="text-red-500 ml-0.5" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only"> ({t("required") || "required"})</span>
           </label>
           {isEditing ? (
             <>
@@ -414,6 +418,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
             {t("COUNTRY")}
+            <span className="text-red-500 ml-0.5" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only"> ({t("required") || "required"})</span>
           </label>
           {isEditing ? (
             <>
@@ -454,6 +462,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
             {t("STATE")}
+            <span className="text-red-500 ml-0.5" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only"> ({t("required") || "required"})</span>
           </label>
           {isEditing ? (
             <>
@@ -479,6 +491,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
             {t("ZIP_CODE")}
+            <span className="text-red-500 ml-0.5" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only"> ({t("required") || "required"})</span>
           </label>
           {isEditing ? (
             <>


### PR DESCRIPTION
### Summary
Added a red asterisk (*) to required fields in the Personal Information tab.

### Changes
- Updated PersonalInformation.jsx to display an asterisk on mandatory fields.
- Styled it to match existing form conventions.

### Testing
- Verified locally with Vite dev server.
- Confirmed consistent behavior on Chrome.