### PR TITLE
feat: Store categories and volunteer skills in localStorage during login

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -324,9 +324,23 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
       }
     };*/
 
-    // Fetch categories from API if not already fetched, following same pattern as other APIs
+    // Fetch categories from localStorage first, then API if not already fetched
     const fetchCategoriesData = async () => {
       if (!categoriesFetched) {
+        // Check localStorage first (similar to enums)
+        const storedCategories = localStorage.getItem("categories");
+        if (storedCategories) {
+          try {
+            const validCategories = JSON.parse(storedCategories);
+            dispatch(loadCategories(validCategories));
+            return; // Exit early if we got categories from localStorage
+          } catch (parseError) {
+            console.warn("Failed to parse categories from localStorage:", parseError);
+            // Continue to API fetch if localStorage parse fails
+          }
+        }
+
+        // If not in localStorage, fetch from API
         try {
           const categoriesData = await getCategories(); // Direct API call like checkProfanity and predictCategories
 
@@ -370,6 +384,8 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
             "out of",
             categoriesArray.length,
           );
+          // Store in localStorage for future use
+          localStorage.setItem("categories", JSON.stringify(validCategories));
           dispatch(loadCategories(validCategories));
         } catch (error) {
           console.warn(

--- a/src/pages/Volunteer/PromoteToVolunteer.jsx
+++ b/src/pages/Volunteer/PromoteToVolunteer.jsx
@@ -53,9 +53,26 @@ const PromoteToVolunteer = () => {
   }, [userId]);
 
   const fetchSkills = async () => {
+    // Check localStorage first (similar to enums and categories)
+    const storedVolunteerSkills = localStorage.getItem("volunteerSkills");
+    if (storedVolunteerSkills) {
+      try {
+        const skillsData = JSON.parse(storedVolunteerSkills);
+        setCategoriesData(skillsData);
+        return; // Exit early if we got skills from localStorage
+      } catch (parseError) {
+        console.warn("Failed to parse volunteer skills from localStorage:", parseError);
+        // Continue to API fetch if localStorage parse fails
+      }
+    }
+
+    // If not in localStorage, fetch from API
     try {
       const response = await getVolunteerSkills();
-      setCategoriesData(response.body);
+      const skillsData = response.body || response;
+      setCategoriesData(skillsData);
+      // Store in localStorage for future use
+      localStorage.setItem("volunteerSkills", JSON.stringify(skillsData));
     } catch (error) {
       console.error("Error fetching skills:", error);
     }

--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -8,9 +8,10 @@ import {
   updateUserAttributes,
 } from "aws-amplify/auth";
 
-import { getEnums } from "../../../services/requestServices";
+import { getEnums, getCategories } from "../../../services/requestServices";
 
-import { getUserId } from "../../../services/volunteerServices";
+import { getUserId, getVolunteerSkills } from "../../../services/volunteerServices";
+import { loadCategories } from "../help_request/requestActions";
 import {
   changeUiLanguage,
   returnDefaultLanguage,
@@ -51,6 +52,57 @@ export const checkAuthStatus = () => async (dispatch) => {
       // console.log("Enums fetched and stored in localStorage:", enumsData);
     } catch (enumError) {
       console.warn(" Failed to fetch enums after login:", enumError.message);
+    }
+
+    try {
+      const categoriesData = await getCategories();
+      // Extract categories array from API response
+      let categoriesArray;
+      if (Array.isArray(categoriesData)) {
+        categoriesArray = categoriesData;
+      } else if (
+        categoriesData &&
+        Array.isArray(categoriesData.categories)
+      ) {
+        categoriesArray = categoriesData.categories;
+      } else if (categoriesData && typeof categoriesData === "object") {
+        console.log("Categories API response structure:", Object.keys(categoriesData));
+        throw new Error(
+          "Invalid API response format - expected array or object with categories array",
+        );
+      } else {
+        throw new Error("Invalid API response format - expected array");
+      }
+
+      // Filter out invalid/header entries (like cat_name, cat_id placeholders)
+      const validCategories = categoriesArray.filter(
+        (cat) =>
+          cat.catName &&
+          cat.catName !== "cat_name" &&
+          cat.catId !== "cat_id" &&
+          cat.catId !== "﻿cat_id" && // Handle BOM characters
+          !cat.catName.toLowerCase().includes("cat_name") &&
+          !cat.catId.toLowerCase().includes("cat_id"),
+      );
+
+      // Store in localStorage
+      localStorage.setItem("categories", JSON.stringify(validCategories));
+      // Also load into Redux state
+      dispatch(loadCategories(validCategories));
+    } catch (categoryError) {
+      console.warn("Failed to fetch categories after login:", categoryError.message);
+    }
+
+    try {
+      const volunteerSkillsData = await getVolunteerSkills();
+      // Store volunteer skills in localStorage for volunteer wizard
+      if (volunteerSkillsData?.body) {
+        localStorage.setItem("volunteerSkills", JSON.stringify(volunteerSkillsData.body));
+      } else if (volunteerSkillsData) {
+        localStorage.setItem("volunteerSkills", JSON.stringify(volunteerSkillsData));
+      }
+    } catch (volunteerSkillsError) {
+      console.warn("Failed to fetch volunteer skills after login:", volunteerSkillsError.message);
     }
 
     let userDbId = null;


### PR DESCRIPTION
- Fetch categories API during login and store in localStorage (similar to enums)
- Load categories into Redux state during login
- Fetch volunteer skills during login and store in localStorage
- Update HelpRequestForm to check localStorage first before API call
- Update PromoteToVolunteer to check localStorage first for volunteer skills
- Ensures categories are available immediately after login for Dashboard and Volunteer Wizard