### PR TITLE
use "Log In" on signup link; mark Forgot Password email required 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9148,14 +9148,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -19673,9 +19673,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -424,7 +424,7 @@ const SignUp = () => {
             className="mx-2 text-left underline"
             onClick={() => navigate("/login")}
           >
-            {t("SIGN_IN")}
+            {t("LOGIN")}
           </button>
         </div>
       </div>

--- a/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -46,7 +46,13 @@ const ForgotPasswordPage = () => {
         <h1 className="my-4 text-3xl font-bold text-center">Password Reset</h1>
 
         <div className="my-2 flex flex-col">
-          <label htmlFor="email">Email</label>
+          <label htmlFor="email">
+            Email{" "}
+            <span className="text-red-500" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only">required</span>
+          </label>
           <input
             id="email"
             value={emailValue}


### PR DESCRIPTION
- Use "Log In" on the Sign Up page bottom link so the link label matches the Login page header.
- Mark the Email field as required on the Forgot Password page by adding a red asterisk and an accessible sr-only label.
- Add small accessibility tweak: asterisk is aria-hidden and an sr-only "required" text is included for screen readers.

Changes for issue #999 