### PR TITLE
Revert workflow test

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -6,11 +6,7 @@ name: CI/CD - Netlify production build
 on:
   # Triggers the workflow on push or pull request events
   push:
-    branches:
-      ["dev", "dev-netlify-github-build", "test", "netlify-deploy-test-1"]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    branches: ["test", "netlify-deploy-test-1"]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -33,7 +29,7 @@ jobs:
 
       - name: Inject env variable
         run: |
-          echo "VITE_BASE_API_URL=${{ secrets.VITE_BASE_API_URL || secrets.NEW_VITE_API_BASE_URL }}" > .env.production
+          echo "VITE_BASE_API_URL=${{ secrets.NEW_VITE_API_BASE_URL }}" > .env.production
 
       - name: Install dependencies
         run: npm ci
@@ -63,4 +59,4 @@ jobs:
           zip -r ../build.zip .
 
       - name: Deploy to netlify
-        run: curl -X POST -H "Content-Type:application/zip" -H "Authorization:Bearer ${{ secrets.NETLIFY_ACCESS_TOKEN }}" --data-binary "@build.zip" https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_DEV_SITE_ID }}/deploys
+        run: curl -X POST -H "Content-Type:application/zip" -H "Authorization:Bearer ${{ secrets.NETLIFY_ACCESS_TOKEN }}" --data-binary "@build.zip" https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_SITE_ID }}/deploys


### PR DESCRIPTION
I accidentally modified `.github/workflows/netlify-deploy.yml` while resolving merge conflicts in the Availability step PR.  
This change bumped the branches and env variable logic, which is only supposed to be managed by the test branch.  

This PR restores the original workflow from `test` so deployments aren’t affected.