### PR TITLE
Dashboards - General Changes suggested on 17 Nov

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -126,13 +126,14 @@ const Dashboard = ({ userRole }) => {
     toggleDropdown();
   }, []);
 
-  // initialize selected dashboard based on user groups (default beneficiary unless volunteer)
   useEffect(() => {
-    if (!selectedDashboard && groups) {
+    const storedDashboard = localStorage.getItem("lastDashboardSelected");
+    if (storedDashboard) {
+      setSelectedDashboard(storedDashboard);
+    } else if (!selectedDashboard && groups) {
       if (groups.includes("Volunteers")) setSelectedDashboard("volunteer");
       else setSelectedDashboard("beneficiary");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [groups]);
 
   useEffect(() => {
@@ -467,6 +468,204 @@ const Dashboard = ({ userRole }) => {
   else if (selectedDashboard === "volunteer")
     dashboardTitle = "Volunteer Dashboard";
 
+  const dashboardDefaultTab = {
+    superAdmin: "myRequests",
+    admin: "myRequests",
+    steward: "myRequests",
+    volunteer: "managedRequests",
+    beneficiary: "myRequests",
+  };
+
+  useEffect(() => {
+    if (selectedDashboard && dashboardDefaultTab[selectedDashboard]) {
+      setActiveTab(dashboardDefaultTab[selectedDashboard]);
+    }
+  }, [selectedDashboard]);
+
+  const dashboardSearchFilters = (
+    <>
+      <div className="mb-4 flex flex-wrap gap-2 px-10">
+        <div className="relative w-1/3">
+          <IoSearchOutline
+            className="text-gray-500 absolute inset-y-0 start-0 flex items-center m-3 my-2"
+            size={22}
+          />
+          <input
+            type="text"
+            placeholder="Search..."
+            value={searchTerm}
+            onChange={handleSearchChange}
+            className="p-2 rounded-md flex-grow block w-full ps-10 bg-gray-50"
+          />
+        </div>
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2 px-10">
+        <div className="relative" onBlur={handleStatusBlur} tabIndex={-1}>
+          <div
+            className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
+            onClick={toggleStatusDropdown}
+            tabIndex={0}
+          >
+            <button className="py-2 px-4 p-2 font-light text-gray-600">
+              {t("Status")}
+            </button>
+            <IoIosArrowDown className="m-2" />
+          </div>
+          {isStatusDropdownOpen && (
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
+              {statusOptions.map((status) => (
+                <label key={status} className="block">
+                  <input
+                    type="checkbox"
+                    checked={
+                      status === "All"
+                        ? Object.values(statusFilter).every(Boolean)
+                        : statusFilter[status] || false
+                    }
+                    onChange={() => handleStatusChange(status)}
+                  />
+                  {status}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="relative" onBlur={handleFilterBlur} tabIndex={-1}>
+          <div
+            className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
+            onClick={toggleCategoryDropdown}
+            tabIndex={0}
+          >
+            <button className="py-2 px-4 p-2 font-light text-gray-600">
+              {t("FILTER_BY")}
+            </button>
+            <IoIosArrowDown className="m-2" />
+          </div>
+          {isCategoryDropdownOpen && (
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
+              <label className="block">
+                <input
+                  type="checkbox"
+                  checked={
+                    Object.keys(categoryFilter).length ===
+                    Object.keys(allCategories).length
+                  }
+                  onChange={() => handleCategoryChange("All")}
+                />
+                All Categories
+              </label>
+              {categoryOptions.map((category) => (
+                <label key={category} className="block">
+                  <input
+                    type="checkbox"
+                    checked={categoryFilter[category] || false}
+                    onChange={() => handleCategoryChange(category)}
+                  />
+                  {category}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* NEW FILTERS START HERE */}
+        <div className="relative" onBlur={handleTypeBlur} tabIndex={-1}>
+          <div
+            className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
+            onClick={toggleTypeDropdown}
+            tabIndex={0}
+          >
+            <button className="py-2 px-4 p-2 font-light text-gray-600">
+              Type
+            </button>
+            <IoIosArrowDown className="m-2" />
+          </div>
+          {isTypeDropdownOpen && (
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
+              {typeOptions.map((type) => (
+                <label key={type} className="block">
+                  <input
+                    type="checkbox"
+                    checked={typeFilter[type] || false}
+                    onChange={() =>
+                      setTypeFilter((prev) => ({
+                        ...prev,
+                        [type]: !prev[type],
+                      }))
+                    }
+                  />
+                  {type}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="relative" onBlur={handlePriorityBlur} tabIndex={-1}>
+          <div
+            className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
+            onClick={togglePriorityDropdown}
+          >
+            <button className="py-2 px-4 p-2 font-light text-gray-600">
+              Priority
+            </button>
+            <IoIosArrowDown className="m-2" />
+          </div>
+          {isPriorityDropdownOpen && (
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
+              {priorityOptions.map((priority) => (
+                <label key={priority} className="block">
+                  <input
+                    type="checkbox"
+                    checked={priorityFilter[priority] || false}
+                    onChange={() =>
+                      setPriorityFilter((prev) => ({
+                        ...prev,
+                        [priority]: !prev[priority],
+                      }))
+                    }
+                  />
+                  {priority}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="relative" onBlur={handleCalamityBlur} tabIndex={-1}>
+          <div
+            className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
+            onClick={toggleCalamityDropdown}
+          >
+            <button className="py-2 px-4 p-2 font-light text-gray-600">
+              Calamity
+            </button>
+            <IoIosArrowDown className="m-2" />
+          </div>
+          {isCalamityDropdownOpen && (
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
+              {calamityOptions.map((cal) => (
+                <label key={cal} className="block">
+                  <input
+                    type="checkbox"
+                    checked={calamityFilter[cal] || false}
+                    onChange={() =>
+                      setCalamityFilter((prev) => ({
+                        ...prev,
+                        [cal]: !prev[cal],
+                      }))
+                    }
+                  />
+                  {cal}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div className="p-5">
       <ToastContainer
@@ -513,7 +712,10 @@ const Dashboard = ({ userRole }) => {
             {isDropdownVisible && (
               <select
                 value={selectedDashboard}
-                onChange={(e) => setSelectedDashboard(e.target.value)}
+                onChange={(e) => {
+                  setSelectedDashboard(e.target.value);
+                  localStorage.setItem("lastDashboardSelected", e.target.value);
+                }}
                 className="text-blue-500 font-semibold underline italic py-2"
               >
                 <option value="superAdmin">Super Admin Dashboard</option>
@@ -527,8 +729,8 @@ const Dashboard = ({ userRole }) => {
         </div>
       </div>
 
-      <div className="flex-1 text-left">
-        <h2 className="text-base font-semibold">{dashboardTitle}</h2>
+      <div className="flex-1 text-center">
+        <h2 className="text-xl font-semibold">{dashboardTitle}</h2>
       </div>
 
       {showAddressMsg && !hasAddress && (
@@ -557,186 +759,6 @@ const Dashboard = ({ userRole }) => {
       )}
 
       <div className="border">
-        <div className="mb-4 flex flex-wrap gap-2 px-10 pt-4">
-          <div className="relative w-1/3">
-            <IoSearchOutline
-              className="text-gray-500 absolute inset-y-0 start-0 flex items-center m-3 my-2"
-              size={22}
-            />
-            <input
-              type="text"
-              placeholder="Search..."
-              value={searchTerm}
-              onChange={handleSearchChange}
-              className="p-2 rounded-md flex-grow block w-full ps-10 bg-gray-50"
-            />
-          </div>
-        </div>
-        <div className="mb-4 flex flex-wrap gap-2 px-10">
-          <div className="relative" onBlur={handleStatusBlur} tabIndex={-1}>
-            <div
-              className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
-              onClick={toggleStatusDropdown}
-              tabIndex={0}
-            >
-              <button className="py-2 px-4 p-2 font-light text-gray-600">
-                {t("Status")}
-              </button>
-              <IoIosArrowDown className="m-2" />
-            </div>
-            {isStatusDropdownOpen && (
-              <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-                {statusOptions.map((status) => (
-                  <label key={status} className="block">
-                    <input
-                      type="checkbox"
-                      checked={
-                        status === "All"
-                          ? Object.values(statusFilter).every(Boolean)
-                          : statusFilter[status] || false
-                      }
-                      onChange={() => handleStatusChange(status)}
-                    />
-                    {status}
-                  </label>
-                ))}
-              </div>
-            )}
-          </div>
-          <div className="relative" onBlur={handleFilterBlur} tabIndex={-1}>
-            <div
-              className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
-              onClick={toggleCategoryDropdown}
-              tabIndex={0}
-            >
-              <button className="py-2 px-4 p-2 font-light text-gray-600">
-                {t("FILTER_BY")}
-              </button>
-              <IoIosArrowDown className="m-2" />
-            </div>
-            {isCategoryDropdownOpen && (
-              <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-                <label className="block">
-                  <input
-                    type="checkbox"
-                    checked={
-                      Object.keys(categoryFilter).length ===
-                      Object.keys(allCategories).length
-                    }
-                    onChange={() => handleCategoryChange("All")}
-                  />
-                  All Categories
-                </label>
-                {categoryOptions.map((category) => (
-                  <label key={category} className="block">
-                    <input
-                      type="checkbox"
-                      checked={categoryFilter[category] || false}
-                      onChange={() => handleCategoryChange(category)}
-                    />
-                    {category}
-                  </label>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* NEW FILTERS START HERE */}
-          <div className="relative" onBlur={handleTypeBlur} tabIndex={-1}>
-            <div
-              className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
-              onClick={toggleTypeDropdown}
-              tabIndex={0}
-            >
-              <button className="py-2 px-4 p-2 font-light text-gray-600">
-                Type
-              </button>
-              <IoIosArrowDown className="m-2" />
-            </div>
-            {isTypeDropdownOpen && (
-              <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-                {typeOptions.map((type) => (
-                  <label key={type} className="block">
-                    <input
-                      type="checkbox"
-                      checked={typeFilter[type] || false}
-                      onChange={() =>
-                        setTypeFilter((prev) => ({
-                          ...prev,
-                          [type]: !prev[type],
-                        }))
-                      }
-                    />
-                    {type}
-                  </label>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="relative" onBlur={handlePriorityBlur} tabIndex={-1}>
-            <div
-              className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
-              onClick={togglePriorityDropdown}
-            >
-              <button className="py-2 px-4 p-2 font-light text-gray-600">
-                Priority
-              </button>
-              <IoIosArrowDown className="m-2" />
-            </div>
-            {isPriorityDropdownOpen && (
-              <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-                {priorityOptions.map((priority) => (
-                  <label key={priority} className="block">
-                    <input
-                      type="checkbox"
-                      checked={priorityFilter[priority] || false}
-                      onChange={() =>
-                        setPriorityFilter((prev) => ({
-                          ...prev,
-                          [priority]: !prev[priority],
-                        }))
-                      }
-                    />
-                    {priority}
-                  </label>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="relative" onBlur={handleCalamityBlur} tabIndex={-1}>
-            <div
-              className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
-              onClick={toggleCalamityDropdown}
-            >
-              <button className="py-2 px-4 p-2 font-light text-gray-600">
-                Calamity
-              </button>
-              <IoIosArrowDown className="m-2" />
-            </div>
-            {isCalamityDropdownOpen && (
-              <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-                {calamityOptions.map((cal) => (
-                  <label key={cal} className="block">
-                    <input
-                      type="checkbox"
-                      checked={calamityFilter[cal] || false}
-                      onChange={() =>
-                        setCalamityFilter((prev) => ({
-                          ...prev,
-                          [cal]: !prev[cal],
-                        }))
-                      }
-                    />
-                    {cal}
-                  </label>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-
         {/* Render the selected dashboard view component */}
         <div className="requests-section overflow-hidden table-height-fix">
           {selectedDashboard === "superAdmin" && (
@@ -755,6 +777,7 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
+              searchFilters={dashboardSearchFilters}
             />
           )}
 
@@ -774,6 +797,7 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
+              searchFilters={dashboardSearchFilters}
             />
           )}
 
@@ -791,6 +815,7 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
+              searchFilters={dashboardSearchFilters}
             />
           )}
 
@@ -810,6 +835,7 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
+              searchFilters={dashboardSearchFilters}
             />
           )}
 
@@ -829,6 +855,7 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
+              searchFilters={dashboardSearchFilters}
             />
           )}
         </div>

--- a/src/pages/Dashboard/views/AdminDashboard.jsx
+++ b/src/pages/Dashboard/views/AdminDashboard.jsx
@@ -16,6 +16,7 @@ const AdminDashboard = (props) => {
     onRowsPerPageChange,
     getLinkPath,
     getLinkState,
+    searchFilters,
   } = props;
 
   return (
@@ -24,7 +25,7 @@ const AdminDashboard = (props) => {
         <button
           className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
             activeTab === "myRequests"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("myRequests")}
@@ -32,9 +33,9 @@ const AdminDashboard = (props) => {
           All Requests
         </button>
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
             activeTab === "analytics"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("analytics")}
@@ -42,6 +43,8 @@ const AdminDashboard = (props) => {
           Analytics
         </button>
       </div>
+
+      {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
         {activeTab === "analytics" ? (

--- a/src/pages/Dashboard/views/BeneficiaryDashboard.jsx
+++ b/src/pages/Dashboard/views/BeneficiaryDashboard.jsx
@@ -16,6 +16,7 @@ const BeneficiaryDashboard = (props) => {
     onRowsPerPageChange,
     getLinkPath,
     getLinkState,
+    searchFilters,
   } = props;
 
   return (
@@ -24,7 +25,7 @@ const BeneficiaryDashboard = (props) => {
         <button
           className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
             activeTab === "myRequests"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("myRequests")}
@@ -32,9 +33,9 @@ const BeneficiaryDashboard = (props) => {
           {"My Requests"}
         </button>
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
             activeTab === "othersRequests"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("othersRequests")}
@@ -42,6 +43,8 @@ const BeneficiaryDashboard = (props) => {
           {"Others Requests"}
         </button>
       </div>
+
+      {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
         {!isLoading && (

--- a/src/pages/Dashboard/views/StewardDashboard.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.jsx
@@ -14,17 +14,20 @@ const StewardDashboard = (props) => {
     onRowsPerPageChange,
     getLinkPath,
     getLinkState,
+    searchFilters,
   } = props;
 
   return (
     <div>
       <div className="flex mb-5">
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold bg-white border-gray-300 mr-1`}
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold bg-white text-blue-500 border-blue-500`}
         >
           All Requests
         </button>
       </div>
+
+      {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
         {!isLoading && (

--- a/src/pages/Dashboard/views/SuperAdminDashboard.jsx
+++ b/src/pages/Dashboard/views/SuperAdminDashboard.jsx
@@ -16,6 +16,7 @@ const SuperAdminDashboard = (props) => {
     onRowsPerPageChange,
     getLinkPath,
     getLinkState,
+    searchFilters,
   } = props;
 
   return (
@@ -24,7 +25,7 @@ const SuperAdminDashboard = (props) => {
         <button
           className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
             activeTab === "myRequests"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("myRequests")}
@@ -32,9 +33,9 @@ const SuperAdminDashboard = (props) => {
           All Requests
         </button>
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
             activeTab === "analytics"
-              ? "bg-white border-gray-300"
+              ? "bg-white text-blue-500 border-blue-500"
               : "bg-gray-300 border-transparent hover:bg-gray-200"
           }`}
           onClick={() => handleTabChange("analytics")}
@@ -42,6 +43,8 @@ const SuperAdminDashboard = (props) => {
           Analytics
         </button>
       </div>
+
+      {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
         {activeTab === "analytics" ? (

--- a/src/pages/Dashboard/views/VolunteerDashboard.jsx
+++ b/src/pages/Dashboard/views/VolunteerDashboard.jsx
@@ -17,6 +17,7 @@ const VolunteerDashboard = (props) => {
     onRowsPerPageChange,
     getLinkPath,
     getLinkState,
+    searchFilters,
   } = props;
 
   // ensure managedRequests tab is selected for volunteer
@@ -29,11 +30,13 @@ const VolunteerDashboard = (props) => {
     <div>
       <div className="flex mb-5">
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold bg-white border-gray-300 mr-1`}
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold bg-white text-blue-500 border-blue-500`}
         >
           Managed Requests
         </button>
       </div>
+
+      {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
         {!isLoading && (


### PR DESCRIPTION
Different dashboard views using RBAC #1057

**Fixed** (As discussed on 17th Nov)

1. Move the headers towards the center (Center Aligned)
2. Make the header slightly bigger.
3. Make sure the Header is displayed below the buttons and the dashboard selection control/slider.
4. The two buttons (Create Help Request” and “Become a Volunteer”) are to be left aligned The dashboard selection control/slider are to be right aligned
5. The dashboard selection control/slider and the two buttons (Create Help Request” and “Become a Volunteer”) must be on the same line.
6. There is a confusion in distinguishing selected tab in a dashboard.
7. Each dashboard has tabs (i.e., My Requests, Others Requests or Analytics). Currently when the tabs are clicked to select it the indicators to distinguish between them are with the colors grey and white, which is causing confusion.
8. The tabs when selected must be indicated by the color Blue, in a manner similar to the indication that appears when an option in the left navigator of the profile section is selected.
9. The Search bar and filtering options (Status, Categories, Type, etc.) are currently displayed above the tabs (i.e., My Requests, Others Requests or Analytics).
10. The search bar and the filtering options are to be displayed below those tabs and above the actual tabular data.
11. Remember user's last dashboard selection across navigation using localStorage.

