### PR TITLE
Fix user ID parsing in authActions and update tests

### DIFF
--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -134,9 +134,16 @@ export const checkAuthStatus = () => async (dispatch) => {
     let userDbId = null;
     try {
       const result = await getUserId(email);
-      userDbId = result?.data?.id || null;
-      if (userDbId) {
+      userDbId =
+        result?.data?.user_id || result?.data?.id || result?.id || null;
+      if (userDbId && typeof userDbId === "string") {
         localStorage.setItem("userDbId", userDbId);
+      } else {
+        console.warn(
+          "getUserId returned successfully but no id found in response:",
+          JSON.stringify(result),
+        );
+        userDbId = null;
       }
     } catch (dbError) {
       console.warn(
@@ -155,14 +162,6 @@ export const checkAuthStatus = () => async (dispatch) => {
       groups,
       userDbId,
     };
-    if (user.userId) {
-      dispatch(
-        loginSuccess({
-          user,
-        }),
-      );
-    }
-
     dispatch(
       loginSuccess({
         user,

--- a/src/redux/features/authentication/authActions.test.js
+++ b/src/redux/features/authentication/authActions.test.js
@@ -103,7 +103,19 @@ describe("authActions", () => {
       getMetadata.mockResolvedValue({ body: { key: "value" } });
     });
 
-    it("stores userDbId in localStorage when getUserId returns valid id", async () => {
+    it("stores userDbId in localStorage when getUserId returns user_id", async () => {
+      const { getUserId } = require("../../../services/volunteerServices");
+      getUserId.mockResolvedValue({ data: { user_id: "SID-00-000-002-622" } });
+
+      await checkAuthStatus()(dispatch);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "userDbId",
+        "SID-00-000-002-622",
+      );
+    });
+
+    it("falls back to data.id when data.user_id is not present", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
       getUserId.mockResolvedValue({ data: { id: "SID-00-000-001" } });
 
@@ -117,7 +129,7 @@ describe("authActions", () => {
 
     it("does not store userDbId in localStorage when getUserId returns null", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { id: null } });
+      getUserId.mockResolvedValue({ data: { user_id: null } });
 
       await checkAuthStatus()(dispatch);
 
@@ -147,7 +159,7 @@ describe("authActions", () => {
 
     it("dispatches loginRequest at start", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { id: "SID-00-000-001" } });
+      getUserId.mockResolvedValue({ data: { user_id: "SID-00-000-001" } });
 
       await checkAuthStatus()(dispatch);
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the User ID was null, causing request creation to fail due to a missing requesterId.

The recent migration of `getUserId` from GET to POST changed the API response structure. The frontend was expecting `data.id`, but the new endpoint returns `data.user_id`.

## Changes Made
- Updated 'authActions.js' to correctly parse 'user_id' from the API response.
- Updated 'authActions.test.js' to mock the correct response structure and verify the fix.
- Cleaned up duplicate 'loginSuccess' dispatch calls.
