### PR TITLE
feat: implement ISO Alpha-2 country dropdown with backward compatibility for signup, profile page

### DIFF
--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -5,6 +5,7 @@ import { IoEyeOffOutline, IoEyeOutline } from "react-icons/io5";
 import { isValidPhoneNumber } from "react-phone-number-input";
 import { useNavigate } from "react-router-dom";
 import { z } from "zod";
+import CountryList from "react-select-country-list";
 import PhoneNumberInputWithCountry from "../../common/components/PhoneNumberInputWithCountry";
 import PHONECODESEN from "../../utils/phone-codes-en";
 import "./Login.css";
@@ -50,7 +51,8 @@ const SignUp = () => {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [phone, setPhone] = useState("");
-  const [country, setCountry] = useState("United States");
+  const countries = CountryList().getData();
+  const [country, setCountry] = useState("US");
   const [confirmPasswordValue, setConfirmPasswordValue] = useState("");
   const [countryCode, setCountryCode] = useState("US");
   const [acceptedTOS, setAcceptedTOS] = useState(false);
@@ -241,19 +243,14 @@ const SignUp = () => {
           <select
             id="country"
             value={country}
-            disabled={true}
             onChange={(e) => setCountry(e.target.value)}
             className="px-4 py-2 border border-gray-300 rounded-xl"
           >
-            {/**
-            <option value="">Select your country</option>
-            {countries.map((option) => (
-              <option key={option.value} value={option.label}>
-                {option.label}
+            {countries.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
               </option>
             ))}
-             */}
-            <option value="United States">{t("UNITED_STATES")}</option>
           </select>
         </div>
 

--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -94,7 +94,10 @@ function PersonalInformation({ setHasUnsavedChanges }) {
 
   const getCountryCodeFromZoneInfo = useCallback((zoneinfo) => {
     if (!zoneinfo) return "";
-    return countryNameToCode[zoneinfo] || "";
+    if (countryNameToCode[zoneinfo]) return countryNameToCode[zoneinfo];
+    if (zoneinfo.length === 2 && zoneinfo === zoneinfo.toUpperCase())
+      return zoneinfo;
+    return "";
   }, []);
 
   const localizedGenderOptions = useMemo(
@@ -604,6 +607,9 @@ function PersonalInformation({ setHasUnsavedChanges }) {
                   {errors.country}
                 </p>
               )}
+              <p className="text-xs text-gray-500 mt-1">
+                To change your country, update it in Your Profile.
+              </p>
             </>
           ) : (
             <p className="text-lg text-gray-900">

--- a/src/pages/Profile/YourProfile.jsx
+++ b/src/pages/Profile/YourProfile.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import PHONECODESEN from "../../utils/phone-codes-en";
 import CountryList from "react-select-country-list";
+import { resolveCountryIso } from "../../utils/countryUtils";
 import { FiPhoneCall, FiVideo } from "react-icons/fi";
 import { FaWhatsapp } from "react-icons/fa";
 
@@ -99,8 +100,7 @@ function YourProfile({ setHasUnsavedChanges }) {
   useEffect(() => {
     if (!user) return;
 
-    const zoneIso =
-      getIsoFromCountryLabel(user.zoneinfo || "United States") || "US";
+    const zoneIso = resolveCountryIso(user.zoneinfo);
 
     let parsedIso = null;
     if (user.phone_number && user.phone_number.startsWith("+")) {
@@ -130,7 +130,7 @@ function YourProfile({ setHasUnsavedChanges }) {
       email: userEmail,
       phone: digits,
       phoneCountryCode: finalIso,
-      country: user.zoneinfo || "",
+      country: resolveCountryIso(user.zoneinfo),
     });
 
     // keep the ContactUs-style phone component in sync
@@ -205,7 +205,6 @@ function YourProfile({ setHasUnsavedChanges }) {
       if (saveError && saveError.includes("email")) setSaveError("");
       if (showEmailVerificationMessage) setShowEmailVerificationMessage(false);
     } else if (name === "country") {
-      const nextIso = getIsoFromCountryLabel(value);
       setProfileInfo((prev) => ({
         ...prev,
         country: value,
@@ -412,8 +411,7 @@ function YourProfile({ setHasUnsavedChanges }) {
 
   const resetFormData = () => {
     if (user) {
-      const zoneIso =
-        getIsoFromCountryLabel(user.zoneinfo || "United States") || "US";
+      const zoneIso = resolveCountryIso(user.zoneinfo);
 
       let parsedIso = null;
       if (user.phone_number && user.phone_number.startsWith("+")) {
@@ -437,7 +435,7 @@ function YourProfile({ setHasUnsavedChanges }) {
           stripDialOnce(user.phone_number || "", finalIso),
         ),
         phoneCountryCode: finalIso,
-        country: user.zoneinfo || "",
+        country: resolveCountryIso(user.zoneinfo),
       });
 
       // keep shared phone component in sync
@@ -618,10 +616,17 @@ function YourProfile({ setHasUnsavedChanges }) {
             onChange={(e) => handleInputChange("country", e.target.value)}
             className="block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 focus:outline-none"
           >
-            <option value="United States">United States</option>
+            {countries.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
           </select>
         ) : (
-          <p className="text-lg text-gray-900">{profileInfo.country}</p>
+          <p className="text-lg text-gray-900">
+            {countries.find((c) => c.value === profileInfo.country)?.label ||
+              profileInfo.country}
+          </p>
         )}
       </div>
 

--- a/src/pages/Profile/your-profile.test.js
+++ b/src/pages/Profile/your-profile.test.js
@@ -119,7 +119,7 @@ const mockUser = {
   family_name: "Doe",
   email: "john@example.com",
   phone_number: "+12345678901", // good: strips to 2345678901 (10 digits)
-  zoneinfo: "United States",
+  zoneinfo: "US",
 };
 
 const defaultStore = createMockStore({

--- a/src/utils/countryUtils.js
+++ b/src/utils/countryUtils.js
@@ -1,0 +1,15 @@
+import countryCodes from "./country-codes-en.json";
+
+const countryNameToCode = Object.entries(countryCodes).reduce(
+  (acc, [code, name]) => {
+    acc[name] = code;
+    return acc;
+  },
+  {},
+);
+
+export const resolveCountryIso = (zoneinfo) => {
+  if (!zoneinfo) return "US";
+  if (countryCodes[zoneinfo]) return zoneinfo;
+  return countryNameToCode[zoneinfo] || "US";
+};

--- a/src/utils/countryUtils.test.js
+++ b/src/utils/countryUtils.test.js
@@ -1,0 +1,35 @@
+import { resolveCountryIso } from "./countryUtils";
+
+describe("resolveCountryIso", () => {
+  it("returns US for null", () => {
+    expect(resolveCountryIso(null)).toBe("US");
+  });
+
+  it("returns US for undefined", () => {
+    expect(resolveCountryIso(undefined)).toBe("US");
+  });
+
+  it("returns US for empty string", () => {
+    expect(resolveCountryIso("")).toBe("US");
+  });
+
+  it("returns ISO as-is when already a valid ISO Alpha-2 code", () => {
+    expect(resolveCountryIso("US")).toBe("US");
+  });
+
+  it("returns correct ISO for another valid Alpha-2 code", () => {
+    expect(resolveCountryIso("AR")).toBe("AR");
+  });
+
+  it("converts full country name to ISO Alpha-2", () => {
+    expect(resolveCountryIso("United States")).toBe("US");
+  });
+
+  it("converts another full country name to ISO Alpha-2", () => {
+    expect(resolveCountryIso("Argentina")).toBe("AR");
+  });
+
+  it("falls back to US for unrecognized string", () => {
+    expect(resolveCountryIso("Narnia")).toBe("US");
+  });
+});


### PR DESCRIPTION
- Enable country dropdown on Signup with full country list (ISO Alpha-2 values)
- Update YourProfile country dropdown to use full country list (ISO Alpha-2)
- Resolve country display from ISO Alpha-2 to full name in YourProfile
- Add resolveCountryIso() helper in countryUtils.js for legacy full-name migration
- Extend getCountryCodeFromZoneInfo() to handle ISO Alpha-2 passthrough in PersonalInformation
- Add update-in-Your-Profile hint below read-only country field
- Update your-profile test mockUser.zoneinfo to ISO Alpha-2 (US) and regenerate snapshot

Related #1428