### PR TITLE
Added red asterisks to mandatory fields on Personal Info tab (#801)

### DIFF
--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -265,9 +265,7 @@ function PersonalInformation({ setHasUnsavedChanges }) {
       }
     }
     if (name === "dateOfBirth") {
-      if (!value) {
-        error = "Date of Birth is required.";
-      } else if (new Date(value) > new Date()) {
+      if (new Date(value) > new Date()) {
         error = "Date of Birth cannot be in the future.";
       }
     }
@@ -369,7 +367,17 @@ function PersonalInformation({ setHasUnsavedChanges }) {
       <div className="grid grid-cols-1 gap-8 mb-6">
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
-            <span className="text-red-500 mr-1">*</span>
+            {isEditing && (
+              <>
+                <span className="text-red-500 mr-1" aria-hidden="true">
+                  *
+                </span>
+                <span className="sr-only">
+                  {" "}
+                  ({t("required") || "required"})
+                </span>
+              </>
+            )}
             {t("ADDRESS", { optional: "" })}
           </label>
           {isEditing ? (
@@ -424,7 +432,6 @@ function PersonalInformation({ setHasUnsavedChanges }) {
       <div className="grid grid-cols-3 gap-8 mb-6">
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
-            <span className="text-red-500 mr-1">*</span>
             {t("COUNTRY")}
           </label>
           {isEditing ? (
@@ -465,7 +472,17 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         </div>
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
-            <span className="text-red-500 mr-1">*</span>
+            {isEditing && (
+              <>
+                <span className="text-red-500 mr-1" aria-hidden="true">
+                  *
+                </span>
+                <span className="sr-only">
+                  {" "}
+                  ({t("required") || "required"})
+                </span>
+              </>
+            )}
             {t("STATE")}
           </label>
           {isEditing ? (
@@ -491,7 +508,17 @@ function PersonalInformation({ setHasUnsavedChanges }) {
         </div>
         <div>
           <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
-            <span className="text-red-500 mr-1">*</span>
+            {isEditing && (
+              <>
+                <span className="text-red-500 mr-1" aria-hidden="true">
+                  *
+                </span>
+                <span className="sr-only">
+                  {" "}
+                  ({t("required") || "required"})
+                </span>
+              </>
+            )}
             {t("ZIP_CODE")}
           </label>
           {isEditing ? (


### PR DESCRIPTION
Added red asterisks (*) to indicate required fields when the user clicks Edit on Personal Info tab under Profile.

Removed the asterisk from the Country field since it is pre-set and not editable.

Reverted the Date of Birth (DOB) field back to optional (it had become required due to earlier changes).

Tested locally and working as expected.

<img width="1240" height="748" alt="Screenshot 1" src="https://github.com/user-attachments/assets/3cbbc1eb-1f2b-4f04-a4a4-fe1a09dc33c1" />
<img width="1166" height="734" alt="Screenshot 2" src="https://github.com/user-attachments/assets/13e93ad0-c5c8-408e-8a3d-ec3777e90c4e" />
