### PR TITLE
fix(profile): add General skill fallback warning

### DIFF
--- a/src/pages/Profile/Skills.jsx
+++ b/src/pages/Profile/Skills.jsx
@@ -1,114 +1,31 @@
 import { List, ListItem, ListItemText } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useImmer } from "use-immer";
 import { useSelector } from "react-redux";
+import {
+  fetchUserSkills,
+  updateUserSkills,
+} from "../../services/volunteerServices";
+import VolunteerSkills from "../Volunteer/steps/Skills";
 
 const Skills = ({ setHasUnsavedChanges }) => {
   const { t } = useTranslation(["profile", "categories"]);
   const [isEditing, setIsEditing] = useState(false);
-  const mockCategories = {
-    Books: { checked: true },
-    Education: {
-      checked: true,
-      Elementary: { checked: true },
-      "Middle School": { checked: true },
-    },
-    Gardening: { checked: true },
-    Matrimonial: { checked: true },
-    Shopping: { checked: true },
-  };
-  const [checkedCategories, setCheckedCategories] = useImmer(mockCategories);
   const [categoriesData, setCategoriesData] = useState([]);
   const [savedSkills, setSavedSkills] = useState([]);
+  const [selectedSkills, setSelectedSkills] = useState([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const categories = useSelector((state) => state.request?.categories || []);
-
-  const getCategoryName = (cat) =>
-    typeof cat === "object" ? cat.catName || cat.category : cat;
-
-  const getSubCategories = (cat) =>
-    typeof cat === "object" ? cat.subCategories || [] : [];
-  const translateCategory = (categoryName, parentPath = "") => {
-    if (!categoryName) return "";
-    if (parentPath) {
-      const parentKey = parentPath.split(".")[0];
-      return t(
-        `categories:REQUEST_CATEGORIES.${parentKey}.SUBCATEGORIES.${categoryName}.LABEL`,
-        { defaultValue: categoryName },
-      );
-    }
-    return t(`categories:REQUEST_CATEGORIES.${categoryName}.LABEL`, {
-      defaultValue: categoryName,
-    });
-  };
-
-  const resolveSkillLabel = (skillId) => {
-    if (!skillId) return "";
-    const id = String(skillId);
-    const top = categoriesData.find(
-      (c) => String(c.catId) === id || c.catName === id,
-    );
-    if (top) return translateCategory(top.catName);
-
-    for (const c of categoriesData) {
-      const sub = (c.subCategories || []).find(
-        (s) => String(s.catId) === id || s.catName === id,
-      );
-      if (sub) {
-        return translateCategory(sub.catName, c.catName);
-      }
-
-      for (const s of c.subCategories || []) {
-        const subSub = (s.subCategories || []).find(
-          (ss) => String(ss.catId) === id || ss.catName === id,
-        );
-        if (subSub) {
-          return t(
-            `categories:REQUEST_CATEGORIES.${c.catName}.SUBCATEGORIES.${s.catName}.SUBCATEGORIES.${subSub.catName}.LABEL`,
-            { defaultValue: subSub.catName },
-          );
-        }
-      }
-    }
-
-    return skillId;
-  };
-
-  const getSelectedSkills = (categories, parentPath = "") => {
-    return categories.map((cat, index) => {
-      const categoryName = getCategoryName(cat);
-      const subCategories = getSubCategories(cat);
-      const hasSubCategories = subCategories.length > 0;
-      const currentPath = parentPath
-        ? `${parentPath}.${categoryName}`
-        : categoryName;
-      if (!getCheckedStatus(currentPath)) return;
-      return (
-        <div className="flex flex-col" disablePadding key={index}>
-          <ListItem className="" disablePadding>
-            <ListItemText
-              primary={`• ${translateCategory(categoryName, parentPath)}`}
-            />
-          </ListItem>
-          {hasSubCategories && getCheckedStatus(currentPath) && (
-            <div className="ml-5" disablePadding>
-              <List className="" disablePadding>
-                {getSelectedSkills(subCategories, currentPath)}
-              </List>
-            </div>
-          )}
-        </div>
-      );
-    });
-  };
+  const userDbId = useSelector((state) => state.auth?.user?.userDbId);
 
   useEffect(() => {
     if (categories && categories.length > 0) {
       setCategoriesData(categories);
       return;
     }
-
     const stored = localStorage.getItem("categories");
     if (stored) {
       try {
@@ -120,103 +37,123 @@ const Skills = ({ setHasUnsavedChanges }) => {
   }, [categories]);
 
   useEffect(() => {
-    const storedSkills = localStorage.getItem("volunteer_skills");
-    if (storedSkills) {
+    if (!userDbId) return;
+    const loadSkills = async () => {
       try {
-        setSavedSkills(JSON.parse(storedSkills));
-      } catch (e) {
-        console.warn("Failed to parse volunteer skills:", e);
+        const response = await fetchUserSkills(userDbId);
+        const skills = response?.data?.skills || [];
+        const skillIds = skills.map((s) => String(s));
+        setSavedSkills(skillIds);
+        setSelectedSkills(skillIds);
+        setLoadError(false);
+      } catch (error) {
+        console.error("Failed to fetch user skills from API:", error);
+        setLoadError(true);
+      }
+    };
+    loadSkills();
+  }, [userDbId]);
+
+  const resolveSkillLabel = (skillId) => {
+    if (!skillId) return "";
+    const id = String(skillId);
+    for (const c of categoriesData) {
+      if (String(c.catId) === id)
+        return t(`categories:REQUEST_CATEGORIES.${c.catName}.LABEL`, {
+          defaultValue: c.catName,
+        });
+      for (const s of c.subCategories || []) {
+        if (String(s.catId) === id)
+          return t(
+            `categories:REQUEST_CATEGORIES.${c.catName}.SUBCATEGORIES.${s.catName}.LABEL`,
+            { defaultValue: s.catName },
+          );
+        for (const ss of s.subCategories || []) {
+          if (String(ss.catId) === id)
+            return t(
+              `categories:REQUEST_CATEGORIES.${c.catName}.SUBCATEGORIES.${s.catName}.SUBCATEGORIES.${ss.catName}.LABEL`,
+              { defaultValue: ss.catName },
+            );
+        }
       }
     }
-  }, []);
-
-  const getCheckedStatus = (categoryPath) => {
-    const keys = categoryPath.split(".");
-    let currentLevel = checkedCategories || {};
-
-    for (let key of keys) {
-      if (!currentLevel[key]) return false;
-      currentLevel = currentLevel[key];
-    }
-
-    return currentLevel.checked;
+    return skillId;
   };
 
-  const handleCheckboxChange = (categoryPath) => {
-    setCheckedCategories((draft) => {
-      const checkedStatus = getCheckedStatus(categoryPath);
-      setCheckboxState(draft, categoryPath, !checkedStatus);
-    });
+  const getGeneralCategoryId = () => {
+    const generalCategory = categoriesData.find(
+      (category) => category.catName === "GENERAL_CATEGORY",
+    );
+    return generalCategory?.catId ? String(generalCategory.catId) : null;
   };
 
-  const setCheckboxState = (draft, categoryPath, checked) => {
-    const keys = categoryPath.split(".");
-    let currentLevel = draft;
-
-    keys.forEach((key, index) => {
-      if (index === keys.length - 1) {
-        if (checked) {
-          currentLevel[key] = { checked: true };
-        } else {
-          delete currentLevel[key];
-        }
-      } else {
-        if (!currentLevel[key]) {
-          currentLevel[key] = {};
-        }
-        currentLevel = currentLevel[key];
-      }
-    });
+  const handleEdit = () => {
+    setSelectedSkills(savedSkills);
+    setSaveError(false);
+    setIsEditing(true);
   };
 
-  const renderCategories = (categories, parentPath = "") => {
-    return categories.map((cat, index) => {
-      const categoryName = getCategoryName(cat);
-      const subCategories = getSubCategories(cat);
-      const hasSubCategories = subCategories.length > 0;
-      const currentPath = parentPath
-        ? `${parentPath}.${categoryName}`
-        : categoryName;
-
-      return (
-        <div key={index} className="ml-4 mb-2">
-          <label className="inline-flex items-center space-x-2">
-            <input
-              type="checkbox"
-              className="h-4 w-4"
-              checked={getCheckedStatus(currentPath)}
-              onChange={() => handleCheckboxChange(currentPath)}
-            />
-            <span className={getCheckedStatus(currentPath) ? "font-bold" : ""}>
-              {translateCategory(categoryName, parentPath)}
-            </span>
-          </label>
-
-          {hasSubCategories && getCheckedStatus(currentPath) && (
-            <div className="ml-3">
-              {renderCategories(subCategories, currentPath)}
-            </div>
-          )}
-        </div>
-      );
-    });
+  const handleCancel = () => {
+    setSelectedSkills(savedSkills);
+    setSaveError(false);
+    setIsEditing(false);
+    setHasUnsavedChanges(false);
   };
 
   const handleSave = async () => {
     try {
+      setIsSaving(true);
+      setSaveError(false);
+      let skillsToSave = selectedSkills.map((skill) => String(skill));
+      if (skillsToSave.length === 0) {
+        const generalId = getGeneralCategoryId();
+        if (!generalId) {
+          setSaveError(true);
+          return;
+        }
+        skillsToSave = [generalId];
+      }
+      await updateUserSkills(userDbId, skillsToSave);
+      setSavedSkills(skillsToSave);
+      setSelectedSkills(skillsToSave);
       setIsEditing(false);
       setHasUnsavedChanges(false);
     } catch (error) {
       console.error("Error saving skills:", error);
+      setSaveError(true);
+    } finally {
+      setIsSaving(false);
     }
   };
 
   return (
     <div className="p-6">
+      {loadError && (
+        <p className="text-red-500 text-sm mb-4">
+          Failed to load skills. Please refresh the page and try again.
+        </p>
+      )}
       <div className="bg-white rounded-lg shadow p-6">
         <div className="space-y-4">
           {isEditing ? (
-            renderCategories(categoriesData)
+            <>
+              <VolunteerSkills
+                selectedSkills={selectedSkills}
+                setSelectedSkills={(skills) => {
+                  setSelectedSkills(skills);
+                  setHasUnsavedChanges(true);
+                }}
+                categories={categoriesData}
+              />
+              {selectedSkills.length === 0 && (
+                <p className="text-amber-600 text-sm">
+                  {t(
+                    "profile:SKILLS_REQUIRED_GENERAL_FALLBACK",
+                    "At least one skill is required. If no skill is selected, General will be saved by default.",
+                  )}
+                </p>
+              )}
+            </>
           ) : savedSkills.length > 0 ? (
             <List className="flex flex-col" disablePadding>
               {savedSkills.map((skill, idx) => (
@@ -226,39 +163,44 @@ const Skills = ({ setHasUnsavedChanges }) => {
               ))}
             </List>
           ) : (
-            <List className="flex flex-col" disablePadding>
-              {getSelectedSkills(categoriesData)}
-            </List>
+            <p className="text-sm text-gray-400 italic">
+              {t("profile:NO_SKILLS") || "No skills added yet."}
+            </p>
           )}
         </div>
       </div>
-      <div className="flex flex-row justify-center items-center gap-3 mb-6 mt-4">
-        {isEditing ? (
-          <>
+      <div className="flex flex-col items-center gap-2 mb-6 mt-4">
+        {saveError && (
+          <p className="text-red-500 text-sm text-center">
+            Failed to save skills. Please try again.
+          </p>
+        )}
+        <div className="flex flex-row gap-3">
+          {isEditing ? (
+            <>
+              <button
+                onClick={handleSave}
+                disabled={isSaving}
+                className="flex items-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50"
+              >
+                {isSaving ? t("SAVING") || "Saving..." : t("SAVE")}
+              </button>
+              <button
+                onClick={handleCancel}
+                className="flex items-center px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+              >
+                {t("CANCEL")}
+              </button>
+            </>
+          ) : (
             <button
-              onClick={handleSave}
+              onClick={handleEdit}
               className="flex items-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
             >
-              {t("SAVE")}
+              {t("EDIT")}
             </button>
-            <button
-              onClick={() => {
-                setIsEditing(false);
-                setHasUnsavedChanges(false);
-              }}
-              className="flex items-center px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
-            >
-              {t("CANCEL")}
-            </button>
-          </>
-        ) : (
-          <button
-            onClick={() => setIsEditing(true)}
-            className="flex items-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-          >
-            {t("EDIT")}
-          </button>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Profile/Skills.test.jsx
+++ b/src/pages/Profile/Skills.test.jsx
@@ -1,0 +1,218 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import Skills from "./Skills";
+import {
+  fetchUserSkills,
+  updateUserSkills,
+} from "../../services/volunteerServices";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, options) => {
+      if (typeof options === "string") return options;
+      return options?.defaultValue || key;
+    },
+    i18n: { language: "en" },
+  }),
+}));
+
+jest.mock("../../services/volunteerServices", () => ({
+  fetchUserSkills: jest.fn(),
+  updateUserSkills: jest.fn(),
+}));
+
+jest.mock("../Volunteer/steps/Skills", () => {
+  return function VolunteerSkillsMock({ selectedSkills, setSelectedSkills }) {
+    return (
+      <div data-testid="volunteer-skills">
+        <span>Selected count: {selectedSkills.length}</span>
+        <button type="button" onClick={() => setSelectedSkills([])}>
+          Clear skills
+        </button>
+        <button type="button" onClick={() => setSelectedSkills([4.2])}>
+          Select numeric skill
+        </button>
+      </div>
+    );
+  };
+});
+
+const categories = [
+  {
+    catId: "0.0.0.0.0",
+    catName: "GENERAL_CATEGORY",
+    subCategories: [],
+  },
+  {
+    catId: "4",
+    catName: "EDUCATION",
+    subCategories: [
+      {
+        catId: "4.2",
+        catName: "TUTORING",
+        subCategories: [],
+      },
+      {
+        catId: "4.3",
+        catName: "LANGUAGE",
+        subCategories: [
+          {
+            catId: "4.3.1",
+            catName: "SPANISH",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const renderSkills = ({
+  requestCategories = categories,
+  setHasUnsavedChanges = jest.fn(),
+} = {}) => {
+  const store = configureStore({
+    reducer: {
+      auth: () => ({ user: { userDbId: "SID-123" } }),
+      request: () => ({ categories: requestCategories }),
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <Skills setHasUnsavedChanges={setHasUnsavedChanges} />
+    </Provider>,
+  );
+};
+
+describe("Profile Skills", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchUserSkills.mockResolvedValue({ data: { skills: [] } });
+    updateUserSkills.mockResolvedValue({ success: true });
+  });
+
+  it("shows the General fallback warning before save when no skills are selected", async () => {
+    renderSkills();
+
+    await waitFor(() =>
+      expect(fetchUserSkills).toHaveBeenCalledWith("SID-123"),
+    );
+    fireEvent.click(screen.getByText("EDIT"));
+
+    expect(
+      screen.getByText(
+        "At least one skill is required. If no skill is selected, General will be saved by default.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("saves General category as the fallback when no skills are selected", async () => {
+    renderSkills();
+
+    await waitFor(() =>
+      expect(fetchUserSkills).toHaveBeenCalledWith("SID-123"),
+    );
+    fireEvent.click(screen.getByText("EDIT"));
+    fireEvent.click(screen.getByText("SAVE"));
+
+    await waitFor(() =>
+      expect(updateUserSkills).toHaveBeenCalledWith("SID-123", ["0.0.0.0.0"]),
+    );
+  });
+
+  it("saves selected skill IDs as strings and hides the fallback warning", async () => {
+    renderSkills();
+
+    await waitFor(() =>
+      expect(fetchUserSkills).toHaveBeenCalledWith("SID-123"),
+    );
+    fireEvent.click(screen.getByText("EDIT"));
+    fireEvent.click(screen.getByText("Select numeric skill"));
+
+    expect(
+      screen.queryByText(
+        "At least one skill is required. If no skill is selected, General will be saved by default.",
+      ),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("SAVE"));
+
+    await waitFor(() =>
+      expect(updateUserSkills).toHaveBeenCalledWith("SID-123", ["4.2"]),
+    );
+  });
+
+  it("renders saved skill labels from category hierarchy", async () => {
+    fetchUserSkills.mockResolvedValue({
+      data: { skills: ["0.0.0.0.0", "4.2", "4.3.1", "unknown"] },
+    });
+
+    renderSkills();
+
+    expect(await screen.findByText("• GENERAL_CATEGORY")).toBeInTheDocument();
+    expect(screen.getByText("• TUTORING")).toBeInTheDocument();
+    expect(screen.getByText("• SPANISH")).toBeInTheDocument();
+    expect(screen.getByText("• unknown")).toBeInTheDocument();
+  });
+
+  it("shows load and save errors when API calls fail", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    fetchUserSkills.mockRejectedValueOnce(new Error("load failed"));
+
+    renderSkills();
+
+    expect(
+      await screen.findByText(
+        "Failed to load skills. Please refresh the page and try again.",
+      ),
+    ).toBeInTheDocument();
+
+    fetchUserSkills.mockResolvedValueOnce({ data: { skills: ["4.2"] } });
+    updateUserSkills.mockRejectedValueOnce(new Error("save failed"));
+    renderSkills();
+
+    await waitFor(() => expect(fetchUserSkills).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getAllByText("EDIT")[1]);
+    fireEvent.click(screen.getByText("SAVE"));
+
+    expect(
+      await screen.findByText("Failed to save skills. Please try again."),
+    ).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  it("shows save error when empty skills have no General fallback category", async () => {
+    renderSkills({ requestCategories: categories.slice(1) });
+
+    await waitFor(() =>
+      expect(fetchUserSkills).toHaveBeenCalledWith("SID-123"),
+    );
+    fireEvent.click(screen.getByText("EDIT"));
+    fireEvent.click(screen.getByText("SAVE"));
+
+    expect(
+      await screen.findByText("Failed to save skills. Please try again."),
+    ).toBeInTheDocument();
+    expect(updateUserSkills).not.toHaveBeenCalled();
+  });
+
+  it("cancels editing and clears unsaved changes", async () => {
+    const setHasUnsavedChanges = jest.fn();
+    fetchUserSkills.mockResolvedValue({ data: { skills: ["4.2"] } });
+
+    renderSkills({ setHasUnsavedChanges });
+
+    await screen.findByText("• TUTORING");
+    fireEvent.click(screen.getByText("EDIT"));
+    fireEvent.click(screen.getByText("Clear skills"));
+    fireEvent.click(screen.getByText("CANCEL"));
+
+    expect(screen.getByText("• TUTORING")).toBeInTheDocument();
+    expect(setHasUnsavedChanges).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/pages/Volunteer/PromoteToVolunteer.jsx
+++ b/src/pages/Volunteer/PromoteToVolunteer.jsx
@@ -10,6 +10,7 @@ import VolunteerCourse from "./steps/VolunteerCourse";
 import {
   createVolunteer,
   updateVolunteer,
+  updateUserSkills,
 } from "../../services/volunteerServices";
 import { getCurrentUser } from "aws-amplify/auth";
 import axios from "axios";
@@ -23,6 +24,7 @@ const PromoteToVolunteer = () => {
   const [isAcknowledged, setIsAcknowledged] = useState(false);
   const [govtIdFile, setGovtIdFile] = useState(null);
   const token = useSelector((state) => state.auth.idToken);
+  const userDbId = useSelector((state) => state.auth?.user?.userDbId);
   const [selectedSkills, setSelectedSkills] = useState([]);
   const [categories, setCategories] = useState([]);
   const [availabilitySlots, setAvailabilitySlots] = useState([
@@ -171,11 +173,16 @@ const PromoteToVolunteer = () => {
             userId: userId,
             skills: extractSkillsFromArray(selectedSkills),
           });
-          // TEMP: persist selected skills locally so Profile → Skills can display them
-          localStorage.setItem(
-            "volunteer_skills",
-            JSON.stringify(selectedSkills),
-          );
+          if (isValidStep && userDbId) {
+            try {
+              const skillsToSave = selectedSkills.map((skill) => String(skill));
+              await updateUserSkills(userDbId, skillsToSave);
+            } catch (skillError) {
+              console.error("Failed to save skills to API:", skillError);
+              setErrorMessage("Failed to save skills. Please try again.");
+              isValidStep = false;
+            }
+          }
           break;
         }
         case 4: {

--- a/src/services/endpoints.json
+++ b/src/services/endpoints.json
@@ -6,6 +6,7 @@
   "GET_VOLUNTEERS_DATA": "v1/volunteer/getVolunteersData",
   "GET_VOLUNTEER_ORGS_LIST": "v1/volunteerorgs/organizations-list",
   "GET_VOLUNTEER_SKILLS": "v1/volunteer/skills",
+  "PROFILE_SKILLS": "v1/volunteer/profileSkills",
   "GET_REQUEST_COMMENTS": "v1/request/getComments",
   "CREATE_VOLUNTEER": "v1/volunteer/createNewVolunteer",
   "UPDATE_VOLUNTEER": "v1/volunteer/updateVolunteer",

--- a/src/services/volunteerServices.js
+++ b/src/services/volunteerServices.js
@@ -10,6 +10,41 @@ export const getVolunteerSkills = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_SKILLS);
   return response.data;
 };
+
+/**
+ * Fetch user skills by userId
+ * @param {string} userId - The user's database ID (e.g., "SID-00-000-002-10000")
+ * @returns {Promise<Object>} - Returns { userId: string, skills: string[] }
+ */
+export const fetchUserSkills = async (userId) => {
+  const response = await api.post(endpoints.PROFILE_SKILLS, { userId });
+  return response.data;
+};
+
+/**
+ * Update user skills (replaces entire skills list)
+ * @param {string} userId - The user's database ID
+ * @param {string[]} skills - Array of skill IDs (e.g., ["0.0.0.0.0", "4.2"])
+ * @returns {Promise<Object>} - API response
+ */
+export const updateUserSkills = async (userId, skills) => {
+  const response = await api.put(endpoints.PROFILE_SKILLS, { userId, skills });
+  return response.data;
+};
+
+/**
+ * Delete user skills by sending empty list or updated list
+ * Internally uses update logic - skills not in list will be removed
+ * @param {string} userId - The user's database ID
+ * @param {string[]} skills - Remaining skills after deletion
+ * @returns {Promise<Object>} - API response
+ */
+export const deleteUserSkills = async (userId, skills) => {
+  const response = await api.delete(endpoints.PROFILE_SKILLS, {
+    data: { userId, skills },
+  });
+  return response.data;
+};
 export const createVolunteer = async (volunteerData) => {
   const response = await api.post(endpoints.CREATE_VOLUNTEER, volunteerData);
   return response.data;

--- a/src/services/volunteerServices.test.js
+++ b/src/services/volunteerServices.test.js
@@ -1,5 +1,12 @@
 import api from "./api";
 import {
+  getVolunteerOrgsList,
+  getVolunteerSkills,
+  fetchUserSkills,
+  deleteUserSkills,
+  createVolunteer,
+  updateVolunteer,
+  getVolunteersData,
   uploadProfileImage,
   deleteProfileImage,
   fetchProfileImage,
@@ -12,6 +19,77 @@ jest.mock("./api");
 jest.mock("../utils/fileToBase64", () => ({
   fileToBase64: jest.fn(() => Promise.resolve("data:image/jpeg;base64,abc")),
 }));
+
+describe("volunteerServices volunteer data APIs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches volunteer organizations", async () => {
+    api.get.mockResolvedValue({ data: { body: ["org"] } });
+
+    await expect(getVolunteerOrgsList()).resolves.toEqual({ body: ["org"] });
+    expect(api.get).toHaveBeenCalledWith("v1/volunteerorgs/organizations-list");
+  });
+
+  it("fetches volunteer skills", async () => {
+    api.get.mockResolvedValue({ data: { body: ["skill"] } });
+
+    await expect(getVolunteerSkills()).resolves.toEqual({ body: ["skill"] });
+    expect(api.get).toHaveBeenCalledWith("v1/volunteer/skills");
+  });
+
+  it("fetches profile skills by user ID", async () => {
+    api.post.mockResolvedValue({ data: { skills: ["0.0.0.0.0"] } });
+
+    await expect(fetchUserSkills("SID-123")).resolves.toEqual({
+      skills: ["0.0.0.0.0"],
+    });
+    expect(api.post).toHaveBeenCalledWith("v1/volunteer/profileSkills", {
+      userId: "SID-123",
+    });
+  });
+
+  it("deletes profile skills with a JSON body", async () => {
+    api.delete.mockResolvedValue({ data: { success: true } });
+
+    await expect(deleteUserSkills("SID-123", ["4.2"])).resolves.toEqual({
+      success: true,
+    });
+    expect(api.delete).toHaveBeenCalledWith("v1/volunteer/profileSkills", {
+      data: { userId: "SID-123", skills: ["4.2"] },
+    });
+  });
+
+  it("creates and updates volunteers", async () => {
+    api.post.mockResolvedValueOnce({ data: { created: true } });
+    api.put.mockResolvedValueOnce({ data: { updated: true } });
+
+    await expect(createVolunteer({ userId: "SID-123" })).resolves.toEqual({
+      created: true,
+    });
+    await expect(updateVolunteer({ userId: "SID-123" })).resolves.toEqual({
+      updated: true,
+    });
+    expect(api.post).toHaveBeenCalledWith("v1/volunteer/createNewVolunteer", {
+      userId: "SID-123",
+    });
+    expect(api.put).toHaveBeenCalledWith("v1/volunteer/updateVolunteer", {
+      userId: "SID-123",
+    });
+  });
+
+  it("normalizes volunteer data responses", async () => {
+    api.get.mockResolvedValueOnce({ data: { body: [{ id: 1 }] } });
+    await expect(getVolunteersData()).resolves.toEqual([{ id: 1 }]);
+
+    api.get.mockResolvedValueOnce({ data: [{ id: 2 }] });
+    await expect(getVolunteersData()).resolves.toEqual([{ id: 2 }]);
+
+    api.get.mockResolvedValueOnce({ data: { body: null } });
+    await expect(getVolunteersData()).resolves.toEqual([]);
+  });
+});
 
 describe("volunteerServices profile image", () => {
   beforeEach(() => {

--- a/src/services/volunteerServices.test.js
+++ b/src/services/volunteerServices.test.js
@@ -5,6 +5,7 @@ import {
   fetchProfileImage,
   signOffUser,
   getUserId,
+  updateUserSkills,
 } from "./volunteerServices";
 
 jest.mock("./api");
@@ -167,6 +168,24 @@ describe("signOffUser", () => {
     await expect(signOffUser("SID-00-000-001")).rejects.toThrow(
       "Network error",
     );
+  });
+});
+
+describe("updateUserSkills", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends skill IDs as strings, including dotted category IDs", async () => {
+    api.put.mockResolvedValue({ data: { success: true } });
+
+    const result = await updateUserSkills("SID-123", ["0.0.0.0.0", "4.2"]);
+
+    expect(api.put).toHaveBeenCalledWith("v1/volunteer/profileSkills", {
+      userId: "SID-123",
+      skills: ["0.0.0.0.0", "4.2"],
+    });
+    expect(result).toEqual({ success: true });
   });
 });
 


### PR DESCRIPTION
Show a warning in the profile skills editor when no skills are selected, letting users know that at least one skill is expected and General will be saved by default. Preserve the frontend fallback behavior by saving the GENERAL_CATEGORY skill ID when the user saves with an empty selection.

Note: this is a frontend-only change. The backend team is yet to update the API to enforce the same fallback or validation for empty skill submissions.