### PR TITLE
#1486: add search-by dropdown (name/email/phone) to volunteer management

### DIFF
--- a/src/pages/RequestDetails/HelpingVolunteers.jsx
+++ b/src/pages/RequestDetails/HelpingVolunteers.jsx
@@ -34,6 +34,7 @@ const HelpingVolunteers = () => {
     direction: "ascending",
   });
   const [searchTerm, setSearchTerm] = useState("");
+  const [searchBy, setSearchBy] = useState("name");
   const [filter, setFilter] = useState(""); // State for filter functionality
   const [sortBy, setSortBy] = useState("Newest"); // State for sort functionality
   const [volunteerCountError, setVolunteerCountError] = useState("");
@@ -167,9 +168,10 @@ const HelpingVolunteers = () => {
       0,
       Math.min(volunteerData.length, volunteersCount),
     );
-    let filteredVolunteers = topN.filter((volunteer) =>
-      volunteer.name.toLowerCase().includes(searchTerm.toLowerCase()),
-    );
+    let filteredVolunteers = topN.filter((volunteer) => {
+      const field = (volunteer[searchBy] || "").toLowerCase();
+      return field.includes(searchTerm.toLowerCase());
+    });
 
     if (filter) {
       filteredVolunteers = filteredVolunteers.filter((volunteer) =>
@@ -451,15 +453,32 @@ const HelpingVolunteers = () => {
             </svg>
             {t("REQUEST_VOLUNTEERS")}
           </button>
-          <div className="ml-auto flex items-center space-x-4">
+          <div className="ml-auto flex items-center space-x-2">
             <input
               type="text"
-              placeholder="Enter volunteer name"
+              placeholder={
+                searchBy === "name"
+                  ? "Enter volunteer name"
+                  : searchBy === "email"
+                    ? "Enter email address"
+                    : "Enter phone number"
+              }
               className="p-3 border rounded-md w-64"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
             />
-            <button className="bg-blue-500 px-6 py-3 text-white rounded-lg whitespace-nowrap hover:bg-blue-600 flex items-center">
-              Find by name
-            </button>
+            <select
+              value={searchBy}
+              onChange={(e) => {
+                setSearchBy(e.target.value);
+                setSearchTerm("");
+              }}
+              className="bg-blue-500 px-4 py-3 text-white rounded-lg whitespace-nowrap hover:bg-blue-600 cursor-pointer border-none outline-none"
+            >
+              <option value="name">Find by Name</option>
+              <option value="email">Find by Email</option>
+              <option value="phone">Find by Phone</option>
+            </select>
           </div>
         </div>
 
@@ -473,7 +492,13 @@ const HelpingVolunteers = () => {
               <div className="flex-grow max-w-md">
                 <input
                   type="text"
-                  placeholder="Search by name..."
+                  placeholder={
+                    searchBy === "name"
+                      ? "Search by name..."
+                      : searchBy === "email"
+                        ? "Search by email..."
+                        : "Search by phone..."
+                  }
                   className="p-2 border border-gray-300 rounded-md w-full"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}

--- a/src/pages/RequestDetails/HelpingVolunteers.test.jsx
+++ b/src/pages/RequestDetails/HelpingVolunteers.test.jsx
@@ -343,6 +343,139 @@ describe("HelpingVolunteers", () => {
     );
   });
 
+  describe("Search by dropdown (name / email / phone)", () => {
+    it("defaults to 'Find by Name' with correct placeholder", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      expect(searchDropdown.value).toBe("name");
+      expect(
+        screen.getByPlaceholderText("Enter volunteer name"),
+      ).toBeInTheDocument();
+    });
+
+    it("changes placeholder when 'Find by Email' is selected", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      fireEvent.change(searchDropdown, { target: { value: "email" } });
+
+      expect(
+        screen.getByPlaceholderText("Enter email address"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText("Enter volunteer name"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("changes placeholder when 'Find by Phone' is selected", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      fireEvent.change(searchDropdown, { target: { value: "phone" } });
+
+      expect(
+        screen.getByPlaceholderText("Enter phone number"),
+      ).toBeInTheDocument();
+    });
+
+    it("filters volunteers by email", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      fireEvent.change(searchDropdown, { target: { value: "email" } });
+
+      const input = screen.getByPlaceholderText("Enter email address");
+      fireEvent.change(input, { target: { value: "jane" } });
+
+      expect(await screen.findByText("Jane Cooper")).toBeInTheDocument();
+      expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+    });
+
+    it("filters volunteers by phone", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      fireEvent.change(searchDropdown, { target: { value: "phone" } });
+
+      const input = screen.getByPlaceholderText("Enter phone number");
+      fireEvent.change(input, { target: { value: "456" } });
+
+      expect(await screen.findByText("John Doe")).toBeInTheDocument();
+      expect(screen.queryByText("Jane Cooper")).not.toBeInTheDocument();
+    });
+
+    it("clears the search term when the search type is switched", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+
+      // Type something in the name input
+      const nameInput = screen.getByPlaceholderText("Enter volunteer name");
+      fireEvent.change(nameInput, { target: { value: "Jane" } });
+      expect(nameInput.value).toBe("Jane");
+
+      // Switch to email — input should be cleared
+      fireEvent.change(searchDropdown, { target: { value: "email" } });
+      const emailInput = screen.getByPlaceholderText("Enter email address");
+      expect(emailInput.value).toBe("");
+    });
+
+    it("table search placeholder updates to match selected search type", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      // Default
+      expect(
+        screen.getByPlaceholderText("Search by name..."),
+      ).toBeInTheDocument();
+
+      const searchDropdown = Array.from(screen.getAllByRole("combobox")).find(
+        (el) => Array.from(el.options).some((o) => o.text === "Find by Name"),
+      );
+      fireEvent.change(searchDropdown, { target: { value: "email" } });
+      expect(
+        screen.getByPlaceholderText("Search by email..."),
+      ).toBeInTheDocument();
+
+      fireEvent.change(searchDropdown, { target: { value: "phone" } });
+      expect(
+        screen.getByPlaceholderText("Search by phone..."),
+      ).toBeInTheDocument();
+    });
+
+    it("shows all volunteers when search term is cleared", async () => {
+      render(<HelpingVolunteers />);
+      await screen.findByText("Jane Cooper");
+
+      const input = screen.getByPlaceholderText("Enter volunteer name");
+      fireEvent.change(input, { target: { value: "Jane" } });
+      expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: "" } });
+      expect(await screen.findByText("Jane Cooper")).toBeInTheDocument();
+      expect(await screen.findByText("John Doe")).toBeInTheDocument();
+    });
+  });
+
   it("handles pagination and sorting", async () => {
     render(<HelpingVolunteers />);
     expect(await screen.findByText("Jane Cooper")).toBeInTheDocument();


### PR DESCRIPTION

1. Replaced the static "Find by Name" button with a dropdown that allows searching volunteers by Name, Email, or Phone
Search input placeholder updates dynamically to match the selected search type (e.g Enter email address, Enter phone number)

2. The table's inline search placeholder also updates to reflect the active search field
3. Switching the search type clears the previous search term to avoid stale results

<img width="1303" height="467" alt="Screenshot 2026-05-18 at 4 52 01 PM" src="https://github.com/user-attachments/assets/375f14ea-6536-4f8c-9be5-aca6c04f0068" />
