### PR TITLE
fix: prevent redirect to home on direct /dashboard URL

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -458,7 +458,6 @@ const Navbar = () => {
                 onClick={(e) => handleLinkClick(e, "/donate")}
                 className="text-black hover:text-gray-600 flex items-center"
                 aria-label={t("DONATE")}
-                title={t("DONATE")}
                 type="button"
               >
                 <VolunteerActivismOutlinedIcon sx={{ fontSize: 28 }} />
@@ -471,7 +470,6 @@ const Navbar = () => {
                 onClick={(e) => handleLinkClick(e, "/donate")}
                 className="text-black hover:text-gray-600 flex items-center"
                 aria-label={t("DONATE")}
-                title={t("DONATE")}
                 type="button"
               >
                 <VolunteerActivismOutlinedIcon sx={{ fontSize: 28 }} />

--- a/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
+++ b/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
@@ -95,7 +95,6 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
               aria-label="mockTranslate(DONATE)"
               class="text-black hover:text-gray-600 flex items-center"
               data-mui-internal-clone-element="true"
-              title="mockTranslate(DONATE)"
               type="button"
             >
               <svg
@@ -509,7 +508,6 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
             aria-label="mockTranslate(DONATE)"
             class="text-black hover:text-gray-600 flex items-center"
             data-mui-internal-clone-element="true"
-            title="mockTranslate(DONATE)"
             type="button"
           >
             <svg
@@ -919,7 +917,6 @@ exports[`Navbar renders correctly when user is logged out 1`] = `
               aria-label="mockTranslate(DONATE)"
               class="text-black hover:text-gray-600 flex items-center"
               data-mui-internal-clone-element="true"
-              title="mockTranslate(DONATE)"
               type="button"
             >
               <svg
@@ -1156,7 +1153,6 @@ exports[`Navbar renders correctly when user is logged out 1`] = `
             aria-label="mockTranslate(DONATE)"
             class="text-black hover:text-gray-600 flex items-center"
             data-mui-internal-clone-element="true"
-            title="mockTranslate(DONATE)"
             type="button"
           >
             <svg

--- a/src/redux/features/authentication/authSlice.js
+++ b/src/redux/features/authentication/authSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  loading: false,
+  loading: true,
   user: null,
   success: false,
   error: null,

--- a/src/redux/features/authentication/authSlice.test.js
+++ b/src/redux/features/authentication/authSlice.test.js
@@ -1,0 +1,49 @@
+import authReducer, {
+  loginRequest,
+  loginSuccess,
+  loginFailure,
+} from "./authSlice";
+
+describe("authSlice", () => {
+  describe("initialState", () => {
+    it("starts with loading: true so protected routes wait for auth check", () => {
+      const state = authReducer(undefined, { type: "@@INIT" });
+      expect(state.loading).toBe(true);
+    });
+
+    it("starts with user: null", () => {
+      const state = authReducer(undefined, { type: "@@INIT" });
+      expect(state.user).toBeNull();
+    });
+  });
+
+  describe("loginRequest", () => {
+    it("sets loading: true", () => {
+      const state = authReducer({ loading: false, user: null }, loginRequest());
+      expect(state.loading).toBe(true);
+    });
+  });
+
+  describe("loginSuccess", () => {
+    it("sets loading: false and stores the user", () => {
+      const mockUser = { userId: "u1", email: "test@example.com" };
+      const state = authReducer(
+        { loading: true, user: null },
+        loginSuccess({ user: mockUser }),
+      );
+      expect(state.loading).toBe(false);
+      expect(state.user).toEqual(mockUser);
+    });
+  });
+
+  describe("loginFailure", () => {
+    it("sets loading: false so ProtectedRoute stops showing the loader", () => {
+      const state = authReducer(
+        { loading: true, user: null },
+        loginFailure("Auth error"),
+      );
+      expect(state.loading).toBe(false);
+      expect(state.user).toBeNull();
+    });
+  });
+});

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import InactivityLogoutTimer from "../common/components/InactivityTimer/InactivityTimer";
+import MainLoader from "../common/components/Loader/MainLoader";
+
 import {
   startVolunteerLocationTracking,
   stopVolunteerLocationTracking,
@@ -11,6 +13,8 @@ import {
 const ProtectedRoute = () => {
   const authState = useSelector((state) => state.auth);
   const user = authState?.user || null;
+
+  const loading = authState?.loading ?? false;
 
   const userDBid = user?.userDbId || "";
 
@@ -76,6 +80,8 @@ const ProtectedRoute = () => {
       stopVolunteerLocationTracking();
     }
   }, [location.pathname]);
+
+  if (loading) return <MainLoader />;
 
   if (!user) return <Navigate to="/" replace />;
 

--- a/src/routes/ProtectedRoute.test.jsx
+++ b/src/routes/ProtectedRoute.test.jsx
@@ -1,0 +1,78 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "../redux/features/authentication/authSlice";
+import ProtectedRoute from "./ProtectedRoute";
+
+const mockNavigateFn = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  Navigate: ({ to }) => <div data-testid="navigate" data-to={to} />,
+  Outlet: () => <div data-testid="outlet" />,
+  useLocation: () => ({ pathname: "/dashboard" }),
+}));
+
+jest.mock("../common/components/InactivityTimer/InactivityTimer", () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("../common/components/Loader/MainLoader", () => ({
+  __esModule: true,
+  default: () => <div data-testid="main-loader" />,
+}));
+
+jest.mock("../services/volunteerLocationTracker", () => ({
+  startVolunteerLocationTracking: jest.fn(),
+  stopVolunteerLocationTracking: jest.fn(),
+  syncVolunteerLocationNow: jest.fn(),
+}));
+
+const renderWithStore = (preloadedState) => {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState,
+  });
+  return render(
+    <Provider store={store}>
+      <ProtectedRoute />
+    </Provider>,
+  );
+};
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    mockNavigateFn.mockClear();
+  });
+
+  it("shows loader while auth check is in progress (loading: true)", () => {
+    renderWithStore({ auth: { loading: true, user: null } });
+    expect(screen.getByTestId("main-loader")).toBeInTheDocument();
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("outlet")).not.toBeInTheDocument();
+  });
+
+  it("redirects to / when auth resolves with no user", () => {
+    renderWithStore({ auth: { loading: false, user: null } });
+    const nav = screen.getByTestId("navigate");
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveAttribute("data-to", "/");
+    expect(screen.queryByTestId("main-loader")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("outlet")).not.toBeInTheDocument();
+  });
+
+  it("renders protected content when auth resolves with a user", () => {
+    const mockUser = { userId: "u1", email: "test@example.com", groups: [] };
+    renderWithStore({ auth: { loading: false, user: mockUser } });
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+    expect(screen.queryByTestId("main-loader")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+  });
+
+  it("does not redirect to / during loading even with no user (prevents premature redirect on /dashboard)", () => {
+    renderWithStore({ auth: { loading: true, user: null } });
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.getByTestId("main-loader")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

 ProtectedRoute /dashboard was immediately redirecting to  Home on page load because loading started as false, causing it to see user: null before checkAuthStatus could resolve. Set initialState.loading: true in authSlice and added a MainLoader in ProtectedRoute to wait for the auth check before making a routing decision.

The Navbar buttons had both a ModernTooltip wrapper and a native title attribute. Removed the redundant title prop since ModernTooltip and aria-label already handle the visual and accessibility needs.