### PR TITLE
Adding missing buttons in Notifications tab and updated it to fully s…

### DIFF
--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -22,6 +22,12 @@
   "SIGNUP": "Sign Up",
 
   "OUR_TEAM": "Our Team",
+  "ALL": "All",
+  "VOLUNTEER_MATCH": "Volunteer Match",
+  "HELP_REQUEST_BUTTON": "Help Request",
+  "NEW_MATCH_REQUEST": "New Match Request",
+  "ACCEPT": "Accept",
+  "DENY": "Deny",
   "OUR_MISSION": "Our Mission",
   "OUR_VISION_NAVBAR": "Our Vision",
   "VOLUNTEER_SERVICES": "Volunteer Services",

--- a/src/pages/Notifications/Notifications.jsx
+++ b/src/pages/Notifications/Notifications.jsx
@@ -86,7 +86,7 @@ export default function NotificationUI() {
               ? t("ALL")
               : type === "volunteer"
                 ? t("VOLUNTEER_MATCH")
-                : t("HELP_REQUEST")}
+                : t("HELP_REQUEST_BUTTON")}
           </button>
         ))}
         <div className="ml-auto">


### PR DESCRIPTION
I updated the Notifications tab to fully support translations in english languages. Specifically, I created new translation keys in common.json for labels like "ALL", "VOLUNTEER_MATCH", "HELP_REQUEST_BUTTON", "NEW_MATCH_REQUEST", "ACCEPT", and "DENY". Then, I replaced the hardcoded button texts and labels in Notifications.jsx to use these translation keys with t(). This ensures that all buttons and labels under the Notifications tab (such as All, Volunteer Match, Help Request, New Match Request, Accept, and Deny) are now pulled from our translation files instead of being hardcoded.