### PR TITLE
Add volunteer name search UI in request details

### DIFF
--- a/src/pages/RequestDetails/HelpingVolunteers.jsx
+++ b/src/pages/RequestDetails/HelpingVolunteers.jsx
@@ -411,6 +411,16 @@ const HelpingVolunteers = () => {
             </svg>
             {t("REQUEST_VOLUNTEERS")}
           </button>
+          <div className="ml-auto flex items-center space-x-4">
+            <input
+              type="text"
+              placeholder="Enter volunteer name"
+              className="p-3 border rounded-md w-64"
+            />
+            <button className="bg-blue-500 px-6 py-3 text-white rounded-lg whitespace-nowrap hover:bg-blue-600 flex items-center">
+              Find by name
+            </button>
+          </div>
         </div>
 
         <div className="mt-6 bg-white p-6 shadow-lg">


### PR DESCRIPTION
This PR adds a new textbox and a "Find by name" button in the Volunteers tab of the Request Details page, placed next to the Request Volunteers section.

This is a UI-only change, and I have attached a screenshot for reference.
<img width="647" height="419" alt="image" src="https://github.com/user-attachments/assets/ab8507e9-9e9d-4397-8ab0-ad37aff48495" />
