### PR TITLE
Adjusted use effects for languages

### DIFF
--- a/src/pages/Profile/Preferences.jsx
+++ b/src/pages/Profile/Preferences.jsx
@@ -19,6 +19,12 @@ function Preferences({ setHasUnsavedChanges }) {
     { value: "volunteer", label: t("VOLUNTEER_DASHBOARD") },
     { value: "beneficiary", label: t("BENEFICIARY_DASHBOARD") },
   ];
+  // Build languages options directly from languagesData.js
+  const languages = languagesData.map((lang) => ({
+    // Special case: If the language is "Mandarin Chinese", convert its value to "Chinese" to match the locale mapping.
+    value: lang.name === "Mandarin Chinese" ? "Chinese" : lang.name,
+    label: t(lang.name),
+  }));
   const dispatch = useDispatch();
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -40,17 +46,7 @@ function Preferences({ setHasUnsavedChanges }) {
     receiveEmergencyNotifications: false,
   });
 
-  const [languages, setLanguages] = useState([]);
-
   useEffect(() => {
-    // Build languages options directly from languagesData.js
-    const languageOptions = languagesData.map((lang) => ({
-      // Special case: If the language is "Mandarin Chinese", convert its value to "Chinese" to match the locale mapping.
-      value: lang.name === "Mandarin Chinese" ? "Chinese" : lang.name,
-      label: t(lang.name),
-    }));
-    setLanguages(languageOptions);
-
     // Get personal information from localStorage (only for email/phone, NOT language preferences)
     const savedPersonalInfo =
       JSON.parse(localStorage.getItem("personalInfo")) || {};


### PR DESCRIPTION
Previously the language drop down has shown only the English language by default.  So adjusted the use effect for languages to reload into selected language whenever we edit it.
<img width="1553" height="847" alt="image" src="https://github.com/user-attachments/assets/d11e1bf8-266c-466b-b91a-90cbaffab6ec" />
