### PR TITLE
feat: auto-detect user location for In Person requests using OpenStreetMap

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -101,7 +101,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
   const groups = useSelector((state) => state.auth.user?.groups);
   const userDbId = useSelector((state) => state.auth.user?.userDbId);
   const [location, setLocation] = useState("");
-  const { inputRef, isLoaded, handleOnPlacesChanged } =
+  const { inputRef, suggestions, handleSearchChange, handleSelectSuggestion } =
     usePlacesSearchBox(setLocation);
 
   const [languages, setLanguages] = useState([]);
@@ -340,6 +340,38 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
     const { id, value } = e.target;
     if (id === "subject") hasUserEditedSubjectRef.current = true;
     setFormData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const getUserLocation = () => {
+    console.log("getUserLocation called");
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          const { latitude, longitude } = position.coords;
+          // ✅ Using OpenStreetMap Nominatim - FREE, no API key needed
+          const response = await fetch(
+            `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`,
+            {
+              headers: {
+                "Accept-Language": "en",
+                "User-Agent": "SaayamForAll/1.0",
+              },
+            },
+          );
+          const data = await response.json();
+          if (data.display_name) {
+            setLocation(data.display_name);
+            setFormData((prev) => ({
+              ...prev,
+              location: data.display_name,
+            }));
+          }
+        },
+        (error) => {
+          console.error("Location error:", error);
+        },
+      );
+    }
   };
 
   const closeForm = () => {
@@ -1924,12 +1956,16 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                     <select
                       id="requestType"
                       value={formData.request_type || "REMOTE"}
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        const value = e.target.value;
                         setFormData({
                           ...formData,
-                          request_type: e.target.value,
-                        })
-                      }
+                          request_type: value,
+                        });
+                        if (value === "IN_PERSON") {
+                          getUserLocation();
+                        }
+                      }}
                       className="
                     block w-full appearance-none
                     bg-white border border-gray-300
@@ -1960,22 +1996,44 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
                       >
                         Location
                       </label>
-                      {isLoaded && (
-                        <StandaloneSearchBox
-                          onLoad={(ref) => (inputRef.current = ref)}
-                          onPlacesChanged={handleOnPlacesChanged}
-                        >
-                          <input
-                            type="text"
-                            id="location"
-                            value={formData.location}
-                            onChange={handleChange}
-                            name="location"
-                            className="border p-2 w-full rounded-lg"
-                            placeholder="Search for location..."
-                          />
-                        </StandaloneSearchBox>
-                      )}
+                      <div className="relative">
+                        <input
+                          type="text"
+                          id="location"
+                          ref={inputRef}
+                          value={location}
+                          onChange={(e) => {
+                            setLocation(e.target.value);
+                            setFormData((prev) => ({
+                              ...prev,
+                              location: e.target.value,
+                            }));
+                            handleSearchChange(e.target.value);
+                          }}
+                          className="border p-2 w-full rounded-lg"
+                          placeholder="Search for location..."
+                        />
+                        {suggestions.length > 0 && (
+                          <ul className="absolute z-10 bg-white border border-gray-300 rounded-lg w-full mt-1 max-h-48 overflow-y-auto shadow-lg">
+                            {suggestions.map((s, i) => (
+                              <li
+                                key={i}
+                                className="px-3 py-2 cursor-pointer hover:bg-blue-50 text-sm"
+                                onClick={() => {
+                                  setLocation(s.display_name);
+                                  setFormData((prev) => ({
+                                    ...prev,
+                                    location: s.display_name,
+                                  }));
+                                  handleSelectSuggestion(s.display_name);
+                                }}
+                              >
+                                {s.display_name}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -348,7 +348,7 @@ const HelpRequestForm = ({ isEdit = false, onClose }) => {
       navigator.geolocation.getCurrentPosition(
         async (position) => {
           const { latitude, longitude } = position.coords;
-          // ✅ Using OpenStreetMap Nominatim - FREE, no API key needed
+          //Using OpenStreetMap Nominatim - FREE, no API key needed
           const response = await fetch(
             `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`,
             {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -54,6 +54,13 @@ jest.mock("../../services/requestApi", () => ({
   useAddRequestMutation: () => [jest.fn(), { isLoading: false }],
 }));
 
+jest.mock("./location/usePlacesSearchBox", () => () => ({
+  inputRef: { current: null },
+  suggestions: [],
+  handleSearchChange: jest.fn(),
+  handleSelectSuggestion: jest.fn(),
+}));
+
 jest.mock("../../utils/mapHelpRequestPayload", () => ({
   mapHelpRequestPayload: jest.fn().mockReturnValue({}),
 }));
@@ -905,5 +912,117 @@ describe("HelpRequestForm — successful submission", () => {
     await act(async () => {
       jest.advanceTimersByTime(1200);
     });
+  });
+});
+
+describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
+  beforeEach(() => {
+    mockT.mockReset();
+    mockT.mockImplementation((text) => `mockTranslate(${text})`);
+
+    //Set enums in localStorage so requestType dropdown has options
+    localStorage.setItem(
+      "enums",
+      JSON.stringify({
+        requestType: {
+          IN_PERSON: "IN_PERSON",
+          REMOTE: "REMOTE",
+        },
+        requestPriority: { MEDIUM: 2 },
+        requestFor: { SELF: 1, OTHER: 2 },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows location field when IN_PERSON request type is selected", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location")).toBeInTheDocument();
+    });
+  });
+
+  it("calls geolocation when IN_PERSON is selected", async () => {
+    const mockGetCurrentPosition = jest.fn();
+    Object.defineProperty(global.navigator, "geolocation", {
+      value: { getCurrentPosition: mockGetCurrentPosition },
+      configurable: true,
+    });
+
+    renderForm();
+
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    expect(mockGetCurrentPosition).toHaveBeenCalled();
+  });
+
+  it("auto-populates location field when geolocation succeeds", async () => {
+    const mockGetCurrentPosition = jest.fn((success) => {
+      success({ coords: { latitude: 38.886491, longitude: -94.649869 } });
+    });
+    Object.defineProperty(global.navigator, "geolocation", {
+      value: { getCurrentPosition: mockGetCurrentPosition },
+      configurable: true,
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({
+        display_name: "5600 West 133rd Terrace, Overland Park, Kansas, USA",
+      }),
+    });
+
+    renderForm();
+
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location").value).toBe(
+        "5600 West 133rd Terrace, Overland Park, Kansas, USA",
+      );
+    });
+  });
+
+  it("does not show location field for REMOTE request type", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole("combobox", { name: /type/i }), {
+        target: { value: "REMOTE" },
+      });
+    });
+
+    expect(
+      screen.queryByPlaceholderText("Search for location..."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1055,6 +1055,36 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
     expect(document.getElementById("location").value).toBe("Kansas City");
   });
 
+  it("shows suggestions and selects one when clicked", async () => {
+    jest.doMock("./location/usePlacesSearchBox", () => () => ({
+      inputRef: { current: null },
+      suggestions: [{ display_name: "Kansas City, Missouri, USA" }],
+      handleSearchChange: jest.fn(),
+      handleSelectSuggestion: jest.fn(),
+    }));
+
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("location"), {
+        target: { value: "Kansas" },
+      });
+    });
+
+    expect(document.getElementById("location").value).toBe("Kansas");
+  });
+
   it("does not show location field for REMOTE request type", async () => {
     renderForm();
 

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -54,11 +54,18 @@ jest.mock("../../services/requestApi", () => ({
   useAddRequestMutation: () => [jest.fn(), { isLoading: false }],
 }));
 
+let mockSuggestions = [];
+let mockHandleSelectSuggestion = jest.fn();
+
 jest.mock("./location/usePlacesSearchBox", () => () => ({
   inputRef: { current: null },
-  suggestions: [],
+  get suggestions() {
+    return mockSuggestions;
+  },
   handleSearchChange: jest.fn(),
-  handleSelectSuggestion: jest.fn(),
+  get handleSelectSuggestion() {
+    return mockHandleSelectSuggestion;
+  },
 }));
 
 jest.mock("../../utils/mapHelpRequestPayload", () => ({
@@ -936,6 +943,7 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
 
   afterEach(() => {
     localStorage.clear();
+    mockSuggestions = [];
   });
 
   it("shows location field when IN_PERSON request type is selected", async () => {
@@ -1054,14 +1062,8 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
 
     expect(document.getElementById("location").value).toBe("Kansas City");
   });
-
   it("shows suggestions and selects one when clicked", async () => {
-    jest.doMock("./location/usePlacesSearchBox", () => () => ({
-      inputRef: { current: null },
-      suggestions: [{ display_name: "Kansas City, Missouri, USA" }],
-      handleSearchChange: jest.fn(),
-      handleSelectSuggestion: jest.fn(),
-    }));
+    mockSuggestions = [{ display_name: "Kansas City, Missouri, USA" }];
 
     renderForm();
     fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
@@ -1073,16 +1075,16 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
     });
 
     await waitFor(() => {
-      expect(document.getElementById("location")).toBeInTheDocument();
+      expect(
+        screen.getByText("Kansas City, Missouri, USA"),
+      ).toBeInTheDocument();
     });
 
-    await act(async () => {
-      fireEvent.change(document.getElementById("location"), {
-        target: { value: "Kansas" },
-      });
-    });
+    fireEvent.click(screen.getByText("Kansas City, Missouri, USA"));
 
-    expect(document.getElementById("location").value).toBe("Kansas");
+    expect(mockHandleSelectSuggestion).toHaveBeenCalledWith(
+      "Kansas City, Missouri, USA",
+    );
   });
 
   it("does not show location field for REMOTE request type", async () => {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1010,6 +1010,51 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
     });
   });
 
+  it("handles geolocation error gracefully", async () => {
+    const mockGetCurrentPosition = jest.fn((success, error) => {
+      error(new Error("Location denied"));
+    });
+    Object.defineProperty(global.navigator, "geolocation", {
+      value: { getCurrentPosition: mockGetCurrentPosition },
+      configurable: true,
+    });
+
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    expect(mockGetCurrentPosition).toHaveBeenCalled();
+    expect(document.getElementById("location")).toBeInTheDocument();
+  });
+
+  it("updates location when user types in location input", async () => {
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("location"), {
+        target: { value: "Kansas City" },
+      });
+    });
+
+    expect(document.getElementById("location").value).toBe("Kansas City");
+  });
+
   it("does not show location field for REMOTE request type", async () => {
     renderForm();
 

--- a/src/pages/HelpRequest/location/usePlacesSearchBox.jsx
+++ b/src/pages/HelpRequest/location/usePlacesSearchBox.jsx
@@ -1,27 +1,44 @@
-import { useRef } from "react";
-import { useJsApiLoader, StandaloneSearchBox } from "@react-google-maps/api";
-
-const GOOGLE_MAP_LIBRARIES = ["places"];
+import { useRef, useState, useCallback } from "react";
 
 const usePlacesSearchBox = (setLocation) => {
   const inputRef = useRef(null);
-  const { isLoaded } = useJsApiLoader({
-    id: "google-map-script",
-    googleMapsApiKey: "AIzaSyDv7--yEnq84ZN3l03y50O33M4S89Un4U0",
-    libraries: GOOGLE_MAP_LIBRARIES,
-  });
+  const [suggestions, setSuggestions] = useState([]);
+  const debounceTimer = useRef(null);
 
-  const handleOnPlacesChanged = () => {
-    if (inputRef.current) {
-      const places = inputRef.current.getPlaces();
-      if (places.length > 0) {
-        const place = places[0]; // Get the first suggested place
-        setLocation(place.formatted_address);
-      }
+  const handleSearchChange = useCallback(async (value) => {
+    if (value.length < 3) {
+      setSuggestions([]);
+      return;
     }
+
+    // wait 500ms before calling API to avoid rate limiting
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(async () => {
+      try {
+        const response = await fetch(
+          `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(value)}&format=json&limit=5`,
+          {
+            headers: {
+              "Accept-Language": "en",
+              "User-Agent": "SaayamForAll/1.0",
+            },
+          },
+        );
+        const data = await response.json();
+        setSuggestions(data);
+      } catch (error) {
+        console.error("Error fetching suggestions:", error);
+        setSuggestions([]);
+      }
+    }, 500);
+  }, []);
+
+  const handleSelectSuggestion = (displayName) => {
+    setLocation(displayName);
+    setSuggestions([]);
   };
 
-  return { inputRef, isLoaded, handleOnPlacesChanged };
+  return { inputRef, suggestions, handleSearchChange, handleSelectSuggestion };
 };
 
 export default usePlacesSearchBox;

--- a/src/pages/HelpRequest/location/usePlacesSearchBox.test.jsx
+++ b/src/pages/HelpRequest/location/usePlacesSearchBox.test.jsx
@@ -1,0 +1,90 @@
+import { renderHook, act } from "@testing-library/react";
+import usePlacesSearchBox from "./usePlacesSearchBox";
+
+describe("usePlacesSearchBox", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns initial empty suggestions", () => {
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("does not fetch suggestions when query is less than 3 characters", async () => {
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    await act(async () => {
+      await result.current.handleSearchChange("ab");
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("fetches suggestions from OpenStreetMap when query is 3+ characters", async () => {
+    const mockSuggestions = [
+      { display_name: "Kansas City, Missouri, USA" },
+      { display_name: "Kansas, USA" },
+    ];
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue(mockSuggestions),
+    });
+
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    await act(async () => {
+      await result.current.handleSearchChange("Kansas");
+      await new Promise((r) => setTimeout(r, 600)); // wait for debounce
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("nominatim.openstreetmap.org/search"),
+      expect.any(Object),
+    );
+  });
+
+  it("clears suggestions when query is less than 3 characters after having results", async () => {
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    await act(async () => {
+      await result.current.handleSearchChange("ab");
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("sets location and clears suggestions when suggestion is selected", () => {
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    act(() => {
+      result.current.handleSelectSuggestion("Kansas City, Missouri, USA");
+    });
+
+    expect(setLocation).toHaveBeenCalledWith("Kansas City, Missouri, USA");
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("handles fetch error gracefully", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    await act(async () => {
+      await result.current.handleSearchChange("Kansas");
+      await new Promise((r) => setTimeout(r, 600));
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1475

## Changes
- Replaced expired Google Maps API with free OpenStreetMap Nominatim
- Location auto-populates when user selects "In Person" request type using browser Geolocation API
- User can edit the address or search manually with address suggestions dropdown
- Added debounce to prevent API rate limiting

## Testing
- Selected "In Person" → location auto-populated 
- Manual address search with suggestions works 
- User can edit the address
