### PR TITLE
fix(Dashboard): request ID as first column and translate category val…

### DIFF
--- a/src/common/components/DataTable/Table.jsx
+++ b/src/common/components/DataTable/Table.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import { useTranslation } from "react-i18next";
 import Pagination from "../Pagination/Pagination";
 
 const Table = ({
@@ -17,6 +18,8 @@ const Table = ({
   getLinkPath,
   getLinkState = undefined,
 }) => {
+  const { t, i18n } = useTranslation(["common", "categories"]);
+
   const paginatedRequests = useMemo(() => {
     return rows.slice(
       (currentPage - 1) * itemsPerPage,
@@ -66,8 +69,36 @@ const Table = ({
   const dataKeyMap = { requestId: "id", beneficiaryId: "userId" };
   const resolveKey = (header) => dataKeyMap[header] || header;
 
+  const headerLabelMap = {
+    status: t("STATUS"),
+    subject: t("SUBJECT"),
+    type: t("TYPE"),
+    category: t("REQUEST_CATEGORY"),
+    priority: t("PRIORITY"),
+  };
+
+  const getCategoryLabel = (code) => {
+    if (!code) return code;
+    const bundle =
+      i18n.getResourceBundle(i18n.language, "categories") ||
+      i18n.getResourceBundle("en", "categories");
+    if (!bundle?.REQUEST_CATEGORIES) return code;
+    const search = (obj, target) => {
+      for (const key in obj) {
+        if (key === target && obj[key].LABEL) return obj[key].LABEL;
+        if (obj[key].SUBCATEGORIES) {
+          const found = search(obj[key].SUBCATEGORIES, target);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+    return search(bundle.REQUEST_CATEGORIES, code) || code;
+  };
+
   const getCellValue = (row, header) => {
     if (header === "requestId") return row[resolveKey(header)];
+    if (header === "category") return getCategoryLabel(row[header]);
     return formatDateTime(row[header], header);
   };
 
@@ -92,11 +123,12 @@ const Table = ({
                     type="button"
                     onClick={() => requestSort(resolveKey(key))}
                   >
-                    {key.charAt(0).toUpperCase() +
-                      key
-                        .slice(1)
-                        .replace(/([A-Z])/g, " $1")
-                        .trim()}
+                    {headerLabelMap[key] ||
+                      key.charAt(0).toUpperCase() +
+                        key
+                          .slice(1)
+                          .replace(/([A-Z])/g, " $1")
+                          .trim()}
                     {getSortIndicator(resolveKey(key))}
                   </button>
                 </th>

--- a/src/common/components/DataTable/table.test.js
+++ b/src/common/components/DataTable/table.test.js
@@ -1,7 +1,64 @@
-import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
 import Table from "./Table";
 
 jest.mock("../Pagination/Pagination");
+
+const mockCategoriesBundle = {
+  REQUEST_CATEGORIES: {
+    FOOD_AND_ESSENTIALS: {
+      LABEL: "Food & Essentials",
+      SUBCATEGORIES: {
+        FOOD_ASSISTANCE: { LABEL: "Food Assistance" },
+        GROCERY_SHOPPING_AND_DELIVERY: {
+          LABEL: "Grocery Shopping & Delivery",
+        },
+      },
+    },
+    GENERAL_CATEGORY: {
+      LABEL: "General",
+      SUBCATEGORIES: {
+        BUY_THINGS: { LABEL: "Buy Household Items" },
+      },
+    },
+  },
+};
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: {
+      language: "en",
+      getResourceBundle: (lang, ns) => {
+        if (ns === "categories") return mockCategoriesBundle;
+        return null;
+      },
+    },
+  }),
+}));
+
+const defaultProps = {
+  headers: ["requestId", "status", "subject", "type", "category", "priority"],
+  rows: [
+    {
+      id: "REQ-001",
+      status: "CREATED",
+      subject: "Test subject",
+      type: "IN_PERSON",
+      category: "FOOD_ASSISTANCE",
+      priority: "HIGH",
+    },
+  ],
+  currentPage: 1,
+  setCurrentPage: jest.fn(),
+  totalPages: 1,
+  totalRows: 1,
+  itemsPerPage: 5,
+  sortConfig: { key: "status", direction: "ascending" },
+  requestSort: jest.fn(),
+  onRowsPerPageChange: jest.fn(),
+  getLinkPath: jest.fn(() => null),
+};
 
 describe("Table", () => {
   const mockHeaders = ["id", "name"];
@@ -32,5 +89,59 @@ describe("Table", () => {
       />,
     );
     expect(tree).toMatchSnapshot();
+  });
+
+  describe("header translation", () => {
+    it("uses translated labels for mapped headers", () => {
+      render(<Table {...defaultProps} />);
+
+      expect(screen.getByText(/^STATUS/)).toBeInTheDocument();
+      expect(screen.getByText(/^SUBJECT/)).toBeInTheDocument();
+      expect(screen.getByText(/^TYPE/)).toBeInTheDocument();
+      expect(screen.getByText(/^REQUEST_CATEGORY/)).toBeInTheDocument();
+      expect(screen.getByText(/^PRIORITY/)).toBeInTheDocument();
+    });
+
+    it("falls back to camelCase transform for unmapped headers", () => {
+      render(<Table {...defaultProps} headers={["requestId", "calamity"]} />);
+
+      expect(screen.getByText("Calamity")).toBeInTheDocument();
+    });
+  });
+
+  describe("category cell translation", () => {
+    it("translates a subcategory code to its readable label", () => {
+      render(<Table {...defaultProps} />);
+
+      expect(screen.getByText("Food Assistance")).toBeInTheDocument();
+    });
+
+    it("translates a nested subcategory code", () => {
+      const props = {
+        ...defaultProps,
+        rows: [{ ...defaultProps.rows[0], category: "BUY_THINGS" }],
+      };
+      render(<Table {...props} />);
+
+      expect(screen.getByText("Buy Household Items")).toBeInTheDocument();
+    });
+
+    it("falls back to raw code when category is not found in bundle", () => {
+      const props = {
+        ...defaultProps,
+        rows: [{ ...defaultProps.rows[0], category: "UNKNOWN_CATEGORY" }],
+      };
+      render(<Table {...props} />);
+
+      expect(screen.getByText("UNKNOWN_CATEGORY")).toBeInTheDocument();
+    });
+
+    it("handles empty category gracefully", () => {
+      const props = {
+        ...defaultProps,
+        rows: [{ ...defaultProps.rows[0], category: "" }],
+      };
+      expect(() => render(<Table {...props} />)).not.toThrow();
+    });
   });
 });

--- a/src/common/components/DataTable/table.test.js
+++ b/src/common/components/DataTable/table.test.js
@@ -136,6 +136,24 @@ describe("Table", () => {
       expect(screen.getByText("UNKNOWN_CATEGORY")).toBeInTheDocument();
     });
 
+    it("falls back to raw code when categories bundle is unavailable", () => {
+      jest
+        .spyOn(require("react-i18next"), "useTranslation")
+        .mockReturnValueOnce({
+          t: (key) => key,
+          i18n: {
+            language: "en",
+            getResourceBundle: () => null,
+          },
+        });
+      const props = {
+        ...defaultProps,
+        rows: [{ ...defaultProps.rows[0], category: "FOOD_ASSISTANCE" }],
+      };
+      render(<Table {...props} />);
+      expect(screen.getByText("FOOD_ASSISTANCE")).toBeInTheDocument();
+    });
+
     it("handles empty category gracefully", () => {
       const props = {
         ...defaultProps,

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -234,7 +234,9 @@ const Dashboard = ({ userRole }) => {
           ]
         : baseHeaders;
     const isAllSelected = Object.values(statusFilter).every(Boolean);
-    return isAllSelected ? ["status", ...headersWithUserId] : headersWithUserId;
+    return isAllSelected
+      ? ["requestId", "status", ...headersWithUserId.slice(1)]
+      : headersWithUserId;
   }, [statusFilter, activeTab]);
 
   const sortedRequests = (requests) => {

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom";
+import { renderWithProviders, MOCK_STATE_LOGGED_IN } from "#utils/test-utils";
+import Dashboard from "./Dashboard";
+
+jest.mock("react-router-dom", () => {
+  const searchParams = new URLSearchParams();
+  return {
+    useLocation: () => ({ state: null, pathname: "/dashboard" }),
+    useSearchParams: () => [searchParams, jest.fn()],
+    Link: ({ children, to }) => <a href={to}>{children}</a>,
+  };
+});
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { changeLanguage: jest.fn() },
+  }),
+}));
+
+jest.mock("react-toastify", () => ({
+  ToastContainer: () => null,
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("../../services/requestServices", () => ({
+  getMyRequests: jest.fn(() => Promise.resolve({ body: [] })),
+  getOthersRequests: jest.fn(() => Promise.resolve({ body: [] })),
+  getManagedRequests: jest.fn(() => Promise.resolve({ body: [] })),
+}));
+
+jest.mock("./views/BeneficiaryDashboard", () => () => (
+  <div data-testid="beneficiary-dashboard" />
+));
+jest.mock("./views/VolunteerDashboard", () => () => (
+  <div data-testid="volunteer-dashboard" />
+));
+jest.mock("./views/AdminDashboard", () => () => (
+  <div data-testid="admin-dashboard" />
+));
+jest.mock("./views/StewardDashboard", () => () => (
+  <div data-testid="steward-dashboard" />
+));
+jest.mock("./views/SuperAdminDashboard", () => () => (
+  <div data-testid="super-admin-dashboard" />
+));
+jest.mock("./components/Analytics/ApplicationAnalytics", () => () => null);
+jest.mock("./components/Analytics/BeneficiariesAnalytics", () => () => null);
+jest.mock("./components/Analytics/GoogleAnalytics", () => () => null);
+jest.mock("./components/Analytics/KPIAnalytics", () => () => null);
+jest.mock("./components/Analytics/RequestsAnalytics", () => () => null);
+jest.mock("./components/Analytics/VolunteerAnalytics", () => () => null);
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders beneficiary dashboard by default when user has no groups", () => {
+    const { getByTestId } = renderWithProviders(<Dashboard />, {
+      preloadedState: {
+        auth: { user: { userId: "u1", groups: [] }, idToken: "tok" },
+      },
+    });
+    expect(getByTestId("beneficiary-dashboard")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
…ues in table

- Keep requestId as leftmost column even when status column is visible
- Add useTranslation to Table component to translate column headers
- Translate raw category codes (e.g. BUY_THINGS) to readable labels using the categories i18n namespace