### PR TITLE
fix-help-category-test on request details page

### DIFF
--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -31,7 +31,7 @@ const findCategoryLabel = (node, targetKey) => {
 };
 
 const RequestDescription = ({ requestData, setIsEditing }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const token = useSelector((state) => state.auth.idToken);
   const navigate = useNavigate();
 
@@ -45,6 +45,17 @@ const RequestDescription = ({ requestData, setIsEditing }) => {
     day: "numeric",
   });
 
+  const lang = i18n.resolvedLanguage || i18n.language || "en";
+  const categoriesBundle = i18n.hasResourceBundle?.(lang, "categories")
+    ? i18n.getResourceBundle(lang, "categories")
+    : i18n.getResourceBundle("en", "categories");
+
+  const categoryLabel =
+    findCategoryLabel(
+      categoriesBundle?.REQUEST_CATEGORIES,
+      requestData?.category,
+    ) || requestData?.category;
+
   const attributes = [
     {
       context: formattedDate,
@@ -52,7 +63,7 @@ const RequestDescription = ({ requestData, setIsEditing }) => {
       icon: <VscCalendar size={22} />,
     },
     {
-      context: requestData.category,
+      context: categoryLabel,
       type: "Category",
       icon: <TbTriangleSquareCircle size={22} />,
     },


### PR DESCRIPTION
- Resolve Help Category labels via categories.json so the Details tab displays human‑readable translations instead of raw enum keys.
- Support nested subcategory paths (e.g., ERRANDS_EVENTS_TRANSPORTATION, SOCIAL_CONNECTION)