### PR TITLE
fix: pre-fill edit form from help-requests reqDesc and reqCatId. 

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -161,6 +161,8 @@ const Dashboard = ({ userRole }) => {
             ...r,
             id: r.requestId || r.id,
             category: r.requestCategory || r.category,
+            description: r.reqDesc || r.description,
+            catId: r.reqCatId || r.catId,
           }),
         );
         setData({ body: normalizedRecords });

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -40,15 +40,19 @@ jest.mock("./views/BeneficiaryDashboard", () => () => (
 jest.mock("./views/VolunteerDashboard", () => () => (
   <div data-testid="volunteer-dashboard" />
 ));
-jest.mock("./views/AdminDashboard", () => (props) => (
-  <div data-testid="admin-dashboard">
-    <button onClick={() => props.handleTabChange("myRequests")}>
-      Click All Requests
-    </button>
-    <button onClick={() => props.setCurrentPage(2)}>Change Page</button>
-    <button onClick={() => props.onRowsPerPageChange(25)}>Change Rows</button>
-  </div>
-));
+let lastAdminDashboardProps = null;
+jest.mock("./views/AdminDashboard", () => (props) => {
+  lastAdminDashboardProps = props;
+  return (
+    <div data-testid="admin-dashboard">
+      <button onClick={() => props.handleTabChange("myRequests")}>
+        Click All Requests
+      </button>
+      <button onClick={() => props.setCurrentPage(2)}>Change Page</button>
+      <button onClick={() => props.onRowsPerPageChange(25)}>Change Rows</button>
+    </div>
+  );
+});
 jest.mock("./views/StewardDashboard", () => () => (
   <div data-testid="steward-dashboard" />
 ));
@@ -67,6 +71,7 @@ import Dashboard from "./Dashboard";
 describe("Dashboard", () => {
   beforeEach(() => {
     localStorage.clear();
+    lastAdminDashboardProps = null;
   });
 
   it("renders beneficiary dashboard by default when user has no groups", () => {
@@ -129,6 +134,56 @@ describe("Dashboard", () => {
     });
     // Malformed JSON is swallowed by the try/catch; Admin role default wins.
     expect(getByTestId("admin-dashboard")).toBeInTheDocument();
+  });
+
+  it("maps reqDesc and reqCatId from paginated help-requests response", async () => {
+    const {
+      getAllPaginatedRequests,
+    } = require("../../services/requestServices");
+
+    const paginatedRow = {
+      requestId: "REQ-00-000-000-0360",
+      requesterId: "SID-00-000-003-016",
+      status: "MATCHING_VOLUNTEER",
+      requestCategory: "MEAL_PREP_BASIC",
+      reqCatId: "1.3.1",
+      reqDesc: "High protein vegetarian meals",
+      type: "REMOTE",
+      priority: "MEDIUM",
+      calamity: false,
+      updatedDate: "2026-05-24T17:17:45.999808Z",
+    };
+
+    getAllPaginatedRequests.mockResolvedValue({
+      data: {
+        content: [paginatedRow],
+        totalPages: 1,
+        totalElements: 1,
+      },
+    });
+
+    const { getByText } = renderWithProviders(<Dashboard />, {
+      preloadedState: {
+        auth: { user: { userId: "u1", groups: ["Admins"] }, idToken: "tok" },
+      },
+    });
+
+    fireEvent.click(getByText("Click All Requests"));
+
+    await waitFor(() => {
+      const row = lastAdminDashboardProps?.filteredData?.find(
+        (r) => r.id === "REQ-00-000-000-0360",
+      );
+      expect(row).toMatchObject({
+        description: "High protein vegetarian meals",
+        catId: "1.3.1",
+        requesterId: "SID-00-000-003-016",
+      });
+    });
+
+    getAllPaginatedRequests.mockResolvedValue({
+      data: { content: [], totalPages: 1, totalElements: 0 },
+    });
   });
 
   it("calls getAllPaginatedRequests when Admin switches to All Requests tab", async () => {

--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -277,6 +277,8 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     if (requestData) {
       const rawCategory =
         requestData.helpCategory?.catId ||
+        requestData.catId ||
+        requestData.reqCatId ||
         requestData.category ||
         requestData.requestCategory ||
         "General";
@@ -285,7 +287,10 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       setFormData({
         ...requestData,
         category,
-        description: requestData.description || requestData.requestDescription,
+        description:
+          requestData.description ||
+          requestData.reqDesc ||
+          requestData.requestDescription,
         subject: requestData.subject || requestData.requestSubject,
         is_calamity: requestData.is_calamity ?? requestData.calamity ?? false,
         // Map paginated API and nested detail API values to flat form fields.

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1157,6 +1157,64 @@ describe("HelpRequestForm — edit mode submission", () => {
     });
   });
 
+  it("restores reqDesc and reqCatId from paginated help-requests API on edit", async () => {
+    const {
+      checkProfanity,
+      updateRequest,
+    } = require("../../services/requestServices");
+    const {
+      mapHelpRequestPayload,
+    } = require("../../utils/mapHelpRequestPayload");
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    updateRequest.mockResolvedValue({
+      data: { requestId: "REQ-00-000-000-0360" },
+    });
+
+    renderForm({
+      isEdit: true,
+      editRequestData: {
+        requestId: "REQ-00-000-000-0360",
+        requesterId: "SID-00-000-002-622",
+        subject: "Meal Prep help",
+        type: "REMOTE",
+        priority: "MEDIUM",
+        reqCatId: "1.3.1",
+        reqDesc: "Looking for high protein vegetarian meals",
+        calamity: false,
+      },
+    });
+
+    expect(document.getElementById("description").value).toBe(
+      "Looking for high protein vegetarian meals",
+    );
+
+    fireEvent.change(document.getElementById("description"), {
+      target: {
+        name: "description",
+        value: "Updated meal prep description.",
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "mockTranslate(SAVE)" }),
+      );
+    });
+
+    await waitFor(() => expect(updateRequest).toHaveBeenCalled());
+
+    const callArgs =
+      mapHelpRequestPayload.mock.calls[
+        mapHelpRequestPayload.mock.calls.length - 1
+      ][0];
+    expect(callArgs.selectedCategoryId).toBe("1.3.1");
+    expect(callArgs.requesterId).toBe("SID-00-000-002-622");
+
+    await act(async () => {
+      jest.advanceTimersByTime(1200);
+    });
+  });
+
   it("resolves sub-subcategory name to numeric catId on edit", async () => {
     const {
       checkProfanity,


### PR DESCRIPTION
Map paginated list fields so description and category restore on edit