### PR TITLE
feat(#1247): AI disclaimer + initial-load indicator for More Info chat

### DIFF
--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
@@ -24,17 +24,27 @@ const counterColorClass = (remaining) => {
   return "bg-gray-400";
 };
 
-const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
+const MoreInfoChatModal = ({
+  show,
+  onClose,
+  requestData,
+  initialResponse,
+  isInitialLoading = false,
+}) => {
   const [messages, setMessages] = useState([]);
   const [remaining, setRemaining] = useState(MAX_QUESTIONS);
   const [inputText, setInputText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const chatEndRef = useRef(null);
 
-  // Seed initial AI message whenever initialResponse changes / modal opens
+  // Reset chat state on open; seed initial AI message once it arrives.
   useEffect(() => {
-    if (show && initialResponse) {
-      setMessages([{ role: "assistant", content: initialResponse }]);
+    if (show) {
+      setMessages(
+        initialResponse
+          ? [{ role: "assistant", content: initialResponse }]
+          : [],
+      );
       setRemaining(MAX_QUESTIONS);
       setInputText("");
     }
@@ -42,7 +52,7 @@ const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isLoading]);
+  }, [messages, isLoading, isInitialLoading]);
 
   if (!show) return null;
 
@@ -161,9 +171,17 @@ const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
             </div>
           ))}
 
-          {isLoading && (
-            <div className="flex justify-start">
-              <div className="bg-gray-100 text-gray-500 px-4 py-2 rounded-2xl rounded-bl-none text-sm italic">
+          {(isInitialLoading || isLoading) && (
+            <div
+              className="flex justify-start"
+              role="status"
+              aria-live="polite"
+            >
+              <div className="bg-gray-100 text-gray-500 px-4 py-2 rounded-2xl rounded-bl-none text-sm italic flex items-center gap-2">
+                <span
+                  className="inline-block w-3 h-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"
+                  aria-hidden="true"
+                />
                 Thinking…
               </div>
             </div>
@@ -186,24 +204,37 @@ const MoreInfoChatModal = ({ show, onClose, requestData, initialResponse }) => {
               if (e.target.value.length <= 250) setInputText(e.target.value);
             }}
             onKeyDown={handleKeyDown}
-            disabled={remaining === 0 || isLoading}
+            disabled={remaining === 0 || isLoading || isInitialLoading}
             rows={3}
             maxLength={250}
             placeholder={
-              remaining === 0
-                ? "No questions remaining"
-                : "Ask a follow-up question… (max 250 characters)"
+              isInitialLoading
+                ? "Loading initial response…"
+                : remaining === 0
+                  ? "No questions remaining"
+                  : "Ask a follow-up question… (max 250 characters)"
             }
             className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed resize-none"
           />
           <button
             onClick={handleSend}
-            disabled={remaining === 0 || isLoading || !inputText.trim()}
+            disabled={
+              remaining === 0 ||
+              isLoading ||
+              isInitialLoading ||
+              !inputText.trim()
+            }
             className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
           >
             Send
           </button>
         </div>
+
+        {/* AI disclaimer */}
+        <p className="px-3 pb-2 text-center text-xs text-gray-500">
+          Responses are AI-generated and may be inaccurate. Please verify
+          important information.
+        </p>
       </div>
     </div>
   );

--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
@@ -206,6 +206,54 @@ describe("MoreInfoChatModal", () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
+  it("shows Thinking… spinner and disables input while initial response is loading", () => {
+    render(
+      <MoreInfoChatModal
+        show={true}
+        onClose={mockOnClose}
+        requestData={mockRequestData}
+        initialResponse=""
+        isInitialLoading={true}
+      />,
+    );
+
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
+    const textarea = screen.getByPlaceholderText("Loading initial response…");
+    expect(textarea).toBeDisabled();
+    expect(screen.getByText("Send")).toBeDisabled();
+  });
+
+  it("hides spinner and renders assistant message once initialResponse arrives", () => {
+    const { rerender } = render(
+      <MoreInfoChatModal
+        show={true}
+        onClose={mockOnClose}
+        requestData={mockRequestData}
+        initialResponse=""
+        isInitialLoading={true}
+      />,
+    );
+
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
+    expect(screen.queryByText("Here are some resources for you.")).toBeNull();
+
+    rerender(
+      <MoreInfoChatModal
+        show={true}
+        onClose={mockOnClose}
+        requestData={mockRequestData}
+        initialResponse="Here are some resources for you."
+        isInitialLoading={false}
+      />,
+    );
+
+    expect(screen.queryByText("Thinking…")).toBeNull();
+    expect(
+      screen.getByText("Here are some resources for you."),
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).not.toBeDisabled();
+  });
+
   it("calls moreInformationChat with user_id, req_id, and conversation_history", async () => {
     moreInformationChat.mockResolvedValue({
       body: { answer: "Response." },

--- a/src/common/components/RequestButton/RequestButton.jsx
+++ b/src/common/components/RequestButton/RequestButton.jsx
@@ -45,6 +45,7 @@ const RequestButton = ({
   const [showCooldownDialog, setShowCooldownDialog] = useState(false);
   const [responseContent, setResponseContent] = useState(null);
   const [initialResponse, setInitialResponse] = useState("");
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
   const navigate = useNavigate();
   const { user } = useSelector((state) => state.auth);
 
@@ -77,12 +78,23 @@ const RequestButton = ({
           return;
         }
 
-        const aiReply = await moreInformationChat({
-          ...buildPayload(),
-          conversation_history: [],
-        });
-        setInitialResponse(aiReply?.body?.answer ?? "");
+        setInitialResponse("");
+        setIsInitialLoading(true);
         setShowModal(true);
+        try {
+          const aiReply = await moreInformationChat({
+            ...buildPayload(),
+            conversation_history: [],
+          });
+          setInitialResponse(aiReply?.body?.answer ?? "");
+        } catch (error) {
+          console.error("Error fetching data:", error);
+          setInitialResponse(
+            "An error occurred while fetching the information. Please try again.",
+          );
+        } finally {
+          setIsInitialLoading(false);
+        }
       } catch (error) {
         console.error("Error fetching data:", error);
         setResponseContent(
@@ -139,6 +151,7 @@ const RequestButton = ({
           onClose={handleChatClose}
           requestData={requestData}
           initialResponse={initialResponse}
+          isInitialLoading={isInitialLoading}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Add a subtle AI disclaimer below the chat input ("AI-generated responses may be inaccurate. Please verify important information.") so users have clear context about LLM output reliability.
- Open the More Info chat modal **immediately** on click and show a "Thinking…" spinner during the ~10s initial GenAI call. Previously the click awaited the API before opening the modal, so it felt unresponsive.
- Disable textarea/Send and swap placeholder while the initial response loads.
- Reset chat state cleanly on each open; surface initial-load failures inside the chat modal instead of leaving an empty modal.

Refs #1247.