### PR TITLE
fix: enhance date of birth validation and age restriction in Personal…

### DIFF
--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -1,13 +1,13 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { Country, State } from "country-state-city";
 import PropTypes from "prop-types";
-import { useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import Select from "react-select";
 import CountryList from "react-select-country-list";
-import { State, Country } from "country-state-city";
 import PhoneNumberInputWithCountry from "../../common/components/PhoneNumberInputWithCountry";
 import countryCodes from "../../utils/country-codes-en.json";
 
@@ -268,8 +268,30 @@ function PersonalInformation({ setHasUnsavedChanges }) {
       }
     }
     if (name === "dateOfBirth") {
-      if (new Date(value) > new Date()) {
+      // If no DOB provided, treat as allowed (per tooltip behavior)
+      if (!value) {
+        return "";
+      }
+
+      const dob = new Date(value);
+      if (isNaN(dob.getTime())) {
+        error = "Invalid Date of Birth.";
+      } else if (dob > new Date()) {
         error = "Date of Birth cannot be in the future.";
+      } else {
+        // calculate age
+        const today = new Date();
+        let age = today.getFullYear() - dob.getFullYear();
+        const monthDiff = today.getMonth() - dob.getMonth();
+        if (
+          monthDiff < 0 ||
+          (monthDiff === 0 && today.getDate() < dob.getDate())
+        ) {
+          age--;
+        }
+        if (age < 21) {
+          error = "You must be at least 21 years old.";
+        }
       }
     }
     if (name === "country") {


### PR DESCRIPTION
Validated the user's date of birth on the Personal Information page and displayed an inline error if the entered DOB makes the user younger than 21. The Save action is blocked until a valid DOB (or blank, per existing tooltip behavior) is provided. Also handled invalid or future dates with appropriate error messages. #1023 
<img width="400" height="160" alt="image" src="https://github.com/user-attachments/assets/c712de1b-7acc-4a4e-bf6f-3740d6a6761a" />
