### PR TITLE
Add 'In The News' to About menu in desktop and mobile

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -368,11 +368,11 @@ const Navbar = () => {
                 <MenuItem onClick={(e) => handleLinkClick(e, "/our-mission")}>
                   <CrisisAlertIcon className="mr-2" /> {t("OUR_MISSION")}
                 </MenuItem>
-                {/* <MenuItem
+                <MenuItem
                   onClick={(e) => handleLinkClick(e, "/news-our-stories")}
                 >
                   <ArticleIcon className="mr-2" /> {t("In The News")}
-                </MenuItem> */}
+                </MenuItem>
               </Menu>
             )}
           </div>
@@ -652,11 +652,11 @@ const Navbar = () => {
                 <MenuItem onClick={(e) => handleDrawerClick(e, "/our-mission")}>
                   <CrisisAlertIcon className="mr-2" /> {t("OUR_MISSION")}
                 </MenuItem>
-                {/* <MenuItem
+                <MenuItem
                   onClick={(e) => handleDrawerClick(e, "/news-our-stories")}
                 >
                   <ArticleIcon className="mr-2" /> {t("In the news")}
-                </MenuItem> */}
+                </MenuItem>
               </Menu>
             )}
           </div>


### PR DESCRIPTION
Adds a new “In The News” link under the About menu.

It appears in both desktop and mobile views and uses an i18n key for consistency.  
Tested in responsive mode to ensure it shows correctly in all layouts.
