### PR TITLE
Implement 2-tab structure for Create Help Request page (#1094)

### DIFF
--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -115,6 +115,8 @@
   "DESCRIPTION": "Description",
   "DESCRIPTION_HELP_TEXT": "Please give a detailed description of the request",
   "DESIGN_CREATIVE_LEAD": "Design Creative Lead",
+  "DETAILS": "Details",
+  "SPECIFICS": "Specifics",
   "DEVELOPER_ADVOCATE_AI_ML_DEV_MANAGER": "Developer Advocate AI/ML Dev Manager",
   "DIRECTOR": "DIRECTOR",
   "DIRECTORS": "Meet the Board of Directors",

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -118,6 +118,8 @@
   "DESCRIPTION": "Descripción",
   "DESCRIPTION_HELP_TEXT": "Please give a detailed description of the request",
   "DESIGN_CREATIVE_LEAD": "Design Creative Lead",
+  "DETAILS": "Detalles",
+  "SPECIFICS": "Específicos",
   "DEVELOPER_ADVOCATE_AI_ML_DEV_MANAGER": "Developer Advocate AI/ML Dev Manager",
   "DIRECTOR": "DIRECTOR",
   "DIRECTORS": "Consejo de administración",

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -118,6 +118,8 @@
   "DESCRIPTION": "विवरण",
   "DESCRIPTION_HELP_TEXT": "Please give a detailed description of the request",
   "DESIGN_CREATIVE_LEAD": "Design Creative Lead",
+  "DETAILS": "विवरण",
+  "SPECIFICS": "विशिष्टताएं",
   "DEVELOPER_ADVOCATE_AI_ML_DEV_MANAGER": "Developer Advocate AI/ML Dev Manager",
   "DIRECTOR": "DIRECTOR",
   "DIRECTORS": "निदेशक मंडल",

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -118,6 +118,8 @@
   "DESCRIPTION": "Описание",
   "DESCRIPTION_HELP_TEXT": "Please give a detailed description of the request",
   "DESIGN_CREATIVE_LEAD": "Design Creative Lead",
+  "DETAILS": "Детали",
+  "SPECIFICS": "Характеристики",
   "DEVELOPER_ADVOCATE_AI_ML_DEV_MANAGER": "Developer Advocate AI/ML Dev Manager",
   "DIRECTOR": "DIRECTOR",
   "DIRECTORS": "Совет директоров",

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -186,6 +186,8 @@
   "DIRECTOR_OF_ENGINEERING": "ఇంజనీరింగ్ డైరెక్టర్",
   "BUSINESS_ANALYST_TEAM_LEAD": "బిజినస్ అనలిస్ట్ టీమ్ లీడ్",
   "PROGRAM_MANAGER_BUSINESS_ANALYST": "ప్రోగ్రామ్ మేనేజర్ | బిజినస్ అనలిస్ట్",
+  "DETAILS": "Details",
+  "SPECIFICS": "Specifics",
   "DESIGN_CREATIVE_LEAD": "డిజైన్ మరియు క్రియేటివ్ లీడ్",
   "AI_ML_TEAM_LEAD": "AI/ML టీమ్ లీడ్",
   "LEAD_DEVSECOPS_ENGINEER": "లీడ్ DevSecOps ఇంజనీర్",

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -119,6 +119,8 @@
   "DESCRIPTION": "描述",
   "DESCRIPTION_HELP_TEXT": "Please give a detailed description of the request",
   "DESIGN_CREATIVE_LEAD": "Design Creative Lead",
+  "DETAILS": "详情",
+  "SPECIFICS": "具体信息",
   "DEVELOPER_ADVOCATE_AI_ML_DEV_MANAGER": "Developer Advocate AI/ML Dev Manager",
   "DIRECTOR": "DIRECTOR",
   "DIRECTORS": "董事会",

--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -46,6 +46,8 @@ import {
   LinearProgress,
   IconButton,
   Box,
+  Tabs,
+  Tab,
 } from "@mui/material";
 
 const genderOptions = [
@@ -61,6 +63,21 @@ const genderOptions = [
 const MAX_FILES = 5;
 const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
 const ALLOWED_MIME_TYPES = ["image/png", "image/jpeg", "application/pdf"];
+
+// TabPanel component for tab content
+function TabPanel({ children, value, index, ...other }) {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`help-request-tabpanel-${index}`}
+      aria-labelledby={`help-request-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ pt: 3 }}>{children}</Box>}
+    </div>
+  );
+}
 
 const HelpRequestForm = ({ isEdit = false, onClose }) => {
   const { t, i18n } = useTranslation(["common", "categories"]);
@@ -659,6 +676,13 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
 
   const [selfFlag, setSelfFlag] = useState(true);
 
+  // Tab state for 2-tab structure
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const handleTabChange = (event, newValue) => {
+    setCurrentTab(newValue);
+  };
+
   const handleConfirmCategorySelection = () => {
     const oldCategory = "General";
     const newCategory = formData.category;
@@ -953,250 +977,25 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
               {t("LIFE_THREATENING_REQUESTS")}
             </div>
           </div>
-          <div className="mt-3 flex gap-4" data-testid="parentDivOne">
-            {/* For Self Dropdown */}
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-1">
-                <label htmlFor="self" className="text-gray-700 font-medium">
-                  {t("FOR_SELF")}
-                </label>
-                <div className="relative group cursor-pointer">
-                  {/* Circle Question Mark Icon */}
-                  <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
-                    ?
-                  </div>
-                  {/* Tooltip */}
-                  <div className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
-                    Choose ‘Yes’ if you’re submitting this request on your own
-                    behalf else ‘No’ if you’re requesting for someone else.
-                  </div>
-                </div>
-              </div>
 
-              <div className="flex-1 relative">
-                <select
-                  id="request_for"
-                  value={formData.request_for || ""}
-                  className="appearance-none bg-white border p-2 w-full rounded-lg text-gray-700"
-                  onChange={(e) => {
-                    const selected = e.target.value;
-                    setFormData({ ...formData, request_for: selected });
-                    setSelfFlag(selected === enums?.requestFor?.[0]); // "SELF" means true, "OTHER" means false
-                  }}
-                >
-                  {enums?.requestFor &&
-                    Object.values(enums.requestFor).map((val) => (
-                      <option key={val} value={val}>
-                        {t(`enums:requestFor.${val}`, val)}
-                      </option>
-                    ))}
-                </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                  <HiChevronDown className="h-5 w-5 text-gray-600" />
-                </div>
-              </div>
-            </div>
+          {/* Tabs for Details and Specifics */}
+          <Box sx={{ borderBottom: 1, borderColor: "divider", mt: 2 }}>
+            <Tabs
+              value={currentTab}
+              onChange={handleTabChange}
+              aria-label="help request form tabs"
+            >
+              <Tab label={t("DETAILS") || "Details"} id="help-request-tab-0" />
+              <Tab
+                label={t("SPECIFICS") || "Specifics"}
+                id="help-request-tab-1"
+              />
+            </Tabs>
+          </Box>
 
-            {/* Lead Volunteer */}
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-1">
-                <label
-                  htmlFor="lead_volunteer"
-                  className="text-gray-700 font-medium"
-                >
-                  {t("Lead Volunteer")}
-                </label>
-                <div className="relative group cursor-pointer">
-                  <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
-                    ?
-                  </div>
-                  <div
-                    className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 
-                                  opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10"
-                  >
-                    Select “Yes” if you’re the main volunteer coordinating this
-                    request.
-                  </div>
-                </div>
-              </div>
-
-              {/* when editing, admins can type new name; otherwise show a dropdown */}
-              {isEdit ? (
-                <input
-                  type="text"
-                  id="lead_volunteer"
-                  name="lead_volunteer"
-                  disabled={
-                    !(
-                      groups?.includes("Admins") ||
-                      groups?.includes("SuperAdmins")
-                    )
-                  }
-                  value={formData.lead_volunteer}
-                  onChange={handleChange}
-                  className="border p-2 w-full rounded-lg disabled:text-gray-600"
-                />
-              ) : (
-                <div className="relative">
-                  <select
-                    id="lead_volunteer"
-                    name="lead_volunteer"
-                    value={formData.lead_volunteer}
-                    onChange={handleChange}
-                    className="block w-full appearance-none bg-white border border-gray-300 rounded-lg 
-                              py-2 px-3 pr-8 text-gray-700 focus:outline-none"
-                  >
-                    <option value="No">{t("No")}</option>
-                    <option value="Yes">{t("Yes")}</option>
-                  </select>
-                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                    <HiChevronDown className="h-5 w-5 text-gray-600" />
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {
-            //Temporarily commented out as MVP only allows for self requests
-            !selfFlag && (
-              <div
-                className="mt-5 w-full border border-gray-200 rounded-lg p-4 bg-gray-50"
-                data-testid="parentDivTwo"
-              >
-                <div className="flex items-start gap-2 mb-3 text-sm text-gray-600">
-                  <IoMdInformationCircle className="text-gray-500 mr-1 mt-0.5" />
-                  <div className="text-sm text-gray-600">
-                    Please fill the details of the person you are submitting the
-                    request for.
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label
-                      htmlFor="requester_first_name"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("FIRST_NAME")}
-                    </label>
-                    <input
-                      type="text"
-                      id="requester_first_name"
-                      value={formData.requester_first_name}
-                      onChange={handleChange}
-                      className="w-full rounded-lg border py-2 px-3"
-                    />
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="requester_last_name"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("LAST_NAME")}
-                    </label>
-                    <input
-                      type="text"
-                      id="requester_last_name"
-                      value={formData.requester_last_name}
-                      onChange={handleChange}
-                      className="w-full rounded-lg border py-2 px-3"
-                    />
-                  </div>
-                </div>
-                <div className="mt-3" data-testid="parentDivThree">
-                  <label
-                    htmlFor="email"
-                    className="block text-gray-700 mb-1 font-medium"
-                  >
-                    {t("EMAIL")}
-                  </label>
-                  <input
-                    type="email"
-                    id="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                    className="w-full rounded-lg border py-2 px-3"
-                  />
-                </div>
-
-                <div className="mt-3 grid grid-cols-2 gap-4">
-                  <div>
-                    <label
-                      htmlFor="phone"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("PHONE")}
-                    </label>
-                    <input
-                      type="text"
-                      id="phone"
-                      value={formData.phone}
-                      onChange={handleChange}
-                      className="w-full rounded-lg border py-2 px-3"
-                    />
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="age"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("AGE")}
-                    </label>
-                    <input
-                      type="number"
-                      id="age"
-                      value={formData.age}
-                      onChange={handleChange}
-                      className="w-full rounded-lg border py-2 px-3"
-                    />
-                  </div>
-                  <div className="mt-3" data-testid="parentDivFour">
-                    <label
-                      htmlFor="gender"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("GENDER")}
-                    </label>
-                    <select
-                      id="gender"
-                      value={formData.gender}
-                      onChange={handleChange}
-                      className="border border-gray-300 text-gray-700 rounded-lg p-2 w-full bg-white"
-                    >
-                      {genderOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="mt-3" data-testid="parentDivFive">
-                    <label
-                      htmlFor="language"
-                      className="block text-gray-700 mb-1 font-medium"
-                    >
-                      {t("PREFERRED_LANGUAGE")}
-                    </label>
-                    <select
-                      id="preferred_language"
-                      value={formData.preferred_language}
-                      onChange={handleChange}
-                      className="border border-gray-300 text-gray-700 rounded-lg p-2 w-full bg-white"
-                    >
-                      {languages.map((language) => (
-                        <option key={language.value} value={language.value}>
-                          {language.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              </div>
-            )
-          }
-
-          {/* Category + Request Type + Priority (kept same) */}
-          <div className="mt-3 grid grid-cols-2 gap-4">
+          {/* Tab 1: Details - Category, Subject, Description */}
+          <TabPanel value={currentTab} index={0}>
+            {/* Category Field */}
             <div className="flex-1 relative">
               <div className="flex items-center gap-2 mb-1">
                 <label htmlFor="category" className="font-medium text-gray-700">
@@ -1211,7 +1010,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                   <div className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
                     Choose the category that best describes your need (e.g.,
                     Medical, Food, Jobs).
-                    <br /> If you select ‘General,’ please describe your need
+                    <br /> If you select 'General,' please describe your need
                     fully in the Description field.
                   </div>
                 </div>
@@ -1231,7 +1030,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                   }}
                 />
 
-                {/* the dropdown arrow, pointer-events-none so it doesn’t block input clicks */}
+                {/* the dropdown arrow, pointer-events-none so it doesn't block input clicks */}
                 <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                   <HiChevronDown className="h-5 w-5 text-gray-600" />
                 </div>
@@ -1368,94 +1167,376 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
               )}
             </div>
 
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-1">
+            {/* Subject Field */}
+            <div className="mt-3" data-testid="parentDivSix">
+              {formData.category === "Jobs" && <JobsCategory />}
+              {formData.category === "Housing" && <HousingCategory />}
+              <label
+                htmlFor="subject"
+                className="block text-gray-700 font-medium mb-2"
+              >
+                {t("SUBJECT")}
+                <span className="text-red-500 m-1">*</span>(
+                {t("MAX_CHARACTERS", { count: 70 })})
+              </label>
+              <input
+                type="text"
+                id="subject"
+                name="subject"
+                value={formData.subject}
+                onChange={handleChange}
+                className="border p-2 w-full rounded-lg"
+                maxLength={70}
+                required
+                placeholder="Please give a brief description of the request"
+              />
+            </div>
+
+            {/* Description + Attach files */}
+            <div className="mt-3" data-testid="parentDivSeven">
+              <div className="flex items-center justify-between">
                 <label
-                  htmlFor="requestType"
-                  className="font-medium text-gray-700"
+                  htmlFor="description"
+                  className="block text-gray-700 font-medium mb-2 flex items-center gap-2"
                 >
-                  {t("REQUEST_TYPE")}
+                  {t("DESCRIPTION")}
+                  <span className="text-red-500 m-1">*</span>(
+                  {t("MAX_CHARACTERS", { count: 500 })}){/* Attach icon */}
+                  <div className="relative group inline-block">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        document.getElementById("fileInput").click()
+                      }
+                      className="flex items-center justify-center w-7 h-7 rounded-md bg-gray-200 hover:bg-gray-300 text-black text-xl font-bold cursor-pointer"
+                    >
+                      📎
+                    </button>
+                    {/* Tooltip (Right side) */}
+                    <div className="absolute left-7 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
+                      Attach Files:
+                      <br />
+                      You can attach up to 5 files
+                      <br />
+                      Allowed: PNG, JPG, JPEG, PDF
+                      <br />
+                      Max size 2MB each
+                    </div>
+                  </div>
+                  {/* Attached count button */}
+                  {(attachedFiles.length > 0 ||
+                    uploadedFilesInfo.length > 0) && (
+                    <button
+                      type="button"
+                      className="ml-2 text-sm px-2 py-1 rounded bg-gray-100 border"
+                      onClick={() => setShowFilesDialog(true)}
+                    >
+                      {attachedFiles.length + uploadedFilesInfo.length} Attached
+                    </button>
+                  )}
                 </label>
-                <div className="relative group cursor-pointer">
-                  {/* Circle Question Mark Icon */}
-                  <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
-                    ?
-                  </div>
-                  <div
-                    className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2
-                                  opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 pointer-events-none"
-                  >
-                    Indicate how you’d like help delivered: “Remote” for virtual
-                    support or “In Person” for onsite assistance.
-                  </div>
-                </div>
               </div>
 
-              <div className="relative">
-                <select
-                  id="requestType"
-                  value={formData.request_type || "REMOTE"}
-                  onChange={(e) =>
-                    setFormData({ ...formData, request_type: e.target.value })
-                  }
-                  className="
-                    block w-full appearance-none
-                    bg-white border border-gray-300
-                    rounded-lg py-2 px-3 pr-8
-                    text-gray-700
-                    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
-                  "
-                >
-                  {enums?.requestType &&
-                    Object.values(enums.requestType).map((val) => (
-                      <option key={val} value={val}>
-                        {t(`enums:requestType.${val}`, val)}
-                      </option>
+              <textarea
+                id="description"
+                name="description"
+                value={formData.description}
+                onChange={handleChange}
+                className="border p-2 w-full rounded-lg"
+                rows="5"
+                maxLength={500}
+                required
+                placeholder="Please give a detailed description of the request"
+              ></textarea>
+
+              {/* Hidden file input */}
+              <input
+                ref={fileInputRef}
+                id="fileInput"
+                type="file"
+                accept=".png,.jpg,.jpeg,.pdf"
+                multiple
+                hidden
+                onChange={handleFileSelection}
+              />
+
+              {/* Per-file upload progress indicators (when uploading) */}
+              {isUploadingFiles && Object.keys(uploadProgress).length > 0 && (
+                <div className="mt-3">
+                  <Typography variant="subtitle2">
+                    Uploading files...
+                  </Typography>
+                  <div className="space-y-2 mt-2">
+                    {Object.keys(uploadProgress).map((key) => (
+                      <Box key={key} sx={{ width: "100%" }}>
+                        <Typography variant="body2" sx={{ fontSize: 12 }}>
+                          {key}
+                        </Typography>
+                        <LinearProgress
+                          variant="determinate"
+                          value={uploadProgress[key] || 0}
+                        />
+                      </Box>
                     ))}
-                </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                  <HiChevronDown className="h-5 w-5 text-gray-600" />
-                </div>
-              </div>
-              {formData.request_type === "INPERSON" && (
-                <div
-                  className="mt-5 ml-2 sm:ml-4 border border-gray-200 rounded-lg p-4 bg-gray-50"
-                  data-testid="parentDivTwo"
-                >
-                  <label
-                    htmlFor="location"
-                    className="block mb-1 font-medium text-gray-700"
-                  >
-                    Location
-                  </label>
-                  {isLoaded && (
-                    <StandaloneSearchBox
-                      onLoad={(ref) => (inputRef.current = ref)}
-                      onPlacesChanged={handleOnPlacesChanged}
-                    >
-                      <input
-                        type="text"
-                        id="location"
-                        value={formData.location}
-                        onChange={handleChange}
-                        name="location"
-                        className="border p-2 w-full rounded-lg"
-                        placeholder="Search for location..."
-                      />
-                    </StandaloneSearchBox>
-                  )}
+                  </div>
                 </div>
               )}
             </div>
+          </TabPanel>
 
-            <div className="mt-3 flex gap-4">
+          {/* Tab 2: Specifics - All other fields */}
+          <TabPanel value={currentTab} index={1}>
+            <div className="mt-3 flex gap-4" data-testid="parentDivOne">
+              {/* For Self Dropdown */}
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                  <label htmlFor="self" className="text-gray-700 font-medium">
+                    {t("FOR_SELF")}
+                  </label>
+                  <div className="relative group cursor-pointer">
+                    {/* Circle Question Mark Icon */}
+                    <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
+                      ?
+                    </div>
+                    {/* Tooltip */}
+                    <div className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
+                      Choose ‘Yes’ if you’re submitting this request on your own
+                      behalf else ‘No’ if you’re requesting for someone else.
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex-1 relative">
+                  <select
+                    id="request_for"
+                    value={formData.request_for || ""}
+                    className="appearance-none bg-white border p-2 w-full rounded-lg text-gray-700"
+                    onChange={(e) => {
+                      const selected = e.target.value;
+                      setFormData({ ...formData, request_for: selected });
+                      setSelfFlag(selected === enums?.requestFor?.[0]); // "SELF" means true, "OTHER" means false
+                    }}
+                  >
+                    {enums?.requestFor &&
+                      Object.values(enums.requestFor).map((val) => (
+                        <option key={val} value={val}>
+                          {t(`enums:requestFor.${val}`, val)}
+                        </option>
+                      ))}
+                  </select>
+                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                    <HiChevronDown className="h-5 w-5 text-gray-600" />
+                  </div>
+                </div>
+              </div>
+
+              {/* Lead Volunteer */}
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-1">
                   <label
-                    htmlFor="calamity"
+                    htmlFor="lead_volunteer"
+                    className="text-gray-700 font-medium"
+                  >
+                    {t("Lead Volunteer")}
+                  </label>
+                  <div className="relative group cursor-pointer">
+                    <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
+                      ?
+                    </div>
+                    <div
+                      className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 
+                                  opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10"
+                    >
+                      Select “Yes” if you’re the main volunteer coordinating
+                      this request.
+                    </div>
+                  </div>
+                </div>
+
+                {/* when editing, admins can type new name; otherwise show a dropdown */}
+                {isEdit ? (
+                  <input
+                    type="text"
+                    id="lead_volunteer"
+                    name="lead_volunteer"
+                    disabled={
+                      !(
+                        groups?.includes("Admins") ||
+                        groups?.includes("SuperAdmins")
+                      )
+                    }
+                    value={formData.lead_volunteer}
+                    onChange={handleChange}
+                    className="border p-2 w-full rounded-lg disabled:text-gray-600"
+                  />
+                ) : (
+                  <div className="relative">
+                    <select
+                      id="lead_volunteer"
+                      name="lead_volunteer"
+                      value={formData.lead_volunteer}
+                      onChange={handleChange}
+                      className="block w-full appearance-none bg-white border border-gray-300 rounded-lg 
+                              py-2 px-3 pr-8 text-gray-700 focus:outline-none"
+                    >
+                      <option value="No">{t("No")}</option>
+                      <option value="Yes">{t("Yes")}</option>
+                    </select>
+                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                      <HiChevronDown className="h-5 w-5 text-gray-600" />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {
+              //Temporarily commented out as MVP only allows for self requests
+              !selfFlag && (
+                <div
+                  className="mt-5 w-full border border-gray-200 rounded-lg p-4 bg-gray-50"
+                  data-testid="parentDivTwo"
+                >
+                  <div className="flex items-start gap-2 mb-3 text-sm text-gray-600">
+                    <IoMdInformationCircle className="text-gray-500 mr-1 mt-0.5" />
+                    <div className="text-sm text-gray-600">
+                      Please fill the details of the person you are submitting
+                      the request for.
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label
+                        htmlFor="requester_first_name"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("FIRST_NAME")}
+                      </label>
+                      <input
+                        type="text"
+                        id="requester_first_name"
+                        value={formData.requester_first_name}
+                        onChange={handleChange}
+                        className="w-full rounded-lg border py-2 px-3"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="requester_last_name"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("LAST_NAME")}
+                      </label>
+                      <input
+                        type="text"
+                        id="requester_last_name"
+                        value={formData.requester_last_name}
+                        onChange={handleChange}
+                        className="w-full rounded-lg border py-2 px-3"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-3" data-testid="parentDivThree">
+                    <label
+                      htmlFor="email"
+                      className="block text-gray-700 mb-1 font-medium"
+                    >
+                      {t("EMAIL")}
+                    </label>
+                    <input
+                      type="email"
+                      id="email"
+                      value={formData.email}
+                      onChange={handleChange}
+                      className="w-full rounded-lg border py-2 px-3"
+                    />
+                  </div>
+
+                  <div className="mt-3 grid grid-cols-2 gap-4">
+                    <div>
+                      <label
+                        htmlFor="phone"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("PHONE")}
+                      </label>
+                      <input
+                        type="text"
+                        id="phone"
+                        value={formData.phone}
+                        onChange={handleChange}
+                        className="w-full rounded-lg border py-2 px-3"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="age"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("AGE")}
+                      </label>
+                      <input
+                        type="number"
+                        id="age"
+                        value={formData.age}
+                        onChange={handleChange}
+                        className="w-full rounded-lg border py-2 px-3"
+                      />
+                    </div>
+                    <div className="mt-3" data-testid="parentDivFour">
+                      <label
+                        htmlFor="gender"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("GENDER")}
+                      </label>
+                      <select
+                        id="gender"
+                        value={formData.gender}
+                        onChange={handleChange}
+                        className="border border-gray-300 text-gray-700 rounded-lg p-2 w-full bg-white"
+                      >
+                        {genderOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="mt-3" data-testid="parentDivFive">
+                      <label
+                        htmlFor="language"
+                        className="block text-gray-700 mb-1 font-medium"
+                      >
+                        {t("PREFERRED_LANGUAGE")}
+                      </label>
+                      <select
+                        id="preferred_language"
+                        value={formData.preferred_language}
+                        onChange={handleChange}
+                        className="border border-gray-300 text-gray-700 rounded-lg p-2 w-full bg-white"
+                      >
+                        {languages.map((language) => (
+                          <option key={language.value} value={language.value}>
+                            {language.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              )
+            }
+
+            {/* Request Type + Priority + Is Calamity */}
+            <div className="mt-3 grid grid-cols-2 gap-4">
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                  <label
+                    htmlFor="requestType"
                     className="font-medium text-gray-700"
                   >
-                    Is Calamity?
+                    {t("REQUEST_TYPE")}
                   </label>
                   <div className="relative group cursor-pointer">
                     {/* Circle Question Mark Icon */}
@@ -1466,252 +1547,155 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                       className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2
                                   opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 pointer-events-none"
                     >
-                      Indicate if it is a calamity by checking the box.
+                      Indicate how you’d like help delivered: “Remote” for
+                      virtual support or “In Person” for onsite assistance.
+                    </div>
+                  </div>
+                </div>
+
+                <div className="relative">
+                  <select
+                    id="requestType"
+                    value={formData.request_type || "REMOTE"}
+                    onChange={(e) =>
+                      setFormData({ ...formData, request_type: e.target.value })
+                    }
+                    className="
+                    block w-full appearance-none
+                    bg-white border border-gray-300
+                    rounded-lg py-2 px-3 pr-8
+                    text-gray-700
+                    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
+                  "
+                  >
+                    {enums?.requestType &&
+                      Object.values(enums.requestType).map((val) => (
+                        <option key={val} value={val}>
+                          {t(`enums:requestType.${val}`, val)}
+                        </option>
+                      ))}
+                  </select>
+                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                    <HiChevronDown className="h-5 w-5 text-gray-600" />
+                  </div>
+                </div>
+                {formData.request_type === "INPERSON" && (
+                  <div
+                    className="mt-5 ml-2 sm:ml-4 border border-gray-200 rounded-lg p-4 bg-gray-50"
+                    data-testid="parentDivTwo"
+                  >
+                    <label
+                      htmlFor="location"
+                      className="block mb-1 font-medium text-gray-700"
+                    >
+                      Location
+                    </label>
+                    {isLoaded && (
+                      <StandaloneSearchBox
+                        onLoad={(ref) => (inputRef.current = ref)}
+                        onPlacesChanged={handleOnPlacesChanged}
+                      >
+                        <input
+                          type="text"
+                          id="location"
+                          value={formData.location}
+                          onChange={handleChange}
+                          name="location"
+                          className="border p-2 w-full rounded-lg"
+                          placeholder="Search for location..."
+                        />
+                      </StandaloneSearchBox>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 flex gap-4">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <label
+                      htmlFor="calamity"
+                      className="font-medium text-gray-700"
+                    >
+                      Is Calamity?
+                    </label>
+                    <div className="relative group cursor-pointer">
+                      {/* Circle Question Mark Icon */}
+                      <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
+                        ?
+                      </div>
+                      <div
+                        className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2
+                                  opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 pointer-events-none"
+                      >
+                        Indicate if it is a calamity by checking the box.
+                      </div>
+                    </div>
+                  </div>
+                  <div className="relative">
+                    <input
+                      id="calamity"
+                      type="checkbox"
+                      name="calamity"
+                      className="w-5 h-5 inset-y-10 right-0 flex items-center pr-2"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="flex-1 relative">
+                <div className="flex items-center gap-2 mb-1">
+                  <label
+                    htmlFor="requestPriority"
+                    className="font-medium text-gray-700"
+                  >
+                    {t("Request Priority")}
+                  </label>
+                  <div className="relative group cursor-pointer">
+                    {/* Circle Question Mark Icon */}
+                    <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
+                      ?
+                    </div>
+                    {/* Tooltip */}
+                    <div className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
+                      How urgent is this request? <br />
+                      • Low – Not time sensitive <br />
+                      • Medium – Within few days <br />• High – Immediate
+                      support
                     </div>
                   </div>
                 </div>
                 <div className="relative">
-                  <input
-                    id="calamity"
-                    type="checkbox"
-                    name="calamity"
-                    className="w-5 h-5 inset-y-10 right-0 flex items-center pr-2"
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="flex-1 relative">
-              <div className="flex items-center gap-2 mb-1">
-                <label
-                  htmlFor="requestPriority"
-                  className="font-medium text-gray-700"
-                >
-                  {t("Request Priority")}
-                </label>
-                <div className="relative group cursor-pointer">
-                  {/* Circle Question Mark Icon */}
-                  <div className="w-4 h-4 flex items-center justify-center rounded-full bg-gray-400 text-white text-xs font-bold">
-                    ?
-                  </div>
-                  {/* Tooltip */}
-                  <div className="absolute left-5 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
-                    How urgent is this request? <br />
-                    • Low – Not time sensitive <br />
-                    • Medium – Within few days <br />• High – Immediate support
-                  </div>
-                </div>
-              </div>
-              <div className="relative">
-                <select
-                  id="requestPriority"
-                  value={formData.priority || enums?.requestPriority?.[1]}
-                  onChange={(e) =>
-                    setFormData({ ...formData, priority: e.target.value })
-                  }
-                  className="
+                  <select
+                    id="requestPriority"
+                    value={formData.priority || enums?.requestPriority?.[1]}
+                    onChange={(e) =>
+                      setFormData({ ...formData, priority: e.target.value })
+                    }
+                    className="
                     block w-full appearance-none
                     bg-white border border-gray-300
                     rounded-lg px-3 py-2 pr-8
                     text-gray-700
                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
                   "
-                >
-                  {enums?.requestPriority &&
-                    Object.values(enums.requestPriority).map((val) => (
-                      <option key={val} value={val}>
-                        {t(`enums:requestPriority.${val}`, val)}
-                      </option>
-                    ))}
-                </select>
-
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                  <HiChevronDown className="h-5 w-5 text-gray-600" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="mt-3" data-testid="parentDivSix">
-            {formData.category === "Jobs" && <JobsCategory />}
-            {formData.category === "Housing" && <HousingCategory />}
-            <label
-              htmlFor="subject"
-              className="block text-gray-700 font-medium mb-2"
-            >
-              {t("SUBJECT")}
-              <span className="text-red-500 m-1">*</span>(
-              {t("MAX_CHARACTERS", { count: 70 })})
-            </label>
-            <input
-              type="text"
-              id="subject"
-              name="subject"
-              value={formData.subject}
-              onChange={handleChange}
-              className="border p-2 w-full rounded-lg"
-              maxLength={70}
-              required
-              placeholder="Please give a brief description of the request"
-            />
-          </div>
-
-          {/* Description + Attach files icon */}
-          <div className="mt-3" data-testid="parentDivSeven">
-            <div className="flex items-center justify-between">
-              <label
-                htmlFor="description"
-                className="block text-gray-700 font-medium mb-2 flex items-center gap-2"
-              >
-                {t("DESCRIPTION")}
-                <span className="text-red-500 m-1">*</span>(
-                {t("MAX_CHARACTERS", { count: 500 })}){/* Attach icon */}
-                <div className="relative group inline-block">
-                  <button
-                    type="button"
-                    onClick={() => document.getElementById("fileInput").click()}
-                    className="flex items-center justify-center w-7 h-7 rounded-md bg-gray-200 hover:bg-gray-300 text-black text-xl font-bold cursor-pointer"
                   >
-                    📎
-                  </button>
-                  {/* Tooltip (Right side) */}
-                  <div className="absolute left-7 top-0 w-52 bg-gray-700 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 group-hover:visible transition-opacity duration-200 z-10 pointer-events-none">
-                    Attach Files:
-                    <br />
-                    You can attach up to 5 files
-                    <br />
-                    Allowed: PNG, JPG, JPEG, PDF
-                    <br />
-                    Max size 2MB each
+                    {enums?.requestPriority &&
+                      Object.values(enums.requestPriority).map((val) => (
+                        <option key={val} value={val}>
+                          {t(`enums:requestPriority.${val}`, val)}
+                        </option>
+                      ))}
+                  </select>
+
+                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                    <HiChevronDown className="h-5 w-5 text-gray-600" />
                   </div>
                 </div>
-                {/* Attached count button */}
-                {(attachedFiles.length > 0 || uploadedFilesInfo.length > 0) && (
-                  <button
-                    type="button"
-                    className="ml-2 text-sm px-2 py-1 rounded bg-gray-100 border"
-                    onClick={() => setShowFilesDialog(true)}
-                  >
-                    {attachedFiles.length + uploadedFilesInfo.length} Attached
-                  </button>
-                )}
-              </label>
-            </div>
-
-            <textarea
-              id="description"
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              className="border p-2 w-full rounded-lg"
-              rows="5"
-              maxLength={500}
-              required
-              placeholder="Please give a detailed description of the request"
-            ></textarea>
-
-            {/* Hidden file input */}
-            <input
-              ref={fileInputRef}
-              id="fileInput"
-              type="file"
-              accept=".png,.jpg,.jpeg,.pdf"
-              multiple
-              hidden
-              onChange={handleFileSelection}
-            />
-
-            {/*/!* Show list of newly selected (not uploaded yet) files inline *!/*/}
-            {/*{attachedFiles.length > 0 && (*/}
-            {/*    <div className="mt-2 border rounded p-2 bg-gray-50">*/}
-            {/*      <div className="flex items-center justify-between">*/}
-            {/*        <strong>Files to upload:</strong>*/}
-            {/*        <span className="text-sm text-gray-600">*/}
-            {/*        {attachedFiles.length}/{MAX_FILES}*/}
-            {/*      </span>*/}
-            {/*      </div>*/}
-            {/*      <ul className="mt-2">*/}
-            {/*        {attachedFiles.map((file, idx) => (*/}
-            {/*            <li*/}
-            {/*                key={file.name + idx}*/}
-            {/*                className="flex items-center justify-between text-sm py-1"*/}
-            {/*            >*/}
-            {/*              <div>*/}
-            {/*                {file.name} ({(file.size / 1024).toFixed(1)} KB)*/}
-            {/*              </div>*/}
-            {/*              <div className="flex items-center gap-2">*/}
-            {/*                <button*/}
-            {/*                    type="button"*/}
-            {/*                    className="text-sm text-red-600"*/}
-            {/*                    onClick={() => removeAttachedFile(idx)}*/}
-            {/*                >*/}
-            {/*                  Remove*/}
-            {/*                </button>*/}
-            {/*              </div>*/}
-            {/*            </li>*/}
-            {/*        ))}*/}
-            {/*      </ul>*/}
-            {/*    </div>*/}
-            {/*)}*/}
-
-            {/*/!* Show uploaded files (from previous uploads) *!/*/}
-            {/*{uploadedFilesInfo.length > 0 && (*/}
-            {/*    <div className="mt-2 border rounded p-2 bg-gray-50">*/}
-            {/*      <div className="flex items-center justify-between">*/}
-            {/*        <strong>Uploaded files:</strong>*/}
-            {/*      </div>*/}
-            {/*      <ul className="mt-2">*/}
-            {/*        {uploadedFilesInfo.map((f, idx) => (*/}
-            {/*            <li*/}
-            {/*                key={f.fileUrl || f.name + idx}*/}
-            {/*                className="flex items-center justify-between text-sm py-1"*/}
-            {/*            >*/}
-            {/*              <div>*/}
-            {/*                <a*/}
-            {/*                    href={f.fileUrl}*/}
-            {/*                    target="_blank"*/}
-            {/*                    rel="noreferrer"*/}
-            {/*                    className="underline"*/}
-            {/*                >*/}
-            {/*                  {f.name}*/}
-            {/*                </a>{" "}*/}
-            {/*                {f.size ? `(${(f.size / 1024).toFixed(1)} KB)` : ""}*/}
-            {/*              </div>*/}
-            {/*              <div className="flex items-center gap-2">*/}
-            {/*                <button*/}
-            {/*                    type="button"*/}
-            {/*                    className="text-sm text-red-600"*/}
-            {/*                    onClick={() => removeUploadedFile(idx)}*/}
-            {/*                >*/}
-            {/*                  Remove*/}
-            {/*                </button>*/}
-            {/*              </div>*/}
-            {/*            </li>*/}
-            {/*        ))}*/}
-            {/*      </ul>*/}
-            {/*    </div>*/}
-            {/*)}*/}
-
-            {/* Per-file upload progress indicators (when uploading) */}
-            {isUploadingFiles && Object.keys(uploadProgress).length > 0 && (
-              <div className="mt-3">
-                <Typography variant="subtitle2">Uploading files...</Typography>
-                <div className="space-y-2 mt-2">
-                  {Object.keys(uploadProgress).map((key) => (
-                    <Box key={key} sx={{ width: "100%" }}>
-                      <Typography variant="body2" sx={{ fontSize: 12 }}>
-                        {key}
-                      </Typography>
-                      <LinearProgress
-                        variant="determinate"
-                        value={uploadProgress[key] || 0}
-                      />
-                    </Box>
-                  ))}
-                </div>
               </div>
-            )}
-          </div>
+            </div>
+          </TabPanel>
 
-          {/* Submit buttons */}
+          {/* Submit buttons - Outside tabs */}
           <div className="mt-8 flex justify-end gap-2">
             <button
               type="submit"


### PR DESCRIPTION
## Changes Made:

### Main Implementation:
- Added Material-UI Tabs component to split Create Help Request form
- Created TabPanel component for tab content management
- Positioned tabs below page title and yellow emergency warning box

### Tab 1 - "Details" (Mandatory Fields):
- Category dropdown (with subcategories and search)
- Subject field (70 char limit)
- Description field (500 char limit)
- File attachment functionality

### Tab 2 - "Specifics" (Additional Fields):
- For Self dropdown
- Lead Volunteer field
- Requester details section (conditional)
- Request Type dropdown
- Location field (conditional for In-Person requests)
- Is Calamity checkbox
- Request Priority dropdown

### Translations Added:
- Added "DETAILS" and "SPECIFICS" translations to:
  - English (en)
  - Spanish (es)
  - Hindi (hi)
  - Russian (ru)
  - Chinese (zh)
  - Telugu (te)

Closes #1094