### PR TITLE
Fix: Profile-Personal Information page Save is not working when user enters Street Address 2 value #1245

### DIFF
--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -463,15 +463,25 @@ function PersonalInformation({ setHasUnsavedChanges }) {
             {t("ADDRESS", { optional: " 2" })}
           </label>
           {isEditing ? (
-            <input
-              type="text"
-              name="streetAddress2"
-              value={personalInfo.streetAddress2}
-              onChange={(e) =>
-                handleInputChange("streetAddress2", e.target.value)
-              }
-              className="appearance-none block w-full bg-white-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
-            />
+            <>
+              <input
+                type="text"
+                name="streetAddress2"
+                value={personalInfo.streetAddress2}
+                onChange={(e) =>
+                  handleInputChange("streetAddress2", e.target.value)
+                }
+                //className="appearance-none block w-full bg-white-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                className={`appearance-none block w-full bg-white-200 text-gray-700 border ${
+                  errors.streetAddress2 ? "border-red-500" : "border-gray-200"
+                } rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500`}
+              />
+              {errors.streetAddress2 && (
+                <p className="text-red-500 text-xs italic">
+                  {errors.streetAddress2}
+                </p>
+              )}
+            </>
           ) : (
             <p className="text-lg text-gray-900">
               {personalInfo.streetAddress2 || ""}


### PR DESCRIPTION
This PR fixes the missing validation error display for the Street Address 2 field in Profile → Personal Information.

**Issue:**
The form was preventing save when Street Address 2 contained 4 or fewer characters.
However, no validation error message was shown to the user.

**Fix Implemented:**
Ensured that when the input length is 4 characters or fewer, the validation error message is properly displayed.

Form behavior remains the same which prevents saving for ≤ 4 characters (allows empty field).
Users now receive clear visual feedback explaining why the form cannot be saved.

<img width="840" height="610" alt="image" src="https://github.com/user-attachments/assets/64ac7e32-75e7-4fe8-b89d-1e37dd8c6539" />
<img width="840" height="610" alt="image" src="https://github.com/user-attachments/assets/e9ead721-eef7-4024-93e1-d8786ee23ce0" />
