### PR TITLE
Add SECONDARY_EMAIL translation for all 12 supported languages

### DIFF
--- a/src/common/i18n/locales/ar/common.json
+++ b/src/common/i18n/locales/ar/common.json
@@ -213,6 +213,7 @@
   "Mandarin Chinese": "الصينية الماندرين",
   "PRIMARY EMAIL PREFERENCE": "تفضيل البريد الإلكتروني الأساسي",
   "PRIMARY EMAIL": "البريد الإلكتروني الأساسي",
+  "SECONDARY_EMAIL": "البريد الإلكتروني الثانوي",
   "PRIMARY PHONE PREFERENCE": "تفضيل الهاتف الأساسي",
   "PRIMARY PHONE": "الهاتف الأساسي",
   "RECEIVE EMERGENCY NOTIFICATIONS": "تلقي إشعارات الطوارئ",

--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -414,6 +414,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "ইমেইল যোগাযোগ পছন্দ",
   "PHONE COMMUNICATION PREFERENCE": "ফোন যোগাযোগ পছন্দ",
   "PRIMARY EMAIL": "প্রাথমিক ইমেল",
+  "SECONDARY_EMAIL": "সেকেন্ডারি ইমেল",
   "PRIMARY PHONE": "প্রাথমিক ফোন",
   "SECONDARY PHONE": "মাধ্যমিক ফোন",
   "SELECT LANGUAGE": "ভাষা নির্বাচন করুন",

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -394,6 +394,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "Präferenz für E-Mail-Kommunikation",
   "PHONE COMMUNICATION PREFERENCE": "Präferenz für Telefonkommunikation",
   "PRIMARY EMAIL": "Primäre E-Mail",
+  "SECONDARY_EMAIL": "Sekundäre E-Mail",
   "PRIMARY PHONE": "Primäres Telefon",
   "SECONDARY PHONE": "Zweittelefon",
   "Lead Volunteer": "Haupt-Freiwilliger",

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -213,6 +213,7 @@
   "Mandarin Chinese": "Mandarin Chinese",
   "PRIMARY EMAIL PREFERENCE": "Primary Email Preference",
   "PRIMARY EMAIL": "Primary Email",
+  "SECONDARY_EMAIL": "Secondary Email",
   "PRIMARY PHONE PREFERENCE": "Primary Phone Preference",
   "PRIMARY PHONE": "Primary Phone",
   "SECONDARY PHONE": "Secondary Phone",

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -392,6 +392,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "Preferencia de comunicación por correo electrónico",
   "PHONE COMMUNICATION PREFERENCE": "Preferencia de comunicación telefónica",
   "PRIMARY EMAIL": "Correo electrónico principal",
+  "SECONDARY_EMAIL": "Correo electrónico secundario",
   "PRIMARY PHONE": "Teléfono principal",
   "SECONDARY PHONE": "Teléfono secundario",
   "SELECT DASHBOARD": "Seleccionar panel de control",

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -435,6 +435,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "Préférence de communication par courrier électronique",
   "PHONE COMMUNICATION PREFERENCE": "Préférence de communication téléphonique",
   "PRIMARY EMAIL": "E-mail principal",
+  "SECONDARY_EMAIL": "E-mail secondaire",
   "PRIMARY PHONE": "Téléphone principal",
   "SECONDARY PHONE": "Téléphone secondaire",
   "SELECT DASHBOARD": "Sélectionner le tableau de bord",

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -453,6 +453,7 @@
   "Mandarin Chinese": "मंदारिन चीनी",
   "PRIMARY EMAIL PREFERENCE": "प्राथमिक ईमेल प्राथमिकता",
   "PRIMARY EMAIL": "प्राथमिक ईमेल",
+  "SECONDARY_EMAIL": "द्वितीयक ईमेल",
   "PRIMARY PHONE PREFERENCE": "प्राथमिक फ़ोन प्राथमिकता",
   "PRIMARY PHONE": "प्राथमिक फ़ोन",
   "SECONDARY PHONE": "द्वितीयक फ़ोन",

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -374,6 +374,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "Preferência de comunicação por e-mail",
   "PHONE COMMUNICATION PREFERENCE": "Preferência de comunicação por telefone",
   "PRIMARY EMAIL": "E-mail principal",
+  "SECONDARY_EMAIL": "E-mail secundário",
   "PRIMARY PHONE": "Telefone principal",
   "SECONDARY PHONE": "Telefone secundário",
   "SELECT DASHBOARD": "Selecionar painel",

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -391,6 +391,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "Настройки электронной почты для связи",
   "PHONE COMMUNICATION PREFERENCE": "Предпочтения телефонной связи",
   "PRIMARY EMAIL": "Основной адрес электронной почты",
+  "SECONDARY_EMAIL": "Дополнительный адрес электронной почты",
   "PRIMARY PHONE": "Основной телефон",
   "SECONDARY PHONE": "Дополнительный телефон",
   "English": "Английский",

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -646,6 +646,7 @@
   "EMAIL COMMUNICATION PREFERENCE": "ఇమెయిల్ కమ్యూనికేషన్ ప్రాధాన్యత",
   "PHONE COMMUNICATION PREFERENCE": "ఫోన్ కమ్యూనికేషన్ ప్రాధాన్యత",
   "PRIMARY EMAIL": "ప్రాథమిక ఇమెయిల్",
+  "SECONDARY_EMAIL": "ద్వితీయ ఇమెయిల్",
   "PRIMARY PHONE": "ప్రాథమిక ఫోన్",
   "SECONDARY PHONE": "సెకండరీ ఫోన్",
   "English": "ఆంగ్లం",

--- a/src/common/i18n/locales/ur/common.json
+++ b/src/common/i18n/locales/ur/common.json
@@ -213,6 +213,7 @@
   "Mandarin Chinese": "مینڈرن چینی",
   "PRIMARY EMAIL PREFERENCE": "بنیادی ای میل کی ترجیح",
   "PRIMARY EMAIL": "بنیادی ای میل",
+  "SECONDARY_EMAIL": "ثانوی ای میل",
   "PRIMARY PHONE PREFERENCE": "بنیادی فون کی ترجیح",
   "PRIMARY PHONE": "بنیادی فون",
   "RECEIVE EMERGENCY NOTIFICATIONS": "ایمرجنسی اطلاعات وصول کریں",

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -340,6 +340,7 @@
   "SELECT LANGUAGE": "选择语言",
   "PRIMARY EMAIL PREFERENCE": "主要电子邮件偏好",
   "PRIMARY EMAIL": "主要电子邮件",
+  "SECONDARY_EMAIL": "次要电子邮件",
   "PRIMARY PHONE PREFERENCE": "主要电话偏好",
   "PRIMARY PHONE": "主要电话",
   "SECONDARY PHONE": "辅助电话",


### PR DESCRIPTION
- Added SECONDARY_EMAIL key to common.json for all languages with full translations
- Languages updated: Arabic, Bengali, Chinese, English, French, German, Hindi, Portuguese, Russian, Spanish, Telugu, Urdu
- Translation follows existing PRIMARY EMAIL pattern
- Total: 12 languages updated

Closes #1040