### PR TITLE
1379 fix translations for help category string on request details page

### DIFF
--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -15,6 +15,21 @@ import {
 import { useNavigate } from "react-router-dom";
 import "./RequestDescription.css";
 
+const findCategoryLabel = (node, targetKey) => {
+  if (!node || !targetKey) return null;
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === targetKey && value?.LABEL) return value.LABEL;
+
+    if (value?.SUBCATEGORIES) {
+      const found = findCategoryLabel(value.SUBCATEGORIES, targetKey);
+      if (found) return found;
+    }
+  }
+
+  return null;
+};
+
 const RequestDescription = ({ requestData, setIsEditing }) => {
   const { t, i18n } = useTranslation();
   const token = useSelector((state) => state.auth.idToken);
@@ -74,7 +89,7 @@ const RequestDescription = ({ requestData, setIsEditing }) => {
             {attributes.map((header, index) => (
               <li key={index} className="flex items-center gap-2">
                 {header.icon}
-                {t(header.context)}
+                {header.context}
               </li>
             ))}
 


### PR DESCRIPTION
- Resolve Help Category labels via categories.json so the Details tab displays human‑readable translations instead of raw enum keys.
- Support nested subcategory paths (e.g., ERRANDS_EVENTS_TRANSPORTATION, SOCIAL_CONNECTION)