### PR TITLE
Super Admin, Admin Dashboard tabs order and implemented three subtabs

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -160,6 +160,7 @@ const Dashboard = ({ userRole }) => {
 
   const handleTabChange = (tab) => {
     setActiveTab(tab);
+    if (tab === "analytics") setAnalyticsSubtab("Infrastructure");
     setCurrentPage(1);
     setStatusFilter({
       Open: true,
@@ -469,8 +470,8 @@ const Dashboard = ({ userRole }) => {
     dashboardTitle = "Volunteer Dashboard";
 
   const dashboardDefaultTab = {
-    superAdmin: "myRequests",
-    admin: "myRequests",
+    superAdmin: "analytics",
+    admin: "analytics",
     steward: "myRequests",
     volunteer: "managedRequests",
     beneficiary: "myRequests",
@@ -666,6 +667,10 @@ const Dashboard = ({ userRole }) => {
     </>
   );
 
+  // Analytics Sub Tabs
+
+  const [analyticsSubtab, setAnalyticsSubtab] = useState("Infrastructure");
+
   return (
     <div className="p-5">
       <ToastContainer
@@ -777,7 +782,11 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
-              searchFilters={dashboardSearchFilters}
+              searchFilters={
+                activeTab === "analytics" ? null : dashboardSearchFilters
+              }
+              analyticsSubtab={analyticsSubtab}
+              setAnalyticsSubtab={setAnalyticsSubtab}
             />
           )}
 
@@ -797,7 +806,11 @@ const Dashboard = ({ userRole }) => {
               onRowsPerPageChange={handleRowsPerPageChange}
               getLinkPath={(request, header) => `/request/${request[header]}`}
               getLinkState={(request) => request}
-              searchFilters={dashboardSearchFilters}
+              searchFilters={
+                activeTab === "analytics" ? null : dashboardSearchFilters
+              }
+              analyticsSubtab={analyticsSubtab}
+              setAnalyticsSubtab={setAnalyticsSubtab}
             />
           )}
 

--- a/src/pages/Dashboard/views/AdminDashboard.jsx
+++ b/src/pages/Dashboard/views/AdminDashboard.jsx
@@ -17,21 +17,13 @@ const AdminDashboard = (props) => {
     getLinkPath,
     getLinkState,
     searchFilters,
+    analyticsSubtab,
+    setAnalyticsSubtab,
   } = props;
 
   return (
     <div>
       <div className="flex mb-5">
-        <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
-            activeTab === "myRequests"
-              ? "bg-white text-blue-500 border-blue-500"
-              : "bg-gray-300 border-transparent hover:bg-gray-200"
-          }`}
-          onClick={() => handleTabChange("myRequests")}
-        >
-          All Requests
-        </button>
         <button
           className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
             activeTab === "analytics"
@@ -42,14 +34,70 @@ const AdminDashboard = (props) => {
         >
           Analytics
         </button>
+        <button
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
+            activeTab === "myRequests"
+              ? "bg-white text-blue-500 border-blue-500"
+              : "bg-gray-300 border-transparent hover:bg-gray-200"
+          }`}
+          onClick={() => handleTabChange("myRequests")}
+        >
+          All Requests
+        </button>
       </div>
 
       {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
+        {activeTab === "analytics" && (
+          <div className="flex mb-4">
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+              ${
+                analyticsSubtab === "Infrastructure"
+                  ? "bg-white text-blue-500 border-blue-500"
+                  : "bg-gray-100 border-transparent hover:bg-gray-200"
+              } mr-1`}
+              onClick={() => setAnalyticsSubtab("Infrastructure")}
+            >
+              Infrastructure
+            </button>
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+              ${
+                analyticsSubtab === "Application Analytics"
+                  ? "bg-white text-blue-500 border-blue-500"
+                  : "bg-gray-100 border-transparent hover:bg-gray-200"
+              } mr-1`}
+              onClick={() => setAnalyticsSubtab("Application Analytics")}
+            >
+              Application Analytics
+            </button>
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+              ${
+                analyticsSubtab === "Google Analytics"
+                  ? "bg-white text-blue-500 border-blue-500"
+                  : "bg-gray-100 border-transparent hover:bg-gray-200"
+              }`}
+              onClick={() => setAnalyticsSubtab("Google Analytics")}
+            >
+              Google Analytics
+            </button>
+          </div>
+        )}
+
         {activeTab === "analytics" ? (
           <div className="p-6 text-center text-gray-600">
-            Analytics placeholder (chart will go here)
+            {analyticsSubtab === "Infrastructure" && (
+              <>Infrastructure (Summary of Errors) - To Be Implemented</>
+            )}
+            {analyticsSubtab === "Application Analytics" && (
+              <>Application Analytics - To Be Implemented</>
+            )}
+            {analyticsSubtab === "Google Analytics" && (
+              <>Google Analytics - To Be Implemented</>
+            )}
           </div>
         ) : (
           !isLoading && (

--- a/src/pages/Dashboard/views/SuperAdminDashboard.jsx
+++ b/src/pages/Dashboard/views/SuperAdminDashboard.jsx
@@ -17,21 +17,13 @@ const SuperAdminDashboard = (props) => {
     getLinkPath,
     getLinkState,
     searchFilters,
+    analyticsSubtab,
+    setAnalyticsSubtab,
   } = props;
 
   return (
     <div>
       <div className="flex mb-5">
-        <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
-            activeTab === "myRequests"
-              ? "bg-white text-blue-500 border-blue-500"
-              : "bg-gray-300 border-transparent hover:bg-gray-200"
-          }`}
-          onClick={() => handleTabChange("myRequests")}
-        >
-          All Requests
-        </button>
         <button
           className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
             activeTab === "analytics"
@@ -42,14 +34,70 @@ const SuperAdminDashboard = (props) => {
         >
           Analytics
         </button>
+        <button
+          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold mr-1 ${
+            activeTab === "myRequests"
+              ? "bg-white text-blue-500 border-blue-500"
+              : "bg-gray-300 border-transparent hover:bg-gray-200"
+          }`}
+          onClick={() => handleTabChange("myRequests")}
+        >
+          All Requests
+        </button>
       </div>
 
       {searchFilters}
 
       <div className="requests-section overflow-hidden table-height-fix">
+        {activeTab === "analytics" && (
+          <div className="flex mb-4">
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+        ${
+          analyticsSubtab === "Infrastructure"
+            ? "bg-white text-blue-500 border-blue-500"
+            : "bg-gray-100 border-transparent hover:bg-gray-200"
+        } mr-1`}
+              onClick={() => setAnalyticsSubtab("Infrastructure")}
+            >
+              Infrastructure
+            </button>
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+        ${
+          analyticsSubtab === "Application Analytics"
+            ? "bg-white text-blue-500 border-blue-500"
+            : "bg-gray-100 border-transparent hover:bg-gray-200"
+        } mr-1`}
+              onClick={() => setAnalyticsSubtab("Application Analytics")}
+            >
+              Application Analytics
+            </button>
+            <button
+              className={`flex-1 py-2 text-center cursor-pointer border-b-2 font-semibold 
+        ${
+          analyticsSubtab === "Google Analytics"
+            ? "bg-white text-blue-500 border-blue-500"
+            : "bg-gray-100 border-transparent hover:bg-gray-200"
+        }`}
+              onClick={() => setAnalyticsSubtab("Google Analytics")}
+            >
+              Google Analytics
+            </button>
+          </div>
+        )}
+
         {activeTab === "analytics" ? (
           <div className="p-6 text-center text-gray-600">
-            Analytics placeholder (chart will go here)
+            {analyticsSubtab === "Infrastructure" && (
+              <>Infrastructure (Summary of Errors) - To Be Implemented</>
+            )}
+            {analyticsSubtab === "Application Analytics" && (
+              <>Application Analytics - To Be Implemented</>
+            )}
+            {analyticsSubtab === "Google Analytics" && (
+              <>Google Analytics - To Be Implemented</>
+            )}
           </div>
         ) : (
           !isLoading && (


### PR DESCRIPTION
#1057
Implemented:

1. Admin Dashboards have two tabs and they are to be displayed in the order from left to right:
  Analytics
  All Requests
2. Analytics Tab will have three subtabs and they are to be displayed in the order from left to right:
    Infrastructure (summary of errors)
    Application analytics
    Google Analytics
3. When logged in as an admin, the default opening must be the infrastructure tab to show what’s working and what’s not working.