### PR TITLE
fix(HelpRequest): use category_number as catId when submitting GenAI …

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -816,10 +816,10 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
   const handleConfirmCategorySelection = () => {
     const oldCategory = "General";
     const newCategory = formData.category;
-    const newCategoryDisplay =
-      suggestedCategories.find(
-        (c) => (c.category_number ?? c.name) === newCategory,
-      )?.displayName ?? newCategory;
+    const matched = suggestedCategories.find(
+      (c) => (c.category_number ?? c.name) === newCategory,
+    );
+    const newCategoryDisplay = matched?.displayName ?? newCategory;
 
     setCategoryConfirmed(true); // unlock submission
     setShowModal(false);

--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -291,6 +291,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
       const formattedCategories = rawCategories.map((cat) => ({
         id: cat.category_name,
         name: cat.category_name,
+        category_number: cat.category_number,
         displayName: formatApiCategoryName(cat.category_name),
         confidence: cat.confidence,
       }));
@@ -815,14 +816,18 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
   const handleConfirmCategorySelection = () => {
     const oldCategory = "General";
     const newCategory = formData.category;
+    const newCategoryDisplay =
+      suggestedCategories.find(
+        (c) => (c.category_number ?? c.name) === newCategory,
+      )?.displayName ?? newCategory;
 
     setCategoryConfirmed(true); // unlock submission
     setShowModal(false);
 
-    if (oldCategory !== newCategory) {
+    if (oldCategory !== newCategoryDisplay) {
       setSnackbar({
         open: true,
-        message: `Category updated from \"${oldCategory}\" to \"${newCategory}\". Click Submit to continue.`,
+        message: `Category updated from \"${oldCategory}\" to \"${newCategoryDisplay}\". Click Submit to continue.`,
         severity: "info",
       });
     }
@@ -2185,7 +2190,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
             {suggestedCategories.map((category, index) => (
               <FormControlLabel
                 key={index}
-                value={category.name}
+                value={category.category_number ?? category.name}
                 control={<Radio />}
                 label={category.displayName ?? category.name}
               />

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -391,6 +391,77 @@ describe("HelpRequestForm — predict categories modal", () => {
       expect(screen.getByText("General")).toBeInTheDocument();
     });
   });
+
+  it("submits with category_number as catId when a GenAI suggested category is selected", async () => {
+    const {
+      checkProfanity,
+      predictCategories,
+      createRequest,
+    } = require("../../services/requestServices");
+    const {
+      mapHelpRequestPayload,
+    } = require("../../utils/mapHelpRequestPayload");
+
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    createRequest.mockResolvedValue({ requestId: "REQ-999" });
+    predictCategories.mockResolvedValue({
+      body: {
+        categories: [
+          {
+            category_number: "4.3",
+            category_name: "TUTORING",
+            confidence: 0.92,
+          },
+        ],
+      },
+    });
+
+    renderForm();
+
+    // Type a description to enable prediction
+    fireEvent.change(document.getElementById("description"), {
+      target: { name: "description", value: "I need help with math tutoring." },
+    });
+
+    // First Submit — triggers the GenAI modal (category is still "General")
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+    );
+
+    // Wait for the modal to appear with the suggested category
+    await waitFor(() => {
+      expect(screen.getByText("Tutoring")).toBeInTheDocument();
+    });
+
+    // Select the "Tutoring" radio — its value should be "4.3" (category_number)
+    fireEvent.click(screen.getByDisplayValue("4.3"));
+
+    // Confirm the selection and wait for modal to close + state updates to flush
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Select" }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    // Second Submit — category is now confirmed, should actually submit
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+      );
+    });
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+
+    // Verify mapHelpRequestPayload received the numeric catId, not the name string
+    const callArgs =
+      mapHelpRequestPayload.mock.calls[
+        mapHelpRequestPayload.mock.calls.length - 1
+      ][0];
+    expect(callArgs.selectedCategoryId).toBe("4.3");
+    expect(callArgs.selectedCategoryId).not.toBe("TUTORING");
+  });
 });
 
 describe("HelpRequestForm — generateSubject auto-fill", () => {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -462,6 +462,50 @@ describe("HelpRequestForm — predict categories modal", () => {
     expect(callArgs.selectedCategoryId).toBe("4.3");
     expect(callArgs.selectedCategoryId).not.toBe("TUTORING");
   });
+
+  it("does not show snackbar when General is confirmed without changing category", async () => {
+    const {
+      checkProfanity,
+      predictCategories,
+    } = require("../../services/requestServices");
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    predictCategories.mockResolvedValue({
+      body: {
+        categories: [
+          {
+            category_number: "4.3",
+            category_name: "TUTORING",
+            confidence: 0.9,
+          },
+        ],
+      },
+    });
+
+    renderForm();
+
+    fireEvent.change(document.getElementById("description"), {
+      target: { name: "description", value: "I need help with something." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("General")).toBeInTheDocument(),
+    );
+
+    // Confirm without changing — keeps "General", no snackbar should fire
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Select" }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    expect(screen.queryByText(/Category updated from/)).not.toBeInTheDocument();
+  });
 });
 
 describe("HelpRequestForm — generateSubject auto-fill", () => {


### PR DESCRIPTION
…suggested category

When a user selected a GenAI-suggested category, helpCategory.catId was being set to the category name string (e.g. "TUTORING") instead of the numeric ID (e.g. "4.3") returned by the predict-categories API, causing the request to fail. Now category_number is stored on the suggested category object and used as the radio value so formData.category holds the correct numeric ID at submission time. Also adds an end-to-end test that asserts the numeric catId reaches mapHelpRequestPayload.