### PR TITLE
Fix: prevent vertical ad panels from creating unnecessary spacing on …

### DIFF
--- a/src/Layout/Layout.jsx
+++ b/src/Layout/Layout.jsx
@@ -14,7 +14,7 @@ const Layout = () => {
   const showAds = matches.some((match) => match?.handle?.leaveAdSpace);
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col min-h-screen">
       <NotificationProvider>
         {/* Navigation Guard to check for unsaved changes */}
 
@@ -26,9 +26,9 @@ const Layout = () => {
         </header>
 
         {/* main content */}
-        <div className="flex flex-1">
+        <div className="flex flex-1 items-start">
           {showAds && (
-            <aside className="left-ads-panel flex-1 ">
+            <aside className="left-ads-panel flex-none ">
               <LeftAds />
             </aside>
           )}
@@ -39,7 +39,7 @@ const Layout = () => {
             </Suspense>
           </main>
           {showAds && (
-            <aside className="right-ads-panel flex-1 ">
+            <aside className="right-ads-panel flex-none ">
               <RightAds />
             </aside>
           )}


### PR DESCRIPTION
On short pages like Login, Signup, and Forgot Password, the vertical ad panels on the left and right create extra blank space above the main content. This sometimes also causes unnecessary scrollbars.

This happens because:

The layout container uses h-screen, forcing the page to fill the viewport height.

The ad <aside> elements use flex-1, which stretches them vertically even if the page content is small.