### PR TITLE
Redesign MetricsTicker as compact single-line strip

### DIFF
--- a/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
+++ b/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
@@ -26,240 +26,137 @@ exports[`LandingPage renders correctly 1`] = `
             </h1>
           </div>
           <div
-            class="w-full my-6 md:my-8 shadow-xl"
-            style="background-color: rgb(59, 130, 246);"
+            class="w-full bg-gray-50 border-y border-gray-200 shadow-sm"
           >
             <div
-              class="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40"
-            />
-            <div
-              class="flex flex-col sm:flex-row w-full divide-y sm:divide-y-0 divide-white/20"
+              class="overflow-x-auto"
             >
               <div
-                class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-                style="border-right: 1px solid rgba(255,255,255,0.25);"
+                class="flex items-center gap-0 px-4 py-2.5 min-w-max mx-auto justify-center"
               >
-                <p
-                  class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-                >
-                  Total Requests
-                </p>
-                <div
-                  class="flex items-center gap-2 mb-3"
+                <span
+                  class="flex items-center"
                 >
                   <span
-                    style="color: rgb(74, 144, 226);"
+                    class="inline-flex items-baseline gap-1 whitespace-nowrap"
                   >
-                    <svg
-                      class="w-6 h-6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
+                    <span
+                      class="text-gray-500 text-sm font-medium"
                     >
-                      <path
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
-                  >
-                    0
-                  </span>
-                </div>
-                <div
-                  class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                  style="background-color: rgb(74, 144, 226);"
-                />
-                <div
-                  class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                  style="background-color: rgb(74, 144, 226);"
-                />
-              </div>
-              <div
-                class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-[#16a34a]"
-                style="border-right: 1px solid rgba(255,255,255,0.25);"
-              >
-                <p
-                  class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-                >
-                  Requests Resolved
-                </p>
-                <div
-                  class="flex items-center gap-2 mb-3"
-                >
-                  <span
-                    style="color: rgb(255, 255, 255);"
-                  >
-                    <svg
-                      class="w-6 h-6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
+                      Total Requests
+                      :
+                    </span>
+                    <span
+                      class="text-sm font-bold tabular-nums"
+                      style="color: rgb(30, 64, 175);"
                     >
-                      <path
-                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
+                      0
+                    </span>
                   </span>
                   <span
-                    class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                    class="mx-3 text-gray-300 select-none font-light"
                   >
-                    0
+                    |
                   </span>
-                </div>
-                <div
-                  class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                  style="background-color: rgb(34, 197, 94);"
-                />
-                <div
-                  class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                  style="background-color: rgb(34, 197, 94);"
-                />
-              </div>
-              <div
-                class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-                style="border-right: 1px solid rgba(255,255,255,0.25);"
-              >
-                <p
-                  class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-                >
-                  Avg Resolution Time
-                </p>
-                <div
-                  class="flex items-center gap-2 mb-3"
+                </span>
+                <span
+                  class="flex items-center"
                 >
                   <span
-                    style="color: rgb(56, 189, 248);"
+                    class="inline-flex items-baseline gap-1 whitespace-nowrap"
                   >
-                    <svg
-                      class="w-6 h-6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
+                    <span
+                      class="text-gray-500 text-sm font-medium"
                     >
-                      <path
-                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
-                  >
-                    0
-                     hrs
-                  </span>
-                </div>
-                <div
-                  class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                  style="background-color: rgb(56, 189, 248);"
-                />
-                <div
-                  class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                  style="background-color: rgb(56, 189, 248);"
-                />
-              </div>
-              <div
-                class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-                style="border-right: 1px solid rgba(255,255,255,0.25);"
-              >
-                <p
-                  class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-                >
-                  Total Volunteers
-                </p>
-                <div
-                  class="flex items-center gap-2 mb-3"
-                >
-                  <span
-                    style="color: rgb(129, 140, 248);"
-                  >
-                    <svg
-                      class="w-6 h-6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
+                      Requests Resolved
+                      :
+                    </span>
+                    <span
+                      class="text-sm font-bold tabular-nums"
+                      style="color: rgb(22, 101, 52);"
                     >
-                      <path
-                        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
+                      0
+                    </span>
                   </span>
                   <span
-                    class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                    class="mx-3 text-gray-300 select-none font-light"
                   >
-                    0
+                    |
                   </span>
-                </div>
-                <div
-                  class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                  style="background-color: rgb(129, 140, 248);"
-                />
-                <div
-                  class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                  style="background-color: rgb(129, 140, 248);"
-                />
-              </div>
-              <div
-                class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-                style="border-right: 1px solid rgba(255,255,255,0.25);"
-              >
-                <p
-                  class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-                >
-                  Total Beneficiaries
-                </p>
-                <div
-                  class="flex items-center gap-2 mb-3"
+                </span>
+                <span
+                  class="flex items-center"
                 >
                   <span
-                    style="color: rgb(245, 158, 11);"
+                    class="inline-flex items-baseline gap-1 whitespace-nowrap"
                   >
-                    <svg
-                      class="w-6 h-6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
+                    <span
+                      class="text-gray-500 text-sm font-medium"
                     >
-                      <path
-                        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
+                      Avg Resolution Time
+                      :
+                    </span>
+                    <span
+                      class="text-sm font-bold tabular-nums"
+                      style="color: rgb(146, 64, 14);"
+                    >
+                      0
+                       hrs
+                    </span>
                   </span>
                   <span
-                    class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                    class="mx-3 text-gray-300 select-none font-light"
                   >
-                    0
+                    |
                   </span>
-                </div>
-                <div
-                  class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                  style="background-color: rgb(245, 158, 11);"
-                />
-                <div
-                  class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                  style="background-color: rgb(245, 158, 11);"
-                />
+                </span>
+                <span
+                  class="flex items-center"
+                >
+                  <span
+                    class="inline-flex items-baseline gap-1 whitespace-nowrap"
+                  >
+                    <span
+                      class="text-gray-500 text-sm font-medium"
+                    >
+                      Total Volunteers
+                      :
+                    </span>
+                    <span
+                      class="text-sm font-bold tabular-nums"
+                      style="color: rgb(91, 33, 182);"
+                    >
+                      0
+                    </span>
+                  </span>
+                  <span
+                    class="mx-3 text-gray-300 select-none font-light"
+                  >
+                    |
+                  </span>
+                </span>
+                <span
+                  class="flex items-center"
+                >
+                  <span
+                    class="inline-flex items-baseline gap-1 whitespace-nowrap"
+                  >
+                    <span
+                      class="text-gray-500 text-sm font-medium"
+                    >
+                      Total Beneficiaries
+                      :
+                    </span>
+                    <span
+                      class="text-sm font-bold tabular-nums"
+                      style="color: rgb(154, 52, 18);"
+                    >
+                      0
+                    </span>
+                  </span>
+                </span>
               </div>
             </div>
-            <div
-              class="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40"
-            />
           </div>
         </div>
         <div
@@ -581,240 +478,137 @@ exports[`LandingPage renders correctly 1`] = `
           </h1>
         </div>
         <div
-          class="w-full my-6 md:my-8 shadow-xl"
-          style="background-color: rgb(59, 130, 246);"
+          class="w-full bg-gray-50 border-y border-gray-200 shadow-sm"
         >
           <div
-            class="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40"
-          />
-          <div
-            class="flex flex-col sm:flex-row w-full divide-y sm:divide-y-0 divide-white/20"
+            class="overflow-x-auto"
           >
             <div
-              class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-              style="border-right: 1px solid rgba(255,255,255,0.25);"
+              class="flex items-center gap-0 px-4 py-2.5 min-w-max mx-auto justify-center"
             >
-              <p
-                class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-              >
-                Total Requests
-              </p>
-              <div
-                class="flex items-center gap-2 mb-3"
+              <span
+                class="flex items-center"
               >
                 <span
-                  style="color: rgb(74, 144, 226);"
+                  class="inline-flex items-baseline gap-1 whitespace-nowrap"
                 >
-                  <svg
-                    class="w-6 h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    viewBox="0 0 24 24"
+                  <span
+                    class="text-gray-500 text-sm font-medium"
                   >
-                    <path
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
-                >
-                  0
-                </span>
-              </div>
-              <div
-                class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                style="background-color: rgb(74, 144, 226);"
-              />
-              <div
-                class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                style="background-color: rgb(74, 144, 226);"
-              />
-            </div>
-            <div
-              class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-[#16a34a]"
-              style="border-right: 1px solid rgba(255,255,255,0.25);"
-            >
-              <p
-                class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-              >
-                Requests Resolved
-              </p>
-              <div
-                class="flex items-center gap-2 mb-3"
-              >
-                <span
-                  style="color: rgb(255, 255, 255);"
-                >
-                  <svg
-                    class="w-6 h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    viewBox="0 0 24 24"
+                    Total Requests
+                    :
+                  </span>
+                  <span
+                    class="text-sm font-bold tabular-nums"
+                    style="color: rgb(30, 64, 175);"
                   >
-                    <path
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                    0
+                  </span>
                 </span>
                 <span
-                  class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                  class="mx-3 text-gray-300 select-none font-light"
                 >
-                  0
+                  |
                 </span>
-              </div>
-              <div
-                class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                style="background-color: rgb(34, 197, 94);"
-              />
-              <div
-                class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                style="background-color: rgb(34, 197, 94);"
-              />
-            </div>
-            <div
-              class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-              style="border-right: 1px solid rgba(255,255,255,0.25);"
-            >
-              <p
-                class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-              >
-                Avg Resolution Time
-              </p>
-              <div
-                class="flex items-center gap-2 mb-3"
+              </span>
+              <span
+                class="flex items-center"
               >
                 <span
-                  style="color: rgb(56, 189, 248);"
+                  class="inline-flex items-baseline gap-1 whitespace-nowrap"
                 >
-                  <svg
-                    class="w-6 h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    viewBox="0 0 24 24"
+                  <span
+                    class="text-gray-500 text-sm font-medium"
                   >
-                    <path
-                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
-                >
-                  0
-                   hrs
-                </span>
-              </div>
-              <div
-                class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                style="background-color: rgb(56, 189, 248);"
-              />
-              <div
-                class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                style="background-color: rgb(56, 189, 248);"
-              />
-            </div>
-            <div
-              class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-              style="border-right: 1px solid rgba(255,255,255,0.25);"
-            >
-              <p
-                class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-              >
-                Total Volunteers
-              </p>
-              <div
-                class="flex items-center gap-2 mb-3"
-              >
-                <span
-                  style="color: rgb(129, 140, 248);"
-                >
-                  <svg
-                    class="w-6 h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    viewBox="0 0 24 24"
+                    Requests Resolved
+                    :
+                  </span>
+                  <span
+                    class="text-sm font-bold tabular-nums"
+                    style="color: rgb(22, 101, 52);"
                   >
-                    <path
-                      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                    0
+                  </span>
                 </span>
                 <span
-                  class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                  class="mx-3 text-gray-300 select-none font-light"
                 >
-                  0
+                  |
                 </span>
-              </div>
-              <div
-                class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                style="background-color: rgb(129, 140, 248);"
-              />
-              <div
-                class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                style="background-color: rgb(129, 140, 248);"
-              />
-            </div>
-            <div
-              class="relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 bg-transparent hover:bg-white/10"
-              style="border-right: 1px solid rgba(255,255,255,0.25);"
-            >
-              <p
-                class="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3"
-              >
-                Total Beneficiaries
-              </p>
-              <div
-                class="flex items-center gap-2 mb-3"
+              </span>
+              <span
+                class="flex items-center"
               >
                 <span
-                  style="color: rgb(245, 158, 11);"
+                  class="inline-flex items-baseline gap-1 whitespace-nowrap"
                 >
-                  <svg
-                    class="w-6 h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    viewBox="0 0 24 24"
+                  <span
+                    class="text-gray-500 text-sm font-medium"
                   >
-                    <path
-                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                    Avg Resolution Time
+                    :
+                  </span>
+                  <span
+                    class="text-sm font-bold tabular-nums"
+                    style="color: rgb(146, 64, 14);"
+                  >
+                    0
+                     hrs
+                  </span>
                 </span>
                 <span
-                  class="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums"
+                  class="mx-3 text-gray-300 select-none font-light"
                 >
-                  0
+                  |
                 </span>
-              </div>
-              <div
-                class="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-                style="background-color: rgb(245, 158, 11);"
-              />
-              <div
-                class="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-                style="background-color: rgb(245, 158, 11);"
-              />
+              </span>
+              <span
+                class="flex items-center"
+              >
+                <span
+                  class="inline-flex items-baseline gap-1 whitespace-nowrap"
+                >
+                  <span
+                    class="text-gray-500 text-sm font-medium"
+                  >
+                    Total Volunteers
+                    :
+                  </span>
+                  <span
+                    class="text-sm font-bold tabular-nums"
+                    style="color: rgb(91, 33, 182);"
+                  >
+                    0
+                  </span>
+                </span>
+                <span
+                  class="mx-3 text-gray-300 select-none font-light"
+                >
+                  |
+                </span>
+              </span>
+              <span
+                class="flex items-center"
+              >
+                <span
+                  class="inline-flex items-baseline gap-1 whitespace-nowrap"
+                >
+                  <span
+                    class="text-gray-500 text-sm font-medium"
+                  >
+                    Total Beneficiaries
+                    :
+                  </span>
+                  <span
+                    class="text-sm font-bold tabular-nums"
+                    style="color: rgb(154, 52, 18);"
+                  >
+                    0
+                  </span>
+                </span>
+              </span>
             </div>
           </div>
-          <div
-            class="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40"
-          />
         </div>
       </div>
       <div

--- a/src/pages/LandingPage/components/MetricsTicker.jsx
+++ b/src/pages/LandingPage/components/MetricsTicker.jsx
@@ -2,121 +2,41 @@ import { useState, useEffect, useRef } from "react";
 
 const METRICS_S3_URL = import.meta.env.VITE_METRICS_S3_URL || "";
 
+// A11Y-compliant colors on #f8fafc background (all >= 4.5:1 contrast ratio)
 const METRIC_CONFIGS = [
   {
     key: "totalRequests",
     label: "Total Requests",
     suffix: "",
-    accentColor: "#4a90e2",
-    icon: (
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.8}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-        />
-      </svg>
-    ),
-    highlight: false,
-  },
+    color: "#1e40af",
+  }, // blue-800   ~7.2:1
   {
     key: "requestsResolved",
     label: "Requests Resolved",
     suffix: "",
-    accentColor: "#22c55e",
-    icon: (
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.8}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-    ),
-    highlight: true,
-  },
+    color: "#166534",
+  }, // green-800  ~8.1:1
   {
     key: "avgResolutionHours",
     label: "Avg Resolution Time",
     suffix: " hrs",
-    accentColor: "#38bdf8",
-    icon: (
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.8}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-    ),
-    highlight: false,
-  },
+    color: "#92400e",
+  }, // amber-800 ~5.1:1
   {
     key: "totalVolunteers",
     label: "Total Volunteers",
     suffix: "",
-    accentColor: "#818cf8",
-    icon: (
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.8}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-        />
-      </svg>
-    ),
-    highlight: false,
-  },
+    color: "#5b21b6",
+  }, // violet-800 ~8.2:1
   {
     key: "totalBeneficiaries",
     label: "Total Beneficiaries",
     suffix: "",
-    accentColor: "#f59e0b",
-    icon: (
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.8}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-        />
-      </svg>
-    ),
-    highlight: false,
-  },
+    color: "#9a3412",
+  }, // orange-800 ~6.0:1
 ];
 
-// Animate a number from 0 to target over ~1.5s
-function useCountUp(target, duration = 1500) {
+function useCountUp(target, duration = 1200) {
   const [value, setValue] = useState(0);
   const rafRef = useRef(null);
 
@@ -129,12 +49,9 @@ function useCountUp(target, duration = 1500) {
     const animate = (now) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
-      // Ease-out cubic
       const eased = 1 - Math.pow(1 - progress, 3);
       setValue(Math.round(eased * target));
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(animate);
-      }
+      if (progress < 1) rafRef.current = requestAnimationFrame(animate);
     };
     rafRef.current = requestAnimationFrame(animate);
     return () => {
@@ -145,51 +62,25 @@ function useCountUp(target, duration = 1500) {
   return value;
 }
 
-function MetricCard({ config, rawValue }) {
+function MetricItem({ config, rawValue }) {
   const animated = useCountUp(rawValue);
   const isFloat =
-    !Number.isInteger(rawValue) && config.key === "avgResolutionHours";
+    config.key === "avgResolutionHours" && !Number.isInteger(rawValue);
   const displayValue = isFloat
     ? rawValue.toFixed(1)
     : animated.toLocaleString();
 
   return (
-    <div
-      className={`relative flex flex-col items-center justify-between py-5 px-4 flex-1 min-w-0 transition-all duration-300 ${
-        config.highlight ? "bg-[#16a34a]" : "bg-transparent hover:bg-white/10"
-      }`}
-      style={{
-        borderRight: "1px solid rgba(255,255,255,0.25)",
-      }}
-    >
-      {/* Label */}
-      <p className="text-xs md:text-sm font-semibold text-white/80 tracking-wide uppercase text-center mb-3">
-        {config.label}
-      </p>
-
-      {/* Icon + Number row */}
-      <div className="flex items-center gap-2 mb-3">
-        <span style={{ color: config.highlight ? "#fff" : config.accentColor }}>
-          {config.icon}
-        </span>
-        <span className="text-2xl md:text-4xl font-bold text-white leading-none tabular-nums">
-          {displayValue}
-          {config.suffix}
-        </span>
-      </div>
-
-      {/* Bottom accent bar */}
-      <div
-        className="absolute bottom-0 left-1/2 -translate-x-1/2 w-8 h-1 rounded-full"
-        style={{ backgroundColor: config.accentColor }}
-      />
-
-      {/* Bottom accent dot */}
-      <div
-        className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-[#3b82f6]"
-        style={{ backgroundColor: config.accentColor }}
-      />
-    </div>
+    <span className="inline-flex items-baseline gap-1 whitespace-nowrap">
+      <span className="text-gray-500 text-sm font-medium">{config.label}:</span>
+      <span
+        className="text-sm font-bold tabular-nums"
+        style={{ color: config.color }}
+      >
+        {displayValue}
+        {config.suffix}
+      </span>
+    </span>
   );
 }
 
@@ -206,38 +97,29 @@ const MetricsTicker = () => {
     if (!METRICS_S3_URL) return;
     fetch(METRICS_S3_URL)
       .then((res) => {
-        if (!res.ok) throw new Error("Failed to fetch metrics");
+        if (!res.ok) throw new Error();
         return res.json();
       })
-      .then((data) => {
-        setMetrics((prev) => ({ ...prev, ...data }));
-      })
-      .catch(() => {
-        // Silently fall back to zeros
-      });
+      .then((data) => setMetrics((prev) => ({ ...prev, ...data })))
+      .catch(() => {});
   }, []);
 
   return (
-    <div
-      className="w-full my-6 md:my-8 shadow-xl"
-      style={{ backgroundColor: "#3b82f6" }}
-    >
-      {/* Thin top accent line */}
-      <div className="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40" />
-
-      {/* Metrics row */}
-      <div className="flex flex-col sm:flex-row w-full divide-y sm:divide-y-0 divide-white/20">
-        {METRIC_CONFIGS.map((config) => (
-          <MetricCard
-            key={config.key}
-            config={config}
-            rawValue={metrics[config.key]}
-          />
-        ))}
+    <div className="w-full bg-gray-50 border-y border-gray-200 shadow-sm">
+      <div className="overflow-x-auto">
+        <div className="flex items-center gap-0 px-4 py-2.5 min-w-max mx-auto justify-center">
+          {METRIC_CONFIGS.map((config, index) => (
+            <span key={config.key} className="flex items-center">
+              <MetricItem config={config} rawValue={metrics[config.key]} />
+              {index < METRIC_CONFIGS.length - 1 && (
+                <span className="mx-3 text-gray-300 select-none font-light">
+                  |
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
       </div>
-
-      {/* Thin bottom accent line */}
-      <div className="h-0.5 w-full bg-gradient-to-r from-white/40 via-white/70 to-white/40" />
     </div>
   );
 };


### PR DESCRIPTION
- Replace tall card layout with a thin horizontal bar (~40px)
- Inline format: "Label: Value | Label: Value | ..."
- Horizontal scroll on mobile instead of stacking vertically
- A11Y-compliant colors per metric (all >= 4.5:1 contrast ratio)