### PR TITLE
Add 'Become a Volunteer' header to volunteer wizard

### DIFF
--- a/src/pages/Volunteer/PromoteToVolunteer.jsx
+++ b/src/pages/Volunteer/PromoteToVolunteer.jsx
@@ -273,6 +273,9 @@ const PromoteToVolunteer = () => {
       </div>
       {/* FIXED STEPPER WRAPPER */}
       <div className="w-full flex flex-col items-center mt-5 pt-8 px-4">
+        <h1 className="text-3xl font-bold text-center mb-8">
+          {t("BECOME A VOLUNTEER") || "Become a Volunteer"}
+        </h1>
         <Stepper steps={steps} currentStep={currentStep} />
         {/* FIXED CONTENT WRAPPER */}
         <div className="w-full mt-8 px-4">{displayStep(currentStep)}</div>


### PR DESCRIPTION
#1203 
## Summary
Added a clear "Become a Volunteer" header to the volunteer registration wizard to improve user experience and provide context about the process they are completing.

## Changes Made
- Added h1 heading above the stepper component in `PromoteToVolunteer.jsx`
- Implemented internationalization support using translation key `BECOME_A_VOLUNTEER`
- Styled header with centered alignment and proper spacing (text-3xl, font-bold, mb-8)

## Visual Impact
The header appears prominently at the top of the volunteer wizard, giving users immediate context that they are in the volunteer registration process.

## Testing
- [x] Tested locally with `npm run dev`
- [x] Verified header displays correctly above stepper
- [x] Confirmed no impact on existing functionality

## Screenshots

<img width="1432" height="772" alt="Screenshot 2026-02-15 at 10 53 10 PM" src="https://github.com/user-attachments/assets/c6f87198-057a-4a7d-9bfb-0d71747e5840" />