### PR TITLE
Fix layout issues on auth pages due to ads (#1323)

### DIFF
--- a/src/Layout/Layout.jsx
+++ b/src/Layout/Layout.jsx
@@ -12,14 +12,22 @@ import Breadcrumbs from "#components/BreadCrumbs/BreadCrumbs";
 
 const Layout = () => {
   const location = useLocation();
+  const currentPath = location.pathname.toLowerCase();
 
   const hideBreadcrumbRoutes = ["/", "/home", "/login"];
-  const shouldHideBreadcrumbs = hideBreadcrumbRoutes.includes(
-    location.pathname.toLowerCase(),
-  );
+  const shouldHideBreadcrumbs = hideBreadcrumbRoutes.includes(currentPath);
+  const hideAdsRoutes = [
+    "/login",
+    "/signup",
+    "/forgot-password",
+    "/reset-password",
+    "/verify-otp",
+  ];
+
+  const shouldHideAds = hideAdsRoutes.includes(currentPath);
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex min-h-screen flex-col">
       <NotificationProvider>
         <NavigationGuard />
 
@@ -28,20 +36,24 @@ const Layout = () => {
         </header>
 
         <div className="flex flex-1">
-          <aside className="left-ads-panel flex-1 ">
-            <LeftAds />
-          </aside>
+          {!shouldHideAds && (
+            <aside className="left-ads-panel flex-1 ">
+              <LeftAds />
+            </aside>
+          )}
 
-          <main className="flex-[6] overflow-auto">
+          <main className={`${shouldHideAds ? "flex-1" : "flex-[6]"} flex-1`}>
             {!shouldHideBreadcrumbs && <Breadcrumbs />}
             <Suspense fallback={<MainLoader />}>
               <Outlet />
             </Suspense>
           </main>
 
-          <aside className="right-ads-panel flex-1 ">
-            <RightAds />
-          </aside>
+          {!shouldHideAds && (
+            <aside className="right-ads-panel flex-1 ">
+              <RightAds />
+            </aside>
+          )}
         </div>
 
         <footer className="">

--- a/src/Layout/__snapshots__/layout.test.js.snap
+++ b/src/Layout/__snapshots__/layout.test.js.snap
@@ -6,7 +6,7 @@ exports[`Layout renders correctly 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="flex flex-col h-screen"
+        class="flex min-h-screen flex-col"
       >
         <mock-navigation-guard />
         <header
@@ -24,7 +24,7 @@ exports[`Layout renders correctly 1`] = `
             <mock-left-ads />
           </aside>
           <main
-            class="flex-[6] overflow-auto"
+            class="flex-[6] flex-1"
           >
             <nav
               aria-label="breadcrumb"
@@ -77,7 +77,7 @@ exports[`Layout renders correctly 1`] = `
   </body>,
   "container": <div>
     <div
-      class="flex flex-col h-screen"
+      class="flex min-h-screen flex-col"
     >
       <mock-navigation-guard />
       <header
@@ -95,7 +95,7 @@ exports[`Layout renders correctly 1`] = `
           <mock-left-ads />
         </aside>
         <main
-          class="flex-[6] overflow-auto"
+          class="flex-[6] flex-1"
         >
           <nav
             aria-label="breadcrumb"


### PR DESCRIPTION
This PR fixes layout issues caused by ads on auth-related pages.

Changes made:
- Disabled left and right ads on auth pages (login, signup, reset password, etc.)
- Fixed extra blank space caused by ad panels on short pages
- Updated layout to ensure footer stays at the bottom of the page


Fixes #1323 