### PR TITLE
fix(login): add auth validation, loading state, and error message mapping 

### DIFF
--- a/src/common/i18n/locales/en/auth.json
+++ b/src/common/i18n/locales/en/auth.json
@@ -1,3 +1,16 @@
 {
-  "//": "Authentication translations will be moved here gradually from common.json"
+  "//": "Authentication translations will be moved here gradually from common.json",
+  "login": {
+    "success": "Login successful.",
+    "email_required": "Email address is required.",
+    "email_invalid": "Please enter a valid email address.",
+    "password_required": "Password is required.",
+    "invalid_credentials": "Invalid email or password.",
+    "account_locked_30min": "Account temporarily locked. Please try again in 30 minutes."
+  },
+  "shared": {
+    "session_expired": "Session Expired",
+    "network_error": "Network error. Please check your connection and try again.",
+    "server_error": "Server Error"
+  }
 }

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -15,8 +15,7 @@ import { checkAuthStatus } from "../../redux/features/authentication/authActions
 import "./Login.css";
 
 const LoginPage = () => {
-  const { t } = useTranslation(["common"]);
-  const { loading } = useSelector((state) => state.auth);
+  const { t } = useTranslation(["auth", "common"]);
 
   const [emailValue, setEmailValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");
@@ -25,6 +24,7 @@ const LoginPage = () => {
   const [passwordFocus, setPasswordFocus] = useState(false);
 
   const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { user } = useSelector((state) => state.auth);
 
@@ -33,8 +33,11 @@ const LoginPage = () => {
   const dispatch = useDispatch();
 
   const loginSchema = z.object({
-    email: z.string().min(1, { message: t("common:EMAIL_REQUIRED") }),
-    password: z.string().min(1, { message: t("common:PASSWORD_REQUIRED") }),
+    email: z
+      .string()
+      .min(1, { message: t("auth:login.email_required") })
+      .email({ message: t("auth:login.email_invalid") }),
+    password: z.string().min(1, { message: t("auth:login.password_required") }),
   });
 
   useEffect(() => {
@@ -43,21 +46,70 @@ const LoginPage = () => {
     }
   }, [user]);
 
-  const handleSignIn = async () => {
-    try {
-      const result = loginSchema.safeParse({
-        email: emailValue,
-        password: passwordValue,
-      });
-      if (!result.success) {
-        const formattedErrors = result.error.format();
-        setErrors({
-          email: formattedErrors.email?._errors[0],
-          password: formattedErrors.password?._errors[0],
-        });
-        return;
-      }
+  const getLoginErrorMessage = (error) => {
+    const errorName = String(error?.name || error?.code || "").toLowerCase();
+    const errorMessage = String(error?.message || "").toLowerCase();
 
+    if (
+      errorName.includes("network") ||
+      errorMessage.includes("network error") ||
+      errorMessage.includes("failed to fetch") ||
+      errorMessage.includes("load failed")
+    ) {
+      return t("auth:shared.network_error");
+    }
+
+    if (
+      errorName.includes("internalerrorexception") ||
+      errorName.includes("service") ||
+      errorMessage.includes("internal error") ||
+      errorMessage.includes("server error") ||
+      errorMessage.includes("status code 500")
+    ) {
+      return t("auth:shared.server_error");
+    }
+
+    if (
+      errorName.includes("toomanyfailedattempts") ||
+      errorName.includes("toomanyrequestsexception") ||
+      errorName.includes("limitexceededexception") ||
+      errorMessage.includes("password attempts exceeded") ||
+      errorMessage.includes("temporarily locked")
+    ) {
+      return t("auth:login.account_locked_30min");
+    }
+
+    if (
+      errorName.includes("notauthorizedexception") ||
+      errorName.includes("usernotfoundexception") ||
+      errorMessage.includes("incorrect username or password") ||
+      errorMessage.includes("incorrect username") ||
+      errorMessage.includes("incorrect password")
+    ) {
+      return t("auth:login.invalid_credentials");
+    }
+
+    return t("auth:shared.server_error");
+  };
+
+  const handleSignIn = async () => {
+    const result = loginSchema.safeParse({
+      email: emailValue,
+      password: passwordValue,
+    });
+    if (!result.success) {
+      const formattedErrors = result.error.format();
+      setErrors({
+        email: formattedErrors.email?._errors[0],
+        password: formattedErrors.password?._errors[0],
+      });
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
       const { isSignedIn, nextStep } = await signIn({
         username: emailValue,
         password: passwordValue,
@@ -81,8 +133,11 @@ const LoginPage = () => {
         }
       }
     } catch (error) {
-      console.log("error", error);
-      setErrors({ root: t("common:INVALID_CREDENTIALS") });
+      console.log("Login error", error);
+      setPasswordValue("");
+      setErrors({ root: getLoginErrorMessage(error) });
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -155,18 +210,24 @@ const LoginPage = () => {
           {t("common:FORGOT_PASSWORD")}
         </button>
         <button
-          disabled={loading}
+          disabled={isSubmitting}
           className="my-4 py-2 bg-blue-400 text-white rounded-xl hover:bg-blue-500"
           onClick={handleSignIn}
+          aria-busy={isSubmitting}
         >
           <div className="flex items-center justify-center">
-            <span className={loading ? "mr-2" : ""}>{t("common:LOGIN")}</span>
-            {loading && <LoadingIndicator size="24px" />}
+            <span className={isSubmitting ? "mr-2" : ""}>
+              {t("common:LOGIN")}
+            </span>
+            {isSubmitting && <LoadingIndicator size="24px" />}
           </div>
         </button>
         {errors.root && (
           <p className="text-red-500 text-sm mt-1">{errors.root}</p>
         )}
+        {/* TODO: Session-expired warnings should be shown here only if upstream
+            routes redirect with explicit route state. Current login flow does
+            not reliably receive that signal. */}
 
         {/* Uncommment for Google and Facebook signin is fully functional*/}
         {/* <div className="flex items-center my-4">

--- a/src/pages/Auth/Login.test.jsx
+++ b/src/pages/Auth/Login.test.jsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "../../redux/features/authentication/authSlice";
@@ -24,7 +24,9 @@ jest.mock(
   () => ({ INACTIVITY_TIMEOUT: 3600000 }),
 );
 
-jest.mock("../../common/components/Loading/Loading.jsx", () => () => null);
+jest.mock("../../common/components/Loading/Loading.jsx", () => () => (
+  <span data-testid="login-loading-indicator">loading</span>
+));
 
 jest.mock("../../redux/features/authentication/authActions", () => ({
   checkAuthStatus: jest.fn(() => ({ type: "mock" })),
@@ -43,9 +45,12 @@ const renderLogin = () => {
 };
 
 describe("LoginPage", () => {
+  const { signIn } = require("aws-amplify/auth");
+
   beforeEach(() => {
     mockLocationState = null;
     mockNavigate.mockClear();
+    signIn.mockReset();
   });
 
   it("renders the login form fields", () => {
@@ -67,5 +72,100 @@ describe("LoginPage", () => {
     expect(
       screen.queryByText("ACCOUNT_CREATED_SUCCESS"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows email invalid format validation and does not submit", async () => {
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText(/EMAIL/i), {
+      target: { value: "invalid-email" },
+    });
+    fireEvent.change(screen.getByLabelText(/PASSWORD/i), {
+      target: { value: "Secret123!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /common:LOGIN/i }));
+
+    expect(
+      await screen.findByText("auth:login.email_invalid"),
+    ).toBeInTheDocument();
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it("clears password and shows invalid credentials on failed login", async () => {
+    signIn.mockRejectedValueOnce({
+      name: "NotAuthorizedException",
+      message: "Incorrect username or password.",
+    });
+
+    renderLogin();
+
+    const emailInput = screen.getByLabelText(/EMAIL/i);
+    const passwordInput = screen.getByLabelText(/PASSWORD/i);
+
+    fireEvent.change(emailInput, {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(passwordInput, {
+      target: { value: "WrongPassword123!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /common:LOGIN/i }));
+
+    expect(
+      await screen.findByText("auth:login.invalid_credentials"),
+    ).toBeInTheDocument();
+    expect(emailInput).toHaveValue("user@example.com");
+    expect(passwordInput).toHaveValue("");
+  });
+
+  it("disables the login button and shows loading while sign-in is in progress", async () => {
+    let resolveSignIn;
+    signIn.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSignIn = resolve;
+      }),
+    );
+
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText(/EMAIL/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/PASSWORD/i), {
+      target: { value: "Secret123!" },
+    });
+
+    const loginButton = screen.getByRole("button", { name: /common:LOGIN/i });
+    fireEvent.click(loginButton);
+
+    expect(loginButton).toBeDisabled();
+    expect(screen.getByTestId("login-loading-indicator")).toBeInTheDocument();
+
+    resolveSignIn({
+      isSignedIn: false,
+      nextStep: { signInStep: "CONFIRM_SIGN_UP" },
+    });
+
+    await waitFor(() => expect(loginButton).not.toBeDisabled());
+  });
+
+  it("maps network failures to the network error message", async () => {
+    signIn.mockRejectedValueOnce({
+      name: "NetworkError",
+      message: "Failed to fetch",
+    });
+
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText(/EMAIL/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/PASSWORD/i), {
+      target: { value: "Secret123!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /common:LOGIN/i }));
+
+    expect(
+      await screen.findByText("auth:shared.network_error"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Implemented login-page messaging and UX fixes for MVP scope.

Changes included:

* Added email format validation
* Added proper in-flight submit/loading state during sign-in
* Disabled submit button while authentication is in progress
* Preserved email and cleared password on failed login
* Added i18n-backed login error mappings for invalid credentials, network error, server error, and lockout-like provider responses
* Added targeted tests for validation, loading state, failed-login password clearing, and network error mapping

Intentionally not included:

* Session-expired warning banner on login page, since current routing does not reliably pass that state
* Backend/auth-provider contract changes
* Login whitespace/ad-layout fix, which appears to be a separate layout concern
