### PR TITLE
fix: datetime issue in Request Details tab

### DIFF
--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -13,7 +13,7 @@ const RequestDescription = ({ requestData, setIsEditing }) => {
   const { t } = useTranslation();
   const token = useSelector((state) => state.auth.idToken);
 
-  const cDate = new Date(requestData.creationDate + "T00:00:00");
+  const cDate = new Date(requestData.creationDate);
   const formattedDate = cDate.toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",


### PR DESCRIPTION
Fixed Invalid Date in Details tab (#1224)

The creationDate field from the API is a full datetime string (e.g., "2024-12-05T23:45:00Z"). And the file was appending "T00:00:00" to it, producing an invalid date string and causing the Details tab to display "Invalid Date".

Fix: Removed the + "T00:00:00" as "new Date(creationDate) "handles datetime strings automatically.