### PR TITLE
Add Change Volunteer and Delete buttons to Request Details - Details tab

### DIFF
--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -69,6 +69,24 @@ const RequestDescription = ({ requestData, setIsEditing }) => {
             </li>
             <button
               className="bg-blue-500 text-white text-sm px-7 py-2 rounded-lg hover:bg-blue-600 ml-auto"
+              onClick={() => {
+                // TODO: Implement change volunteer functionality
+                console.log("Change Volunteer clicked");
+              }}
+            >
+              {t("Change Volunteer")}
+            </button>
+            <button
+              className="bg-blue-500 text-white text-sm px-7 py-2 rounded-lg hover:bg-blue-600"
+              onClick={() => {
+                // TODO: Implement delete functionality
+                console.log("Delete clicked");
+              }}
+            >
+              {t("Delete")}
+            </button>
+            <button
+              className="bg-blue-500 text-white text-sm px-7 py-2 rounded-lg hover:bg-blue-600"
               onClick={() => setIsEditing(true)}
             >
               {t("EDIT")}


### PR DESCRIPTION
## Summary
Fixes #1138

Added two new buttons to the Details tab of the Request Details page:
- **Change Volunteer** button
- **Delete** button

Both buttons are positioned to the left of the existing **Edit** button and use the same blue styling.

## Changes
- Modified `src/pages/RequestDetails/RequestDescription.jsx`
- Added "Change Volunteer" button with placeholder click handler
- Added "Delete" button with placeholder click handler
- Both buttons styled consistently with the Edit button (blue background, hover effects)
- Buttons positioned in correct order: Change Volunteer → Delete → Edit

## Screenshots
Please see the before/after screenshots for visual comparison.
Before:
<img width="1436" height="255" alt="before" src="https://github.com/user-attachments/assets/fa75b540-6423-4a3a-878a-7b48f82472cc" />
After:
<img width="1318" height="256" alt="after" src="https://github.com/user-attachments/assets/f5c4a86f-6090-4eb1-97d1-3340b1ad4df7" />
