### PR TITLE
feat(#1247): styled alert banners for AI disclaimer and cooldown notice

### DIFF
--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import Markdown from "react-markdown";
+import { IoMdInformationCircle } from "react-icons/io";
 import { moreInformationChat } from "../../../services/requestServices";
 import i18n from "../../i18n/i18n";
 
@@ -231,10 +232,16 @@ const MoreInfoChatModal = ({
         </div>
 
         {/* AI disclaimer */}
-        <p className="px-3 pb-2 text-center text-xs text-gray-500">
-          Responses are AI-generated and may be inaccurate. Please verify
-          important information.
-        </p>
+        <div
+          className="flex items-start gap-2 mx-3 mb-3 p-4 text-sm text-yellow-800 rounded-lg bg-yellow-50"
+          role="alert"
+        >
+          <IoMdInformationCircle size={18} className="shrink-0 mt-0.5" />
+          <span>
+            Responses are AI-generated and may be inaccurate. Please verify
+            important information.
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/common/components/RequestButton/RequestButton.jsx
+++ b/src/common/components/RequestButton/RequestButton.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 import { FaPeopleGroup } from "react-icons/fa6";
 import { MdContactPhone } from "react-icons/md";
+import { IoMdInformationCircle } from "react-icons/io";
 import { useNavigate } from "react-router-dom";
 import Modal from "../Modal/Modal";
 import { useSelector } from "react-redux";
@@ -160,10 +161,16 @@ const RequestButton = ({
         show={showCooldownDialog}
         onClose={() => setShowCooldownDialog(false)}
       >
-        <p className="text-gray-700">
-          You have reached the question limit. Please try again after 30
-          minutes.
-        </p>
+        <div
+          className="flex items-start gap-2 p-4 text-sm text-yellow-800 rounded-lg bg-yellow-50"
+          role="alert"
+        >
+          <IoMdInformationCircle size={22} className="shrink-0" />
+          <span>
+            You have reached the question limit. Please try again after 30
+            minutes.
+          </span>
+        </div>
       </Modal>
     </>
   );


### PR DESCRIPTION
## Summary
- Replace muted grey AI disclaimer with a yellow info banner (`role="alert"`, `IoMdInformationCircle` icon) in `MoreInfoChatModal` for higher visibility.
- Apply the same yellow banner treatment to the More-Info cooldown dialog in `RequestButton` so both AI-related notices share one visual language.
- Pure presentational change — no behavior, props, or test changes.

## Refs
Part of #1247.