### PR TITLE
Unnecessary space between Nav bar and Log In section in Login Page

### DIFF
--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -82,8 +82,8 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="flex items-center h-full justify-center">
-      <div className="px-4 py-4 flex flex-col relative w-1/2">
+    <div className="flex items-center justify-center min-h-[calc(100vh-113px)] bg-white">
+      <div className="px-4 py-4 flex flex-col relative w-full max-w-md">
         <h1 className="my-4 text-3xl font-bold text-center">
           {t("common:LOGIN")}
         </h1>


### PR DESCRIPTION
Removed unnecessary amount of space between the Nav Bar and the Log In Section of the login page 

<img width="973" height="756" alt="Screenshot 2026-03-09 at 4 30 56 PM" src="https://github.com/user-attachments/assets/ef1f7b46-04f0-4f39-bdee-46a40bbf7519" />

<img width="1068" height="697" alt="Screenshot 2026-03-09 at 4 31 06 PM" src="https://github.com/user-attachments/assets/31f77dc2-e413-477b-9caf-fb3fc2c07f5c" />
