### PR TITLE
Remove hardcoded URLs from requestApi and use .env and endpoints.json

### DIFF
--- a/src/services/endpoints.json
+++ b/src/services/endpoints.json
@@ -1,4 +1,6 @@
 {
+  "GET_ALL_REQUESTS": "v1/request/mockRequests",
+  "ADD_HELP_REQUEST": "v1/request/help-request",
   "GET_MY_REQUESTS": "v1/request/mockRequests",
   "GET_OTHERS_REQUESTS": "v1/request/mockRequests",
   "GET_MANAGED_REQUESTS": "v1/request/mockRequests",

--- a/src/services/requestApi.js
+++ b/src/services/requestApi.js
@@ -1,9 +1,11 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { getToken } from "../services/authService";
+import endpoints from "./endpoints.json";
+
 export const requestApi = createApi({
   reducerPath: "requestApi",
   baseQuery: fetchBaseQuery({
-    baseUrl: "https://a9g3p46u59.execute-api.us-east-1.amazonaws.com/saayam/",
+    baseUrl: import.meta.env.VITE_BASE_API_URL,
 
     prepareHeaders: (headers) => {
       const token = getToken();
@@ -15,12 +17,12 @@ export const requestApi = createApi({
   }),
   endpoints: (builder) => ({
     getAllRequest: builder.query({
-      query: () => "dev/requests/v0.0.1/mockRequests",
+      query: () => endpoints.GET_ALL_REQUESTS,
       providesTags: ["Request"],
     }),
     addRequest: builder.mutation({
       query: (request) => ({
-        url: "dev/requests/v0.0.1/help-request",
+        url: endpoints.ADD_HELP_REQUEST,
         method: "POST",
         body: request,
       }),


### PR DESCRIPTION
- Use import.meta.env.VITE_BASE_API_URL instead of hardcoded baseUrl
- Added GET_ALL_REQUESTS and ADD_HELP_REQUEST to endpoints.json
- Updated getAllRequest and addRequest to use endpoints from endpoints.json
- Follows the same pattern as all other APIs in the webapp