### PR TITLE
feat(Auth): show success banner on login page after account creation

### DIFF
--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -393,6 +393,7 @@
   "PAGE_NOT_FOUND": "Page Not Found",
   "PASSWORD": "Password",
   "PASSWORD_CHANGE_SUCCESS": "Password changed successfully!",
+  "ACCOUNT_CREATED_SUCCESS": "Account created successfully! Please sign in.",
   "PASSWORD_MISMATCH_ERROR": "Passwords do not match.",
   "PASSWORD_REQUIRED": "Please enter your password",
   "PASSWORD_REQUIREMENTS": "Must contain at least 8 characters.",

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -1,9 +1,13 @@
 import { signIn } from "aws-amplify/auth";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { IoEyeOffOutline, IoEyeOutline } from "react-icons/io5";
+import {
+  IoCheckmarkCircle,
+  IoEyeOffOutline,
+  IoEyeOutline,
+} from "react-icons/io5";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { z } from "zod";
 import { INACTIVITY_TIMEOUT } from "../../common/components/InactivityTimer/InactivityTimer.jsx";
 import LoadingIndicator from "../../common/components/Loading/Loading.jsx";
@@ -25,6 +29,7 @@ const LoginPage = () => {
   const { user } = useSelector((state) => state.auth);
 
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useDispatch();
 
   const loginSchema = z.object({
@@ -84,6 +89,14 @@ const LoginPage = () => {
   return (
     <div className="flex items-center h-full justify-center">
       <div className="px-4 py-4 flex flex-col relative w-1/2">
+        {location.state?.accountCreated && (
+          <div className="flex items-center gap-3 px-4 py-3 mb-4 bg-green-50 border border-green-200 rounded-xl">
+            <IoCheckmarkCircle className="text-green-600 text-2xl shrink-0" />
+            <p className="text-green-800 text-sm font-medium">
+              {t("common:ACCOUNT_CREATED_SUCCESS")}
+            </p>
+          </div>
+        )}
         <h1 className="my-4 text-3xl font-bold text-center">
           {t("common:LOGIN")}
         </h1>

--- a/src/pages/Auth/Login.test.jsx
+++ b/src/pages/Auth/Login.test.jsx
@@ -1,0 +1,71 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "../../redux/features/authentication/authSlice";
+import LoginPage from "./Login";
+
+const mockNavigate = jest.fn();
+let mockLocationState = null;
+
+jest.mock("aws-amplify/auth", () => ({ signIn: jest.fn() }));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: mockLocationState, pathname: "/login" }),
+}));
+
+jest.mock(
+  "../../common/components/InactivityTimer/InactivityTimer.jsx",
+  () => ({ INACTIVITY_TIMEOUT: 3600000 }),
+);
+
+jest.mock("../../common/components/Loading/Loading.jsx", () => () => null);
+
+jest.mock("../../redux/features/authentication/authActions", () => ({
+  checkAuthStatus: jest.fn(() => ({ type: "mock" })),
+}));
+
+const renderLogin = () => {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: { auth: { user: null, loading: false, idToken: null } },
+  });
+  return render(
+    <Provider store={store}>
+      <LoginPage />
+    </Provider>,
+  );
+};
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    mockLocationState = null;
+    mockNavigate.mockClear();
+  });
+
+  it("renders the login form fields", () => {
+    renderLogin();
+    expect(screen.getByLabelText(/EMAIL/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/PASSWORD/i)).toBeInTheDocument();
+  });
+
+  it("shows success banner when accountCreated is true in location state", () => {
+    mockLocationState = { accountCreated: true };
+    renderLogin();
+    expect(
+      screen.getByText("common:ACCOUNT_CREATED_SUCCESS"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show success banner when accountCreated is not in location state", () => {
+    renderLogin();
+    expect(
+      screen.queryByText("ACCOUNT_CREATED_SUCCESS"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/Auth/VerifyOtp.jsx
+++ b/src/pages/Auth/VerifyOtp.jsx
@@ -92,7 +92,10 @@ function OTPVerification() {
 
         if (isSignUpComplete) {
           setMessage("OTP Verified Successfully!");
-          setTimeout(() => navigate("/login"), 2000);
+          setTimeout(
+            () => navigate("/login", { state: { accountCreated: true } }),
+            2000,
+          );
         }
       }
     } catch (error) {

--- a/src/pages/Auth/VerifyOtp.test.jsx
+++ b/src/pages/Auth/VerifyOtp.test.jsx
@@ -1,0 +1,90 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "../../redux/features/authentication/authSlice";
+import OTPVerification from "./VerifyOtp";
+
+const mockNavigate = jest.fn();
+
+jest.mock("aws-amplify/auth", () => ({
+  confirmSignUp: jest.fn(),
+  resendSignUpCode: jest.fn(),
+  confirmUserAttribute: jest.fn(),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: { email: "test@example.com" } }),
+}));
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useDispatch: () => jest.fn(),
+}));
+
+jest.mock("../../redux/features/authentication/authActions", () => ({
+  updateUserProfile: jest.fn(),
+}));
+
+jest.mock("../../utils/utils", () => ({
+  maskEmail: (email) => email,
+}));
+
+const renderVerifyOtp = () => {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: { auth: { user: null, loading: false, idToken: null } },
+  });
+  return render(
+    <Provider store={store}>
+      <OTPVerification />
+    </Provider>,
+  );
+};
+
+describe("OTPVerification", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the OTP form", () => {
+    renderVerifyOtp();
+    expect(screen.getByText(/Verify Your Email/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Verify OTP/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to login with accountCreated state after successful OTP verification", async () => {
+    const { confirmSignUp } = require("aws-amplify/auth");
+    confirmSignUp.mockResolvedValueOnce({ isSignUpComplete: true });
+
+    renderVerifyOtp();
+
+    // Fill in OTP inputs
+    const inputs = screen.getAllByRole("textbox");
+    inputs.forEach((input) => {
+      fireEvent.change(input, { target: { value: "1" } });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Verify OTP/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/OTP Verified Successfully/i),
+      ).toBeInTheDocument();
+    });
+
+    jest.runAllTimers();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/login", {
+      state: { accountCreated: true },
+    });
+  });
+});


### PR DESCRIPTION
- Pass accountCreated flag via router state when navigating from OTP verification to login
- Display a green success banner with checkmark icon above the login form
- Add ACCOUNT_CREATED_SUCCESS translation key to common.json