### PR TITLE
Add enums API integration with i18n translation support across languages

### DIFF
--- a/src/common/i18n/i18n.js
+++ b/src/common/i18n/i18n.js
@@ -13,6 +13,7 @@ import enProfile from "./locales/en/profile.json";
 
 import deCommon from "./locales/de/common.json";
 import deAuth from "./locales/de/auth.json";
+import deEnums from "./locales/de/enums.json";
 import deCategories from "./locales/de/categories.json";
 import deAvailability from "./locales/de/availability.json";
 import deIdentity from "./locales/de/identity.json";
@@ -28,6 +29,7 @@ import esProfile from "./locales/es/profile.json";
 
 import frCommon from "./locales/fr/common.json";
 import frAuth from "./locales/fr/auth.json";
+import frEnums from "./locales/fr/enums.json";
 import frCategories from "./locales/fr/categories.json";
 import frAvailability from "./locales/fr/availability.json";
 import frIdentity from "./locales/fr/identity.json";
@@ -35,6 +37,7 @@ import frProfile from "./locales/fr/profile.json";
 
 import ruCommon from "./locales/ru/common.json";
 import ruAuth from "./locales/ru/auth.json";
+import ruEnums from "./locales/ru/enums.json";
 import ruCategories from "./locales/ru/categories.json";
 import ruAvailability from "./locales/ru/availability.json";
 import ruIdentity from "./locales/ru/identity.json";
@@ -50,6 +53,7 @@ import hiProfile from "./locales/hi/profile.json";
 
 import teCommon from "./locales/te/common.json";
 import teAuth from "./locales/te/auth.json";
+import teEnums from "./locales/te/enums.json";
 import teCategories from "./locales/te/categories.json";
 import teAvailability from "./locales/te/availability.json";
 import teIdentity from "./locales/te/identity.json";
@@ -65,6 +69,7 @@ import zhProfile from "./locales/zh/profile.json";
 
 import ptCommon from "./locales/pt/common.json";
 import ptAuth from "./locales/pt/auth.json";
+import ptEnums from "./locales/pt/enums.json";
 import ptCategories from "./locales/pt/categories.json";
 import ptAvailability from "./locales/pt/availability.json";
 import ptIdentity from "./locales/pt/identity.json";
@@ -73,6 +78,7 @@ import ptProfile from "./locales/pt/profile.json";
 import bnCommon from "./locales/bn/common.json";
 import bnAuth from "./locales/bn/auth.json";
 import bnCategories from "./locales/bn/categories.json";
+import bnEnums from "./locales/bn/enums.json";
 import bnAvailability from "./locales/bn/availability.json";
 import bnIdentity from "./locales/bn/identity.json";
 import bnProfile from "./locales/bn/profile.json";
@@ -80,6 +86,7 @@ import bnProfile from "./locales/bn/profile.json";
 import arCommon from "./locales/ar/common.json";
 import arAuth from "./locales/ar/auth.json";
 import arCategories from "./locales/ar/categories.json";
+import arEnums from "./locales/ar/enums.json";
 import arAvailability from "./locales/ar/availability.json";
 import arIdentity from "./locales/ar/identity.json";
 import arProfile from "./locales/ar/profile.json";
@@ -164,6 +171,7 @@ import tlCategories from "./locales/tl/categories.json";
 import urCommon from "./locales/ur/common.json";
 import urAuth from "./locales/ur/auth.json";
 import urCategories from "./locales/ur/categories.json";
+import urEnums from "./locales/ur/enums.json";
 import urAvailability from "./locales/ur/availability.json";
 import urIdentity from "./locales/ur/identity.json";
 import urProfile from "./locales/ur/profile.json";
@@ -181,7 +189,15 @@ i18n
     // Set default namespace to load
     defaultNS: "common",
     // Define all namespaces that will be used
-    ns: ["common", "auth", "categories", "availability", "identity", "profile"],
+    ns: [
+      "common",
+      "auth",
+      "categories",
+      "availability",
+      "identity",
+      "profile",
+      "enums",
+    ],
     resources: {
       en: {
         common: enCommon,
@@ -195,6 +211,7 @@ i18n
       de: {
         common: deCommon,
         auth: deAuth,
+        enums: deEnums,
         categories: deCategories,
         availability: deAvailability,
         identity: deIdentity,
@@ -212,6 +229,7 @@ i18n
       fr: {
         common: frCommon,
         auth: frAuth,
+        enums: frEnums,
         categories: frCategories,
         availability: frAvailability,
         identity: frIdentity,
@@ -220,6 +238,7 @@ i18n
       ru: {
         common: ruCommon,
         auth: ruAuth,
+        enums: ruEnums,
         categories: ruCategories,
         availability: ruAvailability,
         identity: ruIdentity,
@@ -237,6 +256,7 @@ i18n
       te: {
         common: teCommon,
         auth: teAuth,
+        enums: teEnums,
         categories: teCategories,
         availability: teAvailability,
         identity: teIdentity,
@@ -254,6 +274,7 @@ i18n
       pt: {
         common: ptCommon,
         auth: ptAuth,
+        enums: ptEnums,
         categories: ptCategories,
         availability: ptAvailability,
         identity: ptIdentity,
@@ -262,6 +283,7 @@ i18n
       bn: {
         common: bnCommon,
         auth: bnAuth,
+        enums: bnEnums,
         categories: bnCategories,
         availability: bnAvailability,
         identity: bnIdentity,
@@ -270,6 +292,7 @@ i18n
       ar: {
         common: arCommon,
         auth: arAuth,
+        enums: arEnums,
         categories: arCategories,
         availability: arAvailability,
         identity: arIdentity,
@@ -374,6 +397,7 @@ i18n
       ur: {
         common: urCommon,
         auth: urAuth,
+        enums: urEnums,
         categories: urCategories,
         availability: urAvailability,
         identity: urIdentity,

--- a/src/common/i18n/locales/ar/enums.json
+++ b/src/common/i18n/locales/ar/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "تم الإنشاء",
-    "MATCHING VOLUNTEER": "البحث عن متطوع",
+    "MATCHING_VOLUNTEER": "البحث عن متطوع",
     "MANAGED": "تتم الإدارة",
     "RESOLVED": "تم الحل",
     "CANCELLED": "تم الإلغاء",
-    "DELETED": "تم الحذف"
+    "DELETED": "تم الحذف",
+    "RATED_BY_REQUESTER": "تم التقييم من قبل مقدم الطلب",
+    "RATED_BY_VOLUNTEER": "تم التقييم من قبل المتطوع"
   },
   "requestType": {
     "INPERSON": "شخصياً",

--- a/src/common/i18n/locales/bn/enums.json
+++ b/src/common/i18n/locales/bn/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "তৈরি হয়েছে",
-    "MATCHING VOLUNTEER": "স্বেচ্ছাসেবক খোঁজা হচ্ছে",
+    "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক খোঁজা হচ্ছে",
     "MANAGED": "পরিচালিত",
     "RESOLVED": "সমাধান হয়েছে",
     "CANCELLED": "বাতিল করা হয়েছে",
-    "DELETED": "মুছে ফেলা হয়েছে"
+    "DELETED": "মুছে ফেলা হয়েছে",
+    "RATED_BY_REQUESTER": "অনুরোধকারী দ্বারা মূল্যায়িত",
+    "RATED_BY_VOLUNTEER": "স্বেচ্ছাসেবক দ্বারা মূল্যায়িত"
   },
   "requestType": {
     "INPERSON": "সরাসরি",

--- a/src/common/i18n/locales/de/enums.json
+++ b/src/common/i18n/locales/de/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Erstellt",
-    "MATCHING VOLUNTEER": "Freiwilliger wird gesucht",
+    "MATCHING_VOLUNTEER": "Freiwilliger wird gesucht",
     "MANAGED": "Verwaltet",
     "RESOLVED": "Gelöst",
     "CANCELLED": "Abgebrochen",
-    "DELETED": "Gelöscht"
+    "DELETED": "Gelöscht",
+    "RATED_BY_REQUESTER": "Vom Antragsteller bewertet",
+    "RATED_BY_VOLUNTEER": "Vom Freiwilligen bewertet"
   },
   "requestType": {
     "INPERSON": "Persönlich",

--- a/src/common/i18n/locales/en/enums.json
+++ b/src/common/i18n/locales/en/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Created",
-    "MATCHING VOLUNTEER": "Matching Volunteer",
+    "MATCHING_VOLUNTEER": "Matching Volunteer",
     "MANAGED": "Managed",
     "RESOLVED": "Resolved",
     "CANCELLED": "Cancelled",
-    "DELETED": "Deleted"
+    "DELETED": "Deleted",
+    "RATED_BY_REQUESTER": "Rated by Requester",
+    "RATED_BY_VOLUNTEER": "Rated by Volunteer"
   },
   "requestType": {
     "INPERSON": "In Person",

--- a/src/common/i18n/locales/es/enums.json
+++ b/src/common/i18n/locales/es/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Creado",
-    "MATCHING VOLUNTEER": "Buscando voluntario",
+    "MATCHING_VOLUNTEER": "Buscando voluntario",
     "MANAGED": "Gestionado",
     "RESOLVED": "Resuelto",
     "CANCELLED": "Cancelado",
-    "DELETED": "Eliminado"
+    "DELETED": "Eliminado",
+    "RATED_BY_REQUESTER": "Calificado por el solicitante",
+    "RATED_BY_VOLUNTEER": "Calificado por el voluntario"
   },
   "requestType": {
     "INPERSON": "En persona",

--- a/src/common/i18n/locales/fr/enums.json
+++ b/src/common/i18n/locales/fr/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Créé",
-    "MATCHING VOLUNTEER": "Recherche de bénévole",
+    "MATCHING_VOLUNTEER": "Recherche de bénévole",
     "MANAGED": "Géré",
     "RESOLVED": "Résolu",
     "CANCELLED": "Annulé",
-    "DELETED": "Supprimé"
+    "DELETED": "Supprimé",
+    "RATED_BY_REQUESTER": "Évalué par le demandeur",
+    "RATED_BY_VOLUNTEER": "Évalué par le bénévole"
   },
   "requestType": {
     "INPERSON": "En personne",

--- a/src/common/i18n/locales/hi/enums.json
+++ b/src/common/i18n/locales/hi/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "बनाया गया",
-    "MATCHING VOLUNTEER": "स्वयंसेवक खोज रहे हैं",
+    "MATCHING_VOLUNTEER": "स्वयंसेवक खोज रहे हैं",
     "MANAGED": "प्रबंधित",
     "RESOLVED": "हल किया गया",
     "CANCELLED": "रद्द किया गया",
-    "DELETED": "हटाया गया"
+    "DELETED": "हटाया गया",
+    "RATED_BY_REQUESTER": "अनुरोधकर्ता द्वारा रेट किया गया",
+    "RATED_BY_VOLUNTEER": "स्वयंसेवक द्वारा रेट किया गया"
   },
   "requestType": {
     "INPERSON": "व्यक्तिगत रूप से",

--- a/src/common/i18n/locales/pt/enums.json
+++ b/src/common/i18n/locales/pt/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Criado",
-    "MATCHING VOLUNTEER": "Procurando voluntário",
+    "MATCHING_VOLUNTEER": "Procurando voluntário",
     "MANAGED": "Gerenciado",
     "RESOLVED": "Resolvido",
     "CANCELLED": "Cancelado",
-    "DELETED": "Excluído"
+    "DELETED": "Excluído",
+    "RATED_BY_REQUESTER": "Avaliado pelo solicitante",
+    "RATED_BY_VOLUNTEER": "Avaliado pelo voluntário"
   },
   "requestType": {
     "INPERSON": "Presencial",

--- a/src/common/i18n/locales/ru/enums.json
+++ b/src/common/i18n/locales/ru/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "Создано",
-    "MATCHING VOLUNTEER": "Поиск волонтёра",
+    "MATCHING_VOLUNTEER": "Поиск волонтёра",
     "MANAGED": "Управляется",
     "RESOLVED": "Решено",
     "CANCELLED": "Отменено",
-    "DELETED": "Удалено"
+    "DELETED": "Удалено",
+    "RATED_BY_REQUESTER": "Оценено запросившим",
+    "RATED_BY_VOLUNTEER": "Оценено волонтёром"
   },
   "requestType": {
     "INPERSON": "Лично",

--- a/src/common/i18n/locales/te/enums.json
+++ b/src/common/i18n/locales/te/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "సృష్టించబడింది",
-    "MATCHING VOLUNTEER": "స్వచ్ఛంద సేవకుడిని వెతుకుతోంది",
+    "MATCHING_VOLUNTEER": "స్వచ్ఛంద సేవకుడిని వెతుకుతోంది",
     "MANAGED": "నిర్వహించబడింది",
     "RESOLVED": "పరిష్కరించబడింది",
     "CANCELLED": "రద్దు చేయబడింది",
-    "DELETED": "తొలగించబడింది"
+    "DELETED": "తొలగించబడింది",
+    "RATED_BY_REQUESTER": "అభ్యర్థి రేటింగ్ ఇచ్చారు",
+    "RATED_BY_VOLUNTEER": "స్వచ్ఛంద సేవకుడు రేటింగ్ ఇచ్చారు"
   },
   "requestType": {
     "INPERSON": "వ్యక్తిగతంగా",

--- a/src/common/i18n/locales/ur/enums.json
+++ b/src/common/i18n/locales/ur/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "تخلیق کیا گیا",
-    "MATCHING VOLUNTEER": "رضاکار تلاش کر رہے ہیں",
+    "MATCHING_VOLUNTEER": "رضاکار تلاش کر رہے ہیں",
     "MANAGED": "منظم کیا گیا",
     "RESOLVED": "حل کیا گیا",
     "CANCELLED": "منسوخ کیا گیا",
-    "DELETED": "حذف کیا گیا"
+    "DELETED": "حذف کیا گیا",
+    "RATED_BY_REQUESTER": "درخواست گزار نے درجہ بندی کی",
+    "RATED_BY_VOLUNTEER": "رضاکار نے درجہ بندی کی"
   },
   "requestType": {
     "INPERSON": "ذاتی طور پر",

--- a/src/common/i18n/locales/zh/enums.json
+++ b/src/common/i18n/locales/zh/enums.json
@@ -11,11 +11,13 @@
   },
   "requestStatus": {
     "CREATED": "已创建",
-    "MATCHING VOLUNTEER": "匹配志愿者中",
+    "MATCHING_VOLUNTEER": "匹配志愿者中",
     "MANAGED": "已管理",
     "RESOLVED": "已解决",
     "CANCELLED": "已取消",
-    "DELETED": "已删除"
+    "DELETED": "已删除",
+    "RATED_BY_REQUESTER": "由求助者评分",
+    "RATED_BY_VOLUNTEER": "由志愿者评分"
   },
   "requestType": {
     "INPERSON": "亲自",


### PR DESCRIPTION
Added two new fields for requestStatus in the enums API. Also added keys and translations for 10 languages.