### PR TITLE
fix-Sub-sub category level fields

### DIFF
--- a/src/pages/HelpRequest/Categories/DynamicAdditionalFields.jsx
+++ b/src/pages/HelpRequest/Categories/DynamicAdditionalFields.jsx
@@ -32,7 +32,15 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
       if (!raw) return [];
       const allMetadata = JSON.parse(raw);
       if (!Array.isArray(allMetadata)) return [];
-      const entry = allMetadata.find((m) => m.catId === catId);
+
+      // Try exact match first
+      let entry = allMetadata.find((m) => m.catId === catId);
+
+      if (!entry && catId.includes(".")) {
+        const parentCatId = catId.substring(0, catId.lastIndexOf("."));
+        entry = allMetadata.find((m) => m.catId === parentCatId);
+      }
+
       if (!entry || !Array.isArray(entry.fields)) return [];
       // Only show active fields
       return entry.fields.filter((f) => f.status === "active");

--- a/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
+++ b/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
@@ -666,6 +666,18 @@ describe("DynamicAdditionalFields", () => {
     expect(screen.getByTestId("radio-1.1.A.2")).toBeChecked();
   });
 
+  // ── Sub-sub-category fallback ────────────────────────────────────────
+
+  it("falls back to parent catId when sub-sub-category has no metadata", () => {
+    const onChange = jest.fn();
+    // catId "1.1.1" doesn't exist in metadata, but "1.1" does
+    render(<DynamicAdditionalFields catId="1.1.1" onChange={onChange} />);
+    // Should display the parent "1.1" fields
+    expect(screen.getByText("Preferred Meal Type")).toBeInTheDocument();
+    expect(screen.getByText("Dietary Restrictions")).toBeInTheDocument();
+    expect(screen.getByText("Household Size")).toBeInTheDocument();
+  });
+
   // ── Wrapper ─────────────────────────────────────────────────────────
 
   it("renders the wrapper container with correct test id", () => {


### PR DESCRIPTION
FIX: fallback to parent catId for sub-sub-category metadata