### PR TITLE
Apply user's preferred dashboard from Preferences tab

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -162,6 +162,22 @@ const Dashboard = ({ userRole }) => {
       return;
     }
 
+    // Preferences tab stores defaultDashboard under "userPreferences" in
+    // localStorage (DB persistence pending). Honor it when the user lands
+    // on /dashboard without an explicit ?view= override.
+    let preferredDashboard = null;
+    try {
+      const saved = JSON.parse(localStorage.getItem("userPreferences"));
+      preferredDashboard = saved?.defaultDashboard || null;
+    } catch {
+      preferredDashboard = null;
+    }
+    if (preferredDashboard && accessible.includes(preferredDashboard)) {
+      setSelectedDashboard(preferredDashboard);
+      localStorage.setItem("lastDashboardSelected", preferredDashboard);
+      return;
+    }
+
     const storedDashboard = localStorage.getItem("lastDashboardSelected");
     if (storedDashboard && accessible.includes(storedDashboard)) {
       setSelectedDashboard(storedDashboard);

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -64,4 +64,47 @@ describe("Dashboard", () => {
     });
     expect(getByTestId("beneficiary-dashboard")).toBeInTheDocument();
   });
+
+  it("applies userPreferences.defaultDashboard when accessible to the user", () => {
+    localStorage.setItem(
+      "userPreferences",
+      JSON.stringify({ defaultDashboard: "steward" }),
+    );
+    const { getByTestId } = renderWithProviders(<Dashboard />, {
+      preloadedState: {
+        auth: { user: { userId: "u1", groups: ["Admins"] }, idToken: "tok" },
+      },
+    });
+    // Admin's role-default is admin; preference of steward should override.
+    expect(getByTestId("steward-dashboard")).toBeInTheDocument();
+    expect(localStorage.getItem("lastDashboardSelected")).toBe("steward");
+  });
+
+  it("ignores userPreferences.defaultDashboard when not accessible", () => {
+    localStorage.setItem(
+      "userPreferences",
+      JSON.stringify({ defaultDashboard: "superAdmin" }),
+    );
+    const { getByTestId } = renderWithProviders(<Dashboard />, {
+      preloadedState: {
+        auth: {
+          user: { userId: "u1", groups: ["Beneficiaries"] },
+          idToken: "tok",
+        },
+      },
+    });
+    // Beneficiary cannot access superAdmin; falls back to role default.
+    expect(getByTestId("beneficiary-dashboard")).toBeInTheDocument();
+  });
+
+  it("falls through to role default when userPreferences JSON is malformed", () => {
+    localStorage.setItem("userPreferences", "{not valid json");
+    const { getByTestId } = renderWithProviders(<Dashboard />, {
+      preloadedState: {
+        auth: { user: { userId: "u1", groups: ["Admins"] }, idToken: "tok" },
+      },
+    });
+    // Malformed JSON is swallowed by the try/catch; Admin role default wins.
+    expect(getByTestId("admin-dashboard")).toBeInTheDocument();
+  });
 });

--- a/src/pages/Profile/Preferences.jsx
+++ b/src/pages/Profile/Preferences.jsx
@@ -63,7 +63,7 @@ const getTimezoneDetails = (timezoneValue, locale = "en-US") => {
 function Preferences({ setHasUnsavedChanges }) {
   const { t, i18n } = useTranslation("profile");
   const dashboardOptions = [
-    { value: "super-admin", label: t("SUPER_ADMIN_DASHBOARD") },
+    { value: "superAdmin", label: t("SUPER_ADMIN_DASHBOARD") },
     { value: "admin", label: t("ADMIN_DASHBOARD") },
     { value: "steward", label: t("STEWARD_DASHBOARD") },
     { value: "volunteer", label: t("VOLUNTEER_DASHBOARD") },


### PR DESCRIPTION
Read userPreferences.defaultDashboard from localStorage when landing on /dashboard and route the user to their chosen dashboard view (e.g., Steward) before falling back to lastDashboardSelected or role default. Gated by accessible dashboards so RBAC is respected. Also aligns the superAdmin option value in the Preferences dropdown with the canonical DASHBOARDS enum (was the only hyphenated outlier).