### PR TITLE
Fix: State field not persisting in Personal Information tab (#966)

### DIFF
--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -183,7 +183,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
       setPersonalInfo((prev) => ({
         ...prev,
         country: countryCode || "",
-        state: user.state || "",
+        //state: user.state || "",
+        // Commented out: backend does not return user.state.
+        // Keeping this line was resetting the saved state (from localStorage) to "".
+        // If backend adds state later, re-enable with: state: prev.state || user.state || ""
       }));
     }
   }, [getCountryCodeFromZoneInfo, user]);


### PR DESCRIPTION
Removed user.state overwrite in PersonalInformation component.

This line was resetting the saved State value (from localStorage) to "" whenever the component reloaded.

Verified that State field now persists correctly after saving and navigating between tabs.

Left inline comment in code for future developers in case backend adds user.state support later.

Tested locally and working as expected.
