### PR TITLE
Removed mockid from createRequest

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -1173,8 +1173,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
       });
 
       const response = await createRequest(payload);
-      const requestId =
-        response?.requestId || response?.body?.requestId || response?.id;
+      const requestId = response?.data?.requestId;
 
       setSnackbar({
         open: true,

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -403,7 +403,7 @@ describe("HelpRequestForm — predict categories modal", () => {
     } = require("../../utils/mapHelpRequestPayload");
 
     checkProfanity.mockResolvedValue({ contains_profanity: false });
-    createRequest.mockResolvedValue({ requestId: "REQ-999" });
+    createRequest.mockResolvedValue({ data: { requestId: "REQ-999" } });
     predictCategories.mockResolvedValue({
       body: {
         categories: [
@@ -655,7 +655,7 @@ describe("HelpRequestForm — successful submission", () => {
       createRequest,
     } = require("../../services/requestServices");
     checkProfanity.mockResolvedValue({ contains_profanity: false });
-    createRequest.mockResolvedValue({ requestId: "REQ-12345" });
+    createRequest.mockResolvedValue({ data: { requestId: "REQ-12345" } });
 
     renderForm();
 


### PR DESCRIPTION
After request creation, the success message on the dashboard was showing a generic message instead of the actual request ID. Fixed the response path from response?.requestId to response?.data?.requestId to match the actual API response shape, and updated tests accordingly.