### PR TITLE
fix: add missing Change Volunteer dialog translations for mai and sd …

### DIFF
--- a/src/common/i18n/locales/mai/common.json
+++ b/src/common/i18n/locales/mai/common.json
@@ -32,5 +32,9 @@
   "REMOVE_CATEGORY": "Remove all skills from this category",
   "SELECT_SKILL_TO_CONTINUE": "Select at least one specific skill to move to next step",
   "COMMENTS": "टिप्पणी",
-  "VOLUNTEERS": "स्वयंसेवक"
+  "VOLUNTEERS": "स्वयंसेवक",
+  "CANCEL": "रद्द करू",
+  "CHANGE_VOLUNTEER": "स्वयंसेवक बदलू",
+  "PLEASE_SPECIFY_REASON_FOR_CHANGE_OF_VOLUNTEER": "स्वयंसेवक बदलबाक कारण बताऊ",
+  "REASON": "कारण"
 }

--- a/src/common/i18n/locales/sd/common.json
+++ b/src/common/i18n/locales/sd/common.json
@@ -33,5 +33,9 @@
   "REMOVE_CATEGORY": "Remove all skills from this category",
   "SELECT_SKILL_TO_CONTINUE": "Select at least one specific skill to move to next step",
   "COMMENTS": "تبصرا",
-  "VOLUNTEERS": "رضاڪار"
+  "VOLUNTEERS": "رضاڪار",
+  "CANCEL": "منسوخ ڪريو",
+  "CHANGE_VOLUNTEER": "رضاڪار بدلايو",
+  "PLEASE_SPECIFY_REASON_FOR_CHANGE_OF_VOLUNTEER": "رضاڪار بدلائڻ جو سبب ٻڌايو",
+  "REASON": "سبب"
 }


### PR DESCRIPTION
Fixes #1224 (sub-task 3 - Change Volunteer dialog)

The Change Volunteer dialog was already implemented in RequestDescription.jsx.
Found that translation keys were missing in 2 language files:
- mai (Maithili)
- sd (Sindhi)

Keys added:
- CANCEL
- CHANGE_VOLUNTEER
- PLEASE_SPECIFY_REASON_FOR_CHANGE_OF_VOLUNTEER
- REASON