### PR TITLE
Follow-up fix for #931, added translation for "Availability" on the side bar

### DIFF
--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -425,5 +425,6 @@
   "Remove Time Slot": "সময় স্লট সরান",
   "Add Time Slot": "সময় স্লট যোগ করুন",
   "VACATION_MODE_ACTIVE": "ছুটি মোড সক্রিয়",
-  "NO AVAILABILITY SLOTS": "কোন উপলব্ধতা স্লট কনফিগার করা নেই"
+  "NO AVAILABILITY SLOTS": "কোন উপলব্ধতা স্লট কনফিগার করা নেই",
+  "Availability": "উপলব্ধতা"
 }

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -395,5 +395,6 @@
   "Remove Time Slot": "Zeitslot entfernen",
   "Add Time Slot": "Zeitslot hinzufügen",
   "VACATION_MODE_ACTIVE": "Urlaubsmodus aktiv",
-  "NO AVAILABILITY SLOTS": "Keine Verfügbarkeitsslots konfiguriert"
+  "NO AVAILABILITY SLOTS": "Keine Verfügbarkeitsslots konfiguriert",
+  "Availability": "Verfügbarkeit"
 }

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -326,5 +326,6 @@
   "Remove Time Slot": "Remove Time Slot",
   "Add Time Slot": "Add Time Slot",
   "VACATION_MODE_ACTIVE": "Vacation Mode Active",
-  "NO AVAILABILITY SLOTS": "No availability slots configured"
+  "NO AVAILABILITY SLOTS": "No availability slots configured",
+  "Availability": "Availability"
 }

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -409,5 +409,6 @@
   "Remove Time Slot": "Eliminar horario",
   "Add Time Slot": "Agregar horario",
   "VACATION_MODE_ACTIVE": "Modo vacaciones activo",
-  "NO AVAILABILITY SLOTS": "No hay horarios de disponibilidad configurados"
+  "NO AVAILABILITY SLOTS": "No hay horarios de disponibilidad configurados",
+  "Availability": "Disponibilidad"
 }

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -446,5 +446,6 @@
   "Remove Time Slot": "Supprimer le créneau horaire",
   "Add Time Slot": "Ajouter un créneau horaire",
   "VACATION_MODE_ACTIVE": "Mode vacances actif",
-  "NO AVAILABILITY SLOTS": "Aucun créneau de disponibilité configuré"
+  "NO AVAILABILITY SLOTS": "Aucun créneau de disponibilité configuré",
+  "Availability": "Disponibilité"
 }

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -447,5 +447,6 @@
   "Remove Time Slot": "समय स्लॉट हटाएं",
   "Add Time Slot": "समय स्लॉट जोड़ें",
   "VACATION_MODE_ACTIVE": "छुट्टी मोड सक्रिय",
-  "NO AVAILABILITY SLOTS": "कोई उपलब्धता स्लॉट कॉन्फ़िगर नहीं किया गया"
+  "NO AVAILABILITY SLOTS": "कोई उपलब्धता स्लॉट कॉन्फ़िगर नहीं किया गया",
+  "Availability": "उपलब्धता"
 }

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -391,5 +391,6 @@
   "Remove Time Slot": "Remover horário",
   "Add Time Slot": "Adicionar horário",
   "VACATION_MODE_ACTIVE": "Modo férias ativo",
-  "NO AVAILABILITY SLOTS": "Nenhum horário de disponibilidade configurado"
+  "NO AVAILABILITY SLOTS": "Nenhum horário de disponibilidade configurado",
+  "Availability": "Disponibilidade"
 }

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -402,5 +402,6 @@
   "Remove Time Slot": "Удалить временной слот",
   "Add Time Slot": "Добавить временной слот",
   "VACATION_MODE_ACTIVE": "Режим отпуска активен",
-  "NO AVAILABILITY SLOTS": "Нет настроенных слотов доступности"
+  "NO AVAILABILITY SLOTS": "Нет настроенных слотов доступности",
+  "Availability": "Доступность"
 }

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -652,5 +652,6 @@
   "Remove Time Slot": "సమయ స్లాట్‌ను తొలగించు",
   "Add Time Slot": "సమయ స్లాట్‌ను జోడించు",
   "VACATION_MODE_ACTIVE": "విహార మోడ్ క్రియాశీలం",
-  "NO AVAILABILITY SLOTS": "అందుబాటు స్లాట్‌లు కాన్ఫిగర్ చేయబడలేదు"
+  "NO AVAILABILITY SLOTS": "అందుబాటు స్లాట్‌లు కాన్ఫిగర్ చేయబడలేదు",
+  "Availability": "అందుబాటు"
 }

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -355,5 +355,6 @@
   "Remove Time Slot": "删除时间段",
   "Add Time Slot": "添加时间段",
   "VACATION_MODE_ACTIVE": "假期模式已激活",
-  "NO AVAILABILITY SLOTS": "未配置可用时间段"
+  "NO AVAILABILITY SLOTS": "未配置可用时间段",
+  "Availability": "可用性"
 }


### PR DESCRIPTION
Follow up for #931 
Now the "Availability" tab in the left navigation pane will be properly translated in all supported languages.