### PR TITLE
fix: generate subject only on submit instead of while typing

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -314,7 +314,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
   // Auto-generate subject from description using the genai API (debounced).
   // Skipped in edit mode (preserves saved subject) and when the user has
   // manually typed their own subject.
-  useEffect(() => {
+  /*useEffect(() => {
     if (isEdit) return;
     if (hasUserEditedSubjectRef.current) return;
     if (!formData.description || formData.description.trim().length < 10)
@@ -333,7 +333,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [formData.description]);
+  }, [formData.description]); */
 
   // handleChange
   const handleChange = (e) => {
@@ -1028,6 +1028,22 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
         severity: "error",
       });
       return;
+    }
+
+    if (
+      !isEdit &&
+      !hasUserEditedSubjectRef.current &&
+      formData.description.trim().length >= 10
+    ) {
+      try {
+        const response = await generateSubject(formData.description);
+        const generatedSubject = response?.body?.subject;
+        if (generatedSubject) {
+          setFormData((prev) => ({ ...prev, subject: generatedSubject }));
+        }
+      } catch (error) {
+        console.error("Error generating subject:", error);
+      }
     }
 
     const submissionData = {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -506,6 +506,126 @@ describe("HelpRequestForm — predict categories modal", () => {
 
     expect(screen.queryByText(/Category updated from/)).not.toBeInTheDocument();
   });
+
+  it("shows full hierarchy in category field after AI suggested category is selected", async () => {
+    const {
+      checkProfanity,
+      predictCategories,
+    } = require("../../services/requestServices");
+
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    predictCategories.mockResolvedValue({
+      body: {
+        categories: [
+          {
+            category_number: "4.3.1",
+            category_name: "MATH",
+            confidence: 0.95,
+            hierarchy: "Education Career Support > Tutoring > Math",
+          },
+        ],
+      },
+    });
+
+    renderForm();
+
+    fireEvent.change(document.getElementById("description"), {
+      target: { name: "description", value: "I need help with math tutoring." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Math")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByDisplayValue("4.3.1"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Select" }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    //Category field should show full hierarchy
+    await waitFor(() => {
+      expect(document.getElementById("category").value).toBe(
+        "Education Career Support > Tutoring > Math",
+      );
+    });
+  });
+
+  it("uses category_number in payload not hierarchy string when submitting", async () => {
+    const {
+      checkProfanity,
+      predictCategories,
+      createRequest,
+    } = require("../../services/requestServices");
+    const {
+      mapHelpRequestPayload,
+    } = require("../../utils/mapHelpRequestPayload");
+
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    createRequest.mockResolvedValue({ data: { requestId: "REQ-123" } });
+    predictCategories.mockResolvedValue({
+      body: {
+        categories: [
+          {
+            category_number: "4.3.1",
+            category_name: "MATH",
+            confidence: 0.95,
+            hierarchy: "Education Career Support > Tutoring > Math",
+          },
+        ],
+      },
+    });
+
+    renderForm();
+
+    fireEvent.change(document.getElementById("description"), {
+      target: { name: "description", value: "I need help with math tutoring." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Math")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByDisplayValue("4.3.1"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Select" }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "mockTranslate(SUBMIT)" }),
+      );
+    });
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+
+    //Payload should use category_number not hierarchy string
+    const callArgs =
+      mapHelpRequestPayload.mock.calls[
+        mapHelpRequestPayload.mock.calls.length - 1
+      ][0];
+    expect(callArgs.selectedCategoryId).toBe("4.3.1");
+    expect(callArgs.selectedCategoryId).not.toBe(
+      "Education Career Support > Tutoring > Math",
+    );
+  });
 });
 
 describe("HelpRequestForm — generateSubject auto-fill", () => {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -540,7 +540,13 @@ describe("HelpRequestForm — generateSubject auto-fill", () => {
           value: "I need help picking up groceries from the store.",
         },
       });
-      jest.advanceTimersByTime(800);
+    });
+
+    expect(generateSubject).not.toHaveBeenCalled();
+
+    //generateSubject should be called on submit
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form"));
     });
 
     expect(generateSubject).toHaveBeenCalledWith(
@@ -597,7 +603,14 @@ describe("HelpRequestForm — generateSubject auto-fill", () => {
           value: "I need help picking up groceries from the store.",
         },
       });
-      jest.advanceTimersByTime(800);
+    });
+
+    //generateSubject should NOT be called while typing
+    expect(generateSubject).not.toHaveBeenCalled();
+
+    //generateSubject should be called on submit
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form"));
     });
 
     expect(generateSubject).toHaveBeenCalled();
@@ -627,7 +640,11 @@ describe("HelpRequestForm — generateSubject auto-fill", () => {
           value: "I need help picking up groceries from the store.",
         },
       });
-      jest.advanceTimersByTime(800);
+    });
+
+    //Even on submit, should not overwrite manually typed subject
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form"));
     });
 
     expect(generateSubject).not.toHaveBeenCalled();


### PR DESCRIPTION
- Commented useEffect that called generateSubject on description change
- Added generateSubject call in handleSubmit before form submission
- Subject auto-fills only when Submit button is clicked
- Prevents unnecessary API calls while user is still typing

Fixes #1384