### PR TITLE
Fix: restore Organization ID hyperlink in Volunteer Organizations

### DIFF
--- a/src/pages/RequestDetails/VoluntaryOrganizations.jsx
+++ b/src/pages/RequestDetails/VoluntaryOrganizations.jsx
@@ -236,9 +236,9 @@ const VoluntaryOrganizations = () => {
         sortConfig={sortConfig}
         requestSort={requestSort}
         onRowsPerPageChange={onRowsPerPageChange}
-        getLinkPath={(row, header) => {
-          if (header === "id") {
-            return `/organizations/${row.id}`;
+        getLinkPath={(request, header) => {
+          if (String(header).toLowerCase() === "id") {
+            return `/organization/${request.id}`;
           }
           return null;
         }}


### PR DESCRIPTION
Restored Organization ID hyperlink in Volunteer Organizations page.
Only VoluntaryOrganizations.jsx modified as per guidance.
