### PR TITLE
feat: More Info chatbot - payload update, textarea, and test fixes (#1247)

### DIFF
--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import Markdown from "react-markdown";
 import { moreInformationChat } from "../../../services/requestServices";
-import { getCategoriesFromStorage } from "../../../utils/filterHelpers";
 import i18n from "../../i18n/i18n";
 
 const MAX_QUESTIONS = 5;
@@ -12,28 +11,10 @@ async function translateText(text /*, targetLang */) {
   return text; // passthrough until endpoint available
 }
 
-const findCatId = (catName) => {
-  const categories = getCategoriesFromStorage() || [];
-  const search = (list) => {
-    for (const cat of list) {
-      if (cat.catName === catName) return cat.catId;
-      if (cat.subCategories) {
-        const found = search(cat.subCategories);
-        if (found) return found;
-      }
-    }
-    return null;
-  };
-  return search(categories) ?? catName;
-};
-
-const buildPayload = (requestData) => ({
-  category_id: findCatId(requestData.category ?? ""),
-  subject: requestData.subject ?? "",
-  description: requestData.description ?? "",
-  location: requestData.location ?? "",
-  gender: requestData.gender ?? "",
-  age: requestData.age ?? "",
+// TODO: replace hardcoded defaults with dynamic user_id and req_id
+const buildPayload = () => ({
+  user_id: "SID-00-000-000-050",
+  req_id: "REQ-00-000-000-0085",
 });
 
 const counterColorClass = (remaining) => {
@@ -83,19 +64,9 @@ const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
     setIsLoading(true);
 
     try {
-      // Build conversation_history in backend format
-      const conversationHistory = nextMessages.map((msg) => ({
-        role: msg.role,
-        content:
-          msg.role === "user" && msg === nextMessages[0]
-            ? `Subject: ${requestData.subject ?? ""}\nQuestion: ${msg.content}`
-            : msg.content,
-      }));
-
       const payload = {
-        ...buildPayload(requestData),
-        description: toSend,
-        conversation_history: conversationHistory,
+        ...buildPayload(),
+        conversation_history: nextMessages,
       };
       const rawReply = await moreInformationChat(payload);
       const aiReply = rawReply?.body?.answer ?? "";
@@ -208,19 +179,22 @@ const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
         </div>
 
         {/* Input area */}
-        <div className="border-t border-gray-200 p-3 flex gap-2">
-          <input
-            type="text"
+        <div className="border-t border-gray-200 p-3 flex gap-2 items-end">
+          <textarea
             value={inputText}
-            onChange={(e) => setInputText(e.target.value)}
+            onChange={(e) => {
+              if (e.target.value.length <= 250) setInputText(e.target.value);
+            }}
             onKeyDown={handleKeyDown}
             disabled={remaining === 0 || isLoading}
+            rows={3}
+            maxLength={250}
             placeholder={
               remaining === 0
                 ? "No questions remaining"
-                : "Ask a follow-up question…"
+                : "Ask a follow-up question… (max 250 characters)"
             }
-            className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed resize-none"
           />
           <button
             onClick={handleSend}

--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
@@ -12,18 +12,6 @@ jest.mock("../../../services/requestServices", () => ({
   moreInformationChat: jest.fn(),
 }));
 
-jest.mock("../../../utils/filterHelpers", () => ({
-  getCategoriesFromStorage: jest.fn(() => [
-    {
-      catId: "6",
-      catName: "ELDERLY_COMMUNITY_ASSISTANCE",
-      subCategories: [
-        { catId: "6.5", catName: "ERRANDS_EVENTS_TRANSPORTATION" },
-      ],
-    },
-  ]),
-}));
-
 jest.mock("../../i18n/i18n", () => ({
   language: "en",
 }));
@@ -39,15 +27,13 @@ const { moreInformationChat } = require("../../../services/requestServices");
 
 const mockRequestData = {
   id: "REQ-001",
-  category: "ERRANDS_EVENTS_TRANSPORTATION",
   subject: "Pick up dry cleaning",
   description: "Need someone to pick up my dry cleaning.",
-  location: "San Francisco, CA",
-  gender: "Female",
-  age: "35",
 };
 
 const mockOnClose = jest.fn();
+
+const PLACEHOLDER = "Ask a follow-up question… (max 250 characters)";
 
 const renderModal = (props = {}) =>
   render(
@@ -92,11 +78,28 @@ describe("MoreInfoChatModal", () => {
     expect(screen.getByTitle("5 questions remaining")).toHaveTextContent("5");
   });
 
+  it("renders a textarea for input", () => {
+    renderModal();
+    const textarea = screen.getByPlaceholderText(PLACEHOLDER);
+    expect(textarea.tagName).toBe("TEXTAREA");
+    expect(textarea).toHaveAttribute("maxLength", "250");
+    expect(textarea).toHaveAttribute("rows", "3");
+  });
+
   it("updates input text on change", () => {
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "What documents?" } });
     expect(input.value).toBe("What documents?");
+  });
+
+  it("enforces 250 character limit", () => {
+    renderModal();
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+    const longText = "a".repeat(300);
+    fireEvent.change(input, { target: { value: longText } });
+    // onChange guard rejects values over 250
+    expect(input.value).toBe("");
   });
 
   it("sends message and decrements counter on Send click", async () => {
@@ -105,7 +108,7 @@ describe("MoreInfoChatModal", () => {
     });
 
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "What documents do I need?" } });
     fireEvent.click(screen.getByText("Send"));
 
@@ -124,7 +127,7 @@ describe("MoreInfoChatModal", () => {
     });
 
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "Enter test" } });
     fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
 
@@ -135,11 +138,13 @@ describe("MoreInfoChatModal", () => {
 
   it("does not send on Shift+Enter", () => {
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "No send" } });
     fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
 
-    expect(screen.queryByText("No send")).not.toBeInTheDocument();
+    // Message should stay in textarea, not be sent to the API
+    expect(moreInformationChat).not.toHaveBeenCalled();
+    expect(input.value).toBe("No send");
   });
 
   it("does not send empty message", () => {
@@ -152,7 +157,7 @@ describe("MoreInfoChatModal", () => {
     moreInformationChat.mockRejectedValue(new Error("Network error"));
 
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "Will this fail?" } });
     fireEvent.click(screen.getByText("Send"));
 
@@ -201,25 +206,24 @@ describe("MoreInfoChatModal", () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it("calls moreInformationChat with correct payload shape", async () => {
+  it("calls moreInformationChat with user_id, req_id, and conversation_history", async () => {
     moreInformationChat.mockResolvedValue({
       body: { answer: "Response." },
     });
 
     renderModal();
-    const input = screen.getByPlaceholderText("Ask a follow-up question…");
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(input, { target: { value: "My question" } });
     fireEvent.click(screen.getByText("Send"));
 
     await waitFor(() => {
       expect(moreInformationChat).toHaveBeenCalledWith(
         expect.objectContaining({
-          category_id: "6.5",
-          subject: "Pick up dry cleaning",
-          description: "My question",
+          user_id: "SID-00-000-000-050",
+          req_id: "REQ-00-000-000-0085",
           conversation_history: expect.arrayContaining([
             expect.objectContaining({ role: "assistant" }),
-            expect.objectContaining({ role: "user" }),
+            expect.objectContaining({ role: "user", content: "My question" }),
           ]),
         }),
       );

--- a/src/common/components/RequestButton/RequestButton.jsx
+++ b/src/common/components/RequestButton/RequestButton.jsx
@@ -9,7 +9,6 @@ import {
   getEmergencyContactInfo,
   moreInformationChat,
 } from "../../../services/requestServices";
-import { getCategoriesFromStorage } from "../../../utils/filterHelpers";
 import MoreInfoChatModal from "../MoreInfoChatModal/MoreInfoChatModal";
 
 const COOLDOWN_MS = 30 * 60 * 1000;
@@ -26,28 +25,10 @@ const isCoolingDown = (data) => {
   return false;
 };
 
-const findCatId = (catName) => {
-  const categories = getCategoriesFromStorage() || [];
-  const search = (list) => {
-    for (const cat of list) {
-      if (cat.catName === catName) return cat.catId;
-      if (cat.subCategories) {
-        const found = search(cat.subCategories);
-        if (found) return found;
-      }
-    }
-    return null;
-  };
-  return search(categories) ?? catName;
-};
-
-const buildPayload = (requestData) => ({
-  category_id: findCatId(requestData.category ?? ""),
-  subject: requestData.subject ?? "",
-  description: requestData.description ?? "",
-  location: requestData.location ?? "",
-  gender: requestData.gender ?? "",
-  age: requestData.age ?? "",
+// TODO: replace hardcoded defaults with dynamic user_id and req_id
+const buildPayload = () => ({
+  user_id: "SID-00-000-000-050",
+  req_id: "REQ-00-000-000-0085",
 });
 
 const RequestButton = ({
@@ -95,7 +76,10 @@ const RequestButton = ({
           return;
         }
 
-        const aiReply = await moreInformationChat(buildPayload(requestData));
+        const aiReply = await moreInformationChat({
+          ...buildPayload(),
+          conversation_history: [],
+        });
         setInitialResponse(aiReply?.body?.answer ?? "");
         setShowModal(true);
       } catch (error) {

--- a/src/common/components/RequestButton/RequestButton.test.js
+++ b/src/common/components/RequestButton/RequestButton.test.js
@@ -16,18 +16,6 @@ jest.mock("../../../services/requestServices", () => ({
   moreInformationChat: jest.fn(),
 }));
 
-jest.mock("../../../utils/filterHelpers", () => ({
-  getCategoriesFromStorage: jest.fn(() => [
-    {
-      catId: "6",
-      catName: "ELDERLY_COMMUNITY_ASSISTANCE",
-      subCategories: [
-        { catId: "6.5", catName: "ERRANDS_EVENTS_TRANSPORTATION" },
-      ],
-    },
-  ]),
-}));
-
 jest.mock(
   "../MoreInfoChatModal/MoreInfoChatModal",
   () => (props) =>
@@ -45,12 +33,8 @@ const {
 
 const mockRequestData = {
   id: "REQ-001",
-  category: "ERRANDS_EVENTS_TRANSPORTATION",
   subject: "Pick up dry cleaning",
   description: "Need dry cleaning pickup.",
-  location: "",
-  gender: "",
-  age: "",
 };
 
 describe("RequestButton", () => {
@@ -126,7 +110,7 @@ describe("RequestButton", () => {
     });
   });
 
-  it("calls moreInformationChat with resolved category_id", async () => {
+  it("calls moreInformationChat with user_id, req_id, and empty conversation_history", async () => {
     moreInformationChat.mockResolvedValue({
       body: { answer: "Answer" },
     });
@@ -144,12 +128,11 @@ describe("RequestButton", () => {
     fireEvent.click(screen.getByRole("button"));
 
     await waitFor(() => {
-      expect(moreInformationChat).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category_id: "6.5",
-          subject: "Pick up dry cleaning",
-        }),
-      );
+      expect(moreInformationChat).toHaveBeenCalledWith({
+        user_id: "SID-00-000-000-050",
+        req_id: "REQ-00-000-000-0085",
+        conversation_history: [],
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Switched payload to `user_id` + `req_id` + `conversation_history` (hardcoded defaults for now)
- Removed `category_id`/`subject`/`description` payload and `findCatId` category lookup
- Changed input from single-line text field to textarea (3 rows, 250 char max)
- Updated all tests to match new payload format and textarea component
- Extracts response from `response.body.answer`

## Still Pending (next PR)
- Dynamic `user_id` and `req_id` from actual user/request data
- SAAYAM error codes and icons for all user-facing messages
- Translation API integration