### PR TITLE
Fix: French translation for 'In The News' in navbar and breadcrumbs

### DIFF
--- a/src/common/components/BreadCrumbs/BreadCrumbs.jsx
+++ b/src/common/components/BreadCrumbs/BreadCrumbs.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import "./BreadCrumbs.css";
 
 const Breadcrumbs = () => {
+  const { t } = useTranslation();
   const location = useLocation();
   const currentPath = location.pathname.toLowerCase();
   const passedTrail = Array.isArray(location.state?.breadcrumbTrail)
@@ -146,7 +148,7 @@ const Breadcrumbs = () => {
     }
     if (currentPath === "/our-team") return "Our Team";
     if (currentPath === "/our-mission") return "Our Mission";
-    if (currentPath === "/news-our-stories") return "News Our Stories";
+    if (currentPath === "/news-our-stories") return t("IN_THE_NEWS");
     if (currentPath === "/how-we-operate") return "How We Operate";
     if (currentPath === "/collaborators") return "Collaborators";
     if (currentPath === "/contact") return "Contact";

--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -581,7 +581,7 @@ const Navbar = () => {
                   <MenuItem
                     onClick={(e) => handleLinkClick(e, "/news-our-stories")}
                   >
-                    <ArticleIcon className="mr-2" /> {t("In The News")}
+                    <ArticleIcon className="mr-2" /> {t("IN_THE_NEWS")}
                   </MenuItem>
                 </Menu>
               )}
@@ -885,7 +885,7 @@ const Navbar = () => {
                   <MenuItem
                     onClick={(e) => handleDrawerClick(e, "/news-our-stories")}
                   >
-                    <ArticleIcon className="mr-2" /> {t("In the news")}
+                    <ArticleIcon className="mr-2" /> {t("IN_THE_NEWS")}
                   </MenuItem>
                 }
               </Menu>

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -256,6 +256,7 @@
   "INVALID_EMAIL": "E-mail invalide",
   "INVALID_PHONE": "Téléphone invalide",
   "IN_PERSON": "En personne",
+  "IN_THE_NEWS": "Dans les actualités",
   "IS_SAAYAM_NON_PROFIT": "Saayam For All est-il un organisme à but non lucratif",
   "I_HAVE_READ": "J'ai lu et compris le document",
   "I_WANT_TO_DELETE_MY_ACCOUNT": "Je veux supprimer mon compte",


### PR DESCRIPTION
- Add IN_THE_NEWS key to `fr/common.json`
- Update Navbar desktop and mobile menu items to use t("IN_THE_NEWS") instead of hardcoded strings
- Add useTranslation to BreadCrumbs and use t("IN_THE_NEWS") for /news-our-stories label