### PR TITLE
Lock profile country after it is set

### DIFF
--- a/src/pages/Auth/Signup.test.jsx
+++ b/src/pages/Auth/Signup.test.jsx
@@ -1,0 +1,71 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SignUp from "./Signup";
+
+jest.mock("aws-amplify/auth", () => ({ signUp: jest.fn() }));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock("react-select-country-list", () =>
+  jest.fn(() => ({
+    getData: () => [
+      { value: "US", label: "United States" },
+      { value: "AR", label: "Argentina" },
+      { value: "CA", label: "Canada" },
+    ],
+  })),
+);
+
+jest.mock("react-phone-number-input", () => ({
+  isValidPhoneNumber: jest.fn(() => true),
+}));
+
+jest.mock("../../common/components/PhoneNumberInputWithCountry", () => {
+  const React = require("react");
+  return function PhoneInputMock(props) {
+    React.useLayoutEffect(() => {
+      props.setCountryCode?.("US");
+      props.setPhone?.("2345678901");
+      props.setError?.("");
+    }, []);
+    return <div data-testid="phone-input-mock" />;
+  };
+});
+
+jest.mock("../../utils/phone-codes-en", () => ({
+  US: { primary: "United States", secondary: "+1", dialCode: "+1" },
+}));
+
+describe("SignUp", () => {
+  it("renders the country dropdown with ISO Alpha-2 options", () => {
+    render(<SignUp />);
+    const select = screen.getByRole("combobox", { name: /country/i });
+    expect(select).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "United States" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Argentina" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Canada" })).toBeInTheDocument();
+  });
+
+  it("defaults country selection to US", () => {
+    render(<SignUp />);
+    const select = screen.getByRole("combobox", { name: /country/i });
+    expect(select.value).toBe("US");
+  });
+
+  it("updates country when a different option is selected", () => {
+    render(<SignUp />);
+    const select = screen.getByRole("combobox", { name: /country/i });
+    fireEvent.change(select, { target: { value: "AR" } });
+    expect(select.value).toBe("AR");
+  });
+});

--- a/src/pages/Profile/PersonalInformation.jsx
+++ b/src/pages/Profile/PersonalInformation.jsx
@@ -607,9 +607,6 @@ function PersonalInformation({ setHasUnsavedChanges }) {
                   {errors.country}
                 </p>
               )}
-              <p className="text-xs text-gray-500 mt-1">
-                To change your country, update it in Your Profile.
-              </p>
             </>
           ) : (
             <p className="text-lg text-gray-900">

--- a/src/pages/Profile/YourProfile.jsx
+++ b/src/pages/Profile/YourProfile.jsx
@@ -36,6 +36,7 @@ function YourProfile({ setHasUnsavedChanges }) {
   const firstNameRef = useRef(null);
   const countries = CountryList().getData();
   const user = useSelector((state) => state.auth.user);
+  const canEditProfileCountry = !String(user?.zoneinfo || "").trim();
 
   const [nameErrors, setNameErrors] = useState({ firstName: "", lastName: "" });
   const [emailError, setEmailError] = useState("");
@@ -57,11 +58,9 @@ function YourProfile({ setHasUnsavedChanges }) {
   const [countryCode, setCountryCode] = useState("US"); // ISO
 
   // ---------------- helpers ----------------
-  const getIsoFromCountryLabel = (label) => {
-    const match = Object.entries(PHONECODESEN).find(
-      ([, data]) => data.primary === label,
-    );
-    return match ? match[0] : null;
+  const getProfileCountryIso = (zoneinfo) => {
+    if (!String(zoneinfo || "").trim()) return "";
+    return resolveCountryIso(zoneinfo);
   };
 
   // Prefer zoneinfo ISO when dial code collides (fallback if parsing fails)
@@ -130,7 +129,7 @@ function YourProfile({ setHasUnsavedChanges }) {
       email: userEmail,
       phone: digits,
       phoneCountryCode: finalIso,
-      country: resolveCountryIso(user.zoneinfo),
+      country: getProfileCountryIso(user.zoneinfo),
     });
 
     // keep the ContactUs-style phone component in sync
@@ -264,6 +263,7 @@ function YourProfile({ setHasUnsavedChanges }) {
       if (!profileInfo.email.trim()) throw new Error("Email is required");
       if (!validateEmail(profileInfo.email, true))
         throw new Error("Please enter a valid email address");
+      if (!profileInfo.country) throw new Error("Country is required");
 
       // ✅ ContactUs-style validation + strict region check
       const dial = PHONECODESEN[countryCode]?.secondary || "";
@@ -435,7 +435,7 @@ function YourProfile({ setHasUnsavedChanges }) {
           stripDialOnce(user.phone_number || "", finalIso),
         ),
         phoneCountryCode: finalIso,
-        country: resolveCountryIso(user.zoneinfo),
+        country: getProfileCountryIso(user.zoneinfo),
       });
 
       // keep shared phone component in sync
@@ -606,16 +606,31 @@ function YourProfile({ setHasUnsavedChanges }) {
 
       {/* Country */}
       <div className="mb-6">
-        <label className="block tracking-wide text-gray-700 text-xs font-bold mb-2">
-          {isEditing && <span className="text-red-500 mr-1">*</span>}
+        <label
+          htmlFor="profile-country"
+          className="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+        >
+          {isEditing && canEditProfileCountry && (
+            <span className="text-red-500 mr-1">*</span>
+          )}
           {t("COUNTRY")}
         </label>
         {isEditing ? (
           <select
+            id="profile-country"
+            name="country"
             value={profileInfo.country}
             onChange={(e) => handleInputChange("country", e.target.value)}
-            className="block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 focus:outline-none"
+            disabled={!canEditProfileCountry}
+            className={`block w-full border border-gray-200 rounded py-3 px-4 focus:outline-none ${
+              canEditProfileCountry
+                ? "bg-white text-gray-700"
+                : "bg-gray-100 text-gray-500 cursor-not-allowed"
+            }`}
           >
+            {canEditProfileCountry && (
+              <option value="">{t("SELECT_COUNTRY")}</option>
+            )}
             {countries.map((c) => (
               <option key={c.value} value={c.value}>
                 {c.label}

--- a/src/pages/Profile/__snapshots__/your-profile.test.js.snap
+++ b/src/pages/Profile/__snapshots__/your-profile.test.js.snap
@@ -112,6 +112,7 @@ exports[`YourProfile matches snapshot 1`] = `
     >
       <label
         class="block tracking-wide text-gray-700 text-xs font-bold mb-2"
+        for="profile-country"
       >
         COUNTRY
       </label>

--- a/src/pages/Profile/your-profile.test.js
+++ b/src/pages/Profile/your-profile.test.js
@@ -189,6 +189,40 @@ describe("YourProfile", () => {
     });
   });
 
+  it("keeps country locked in edit mode when the profile already has country", async () => {
+    renderWithProvider(
+      <YourProfile setHasUnsavedChanges={mockSetHasUnsavedChanges} />,
+    );
+
+    fireEvent.click(screen.getByText("EDIT"));
+
+    const countrySelect = await screen.findByLabelText(/COUNTRY/);
+    expect(countrySelect).toBeDisabled();
+    expect(countrySelect).toHaveValue("US");
+  });
+
+  it("allows country selection in edit mode when profile country is missing", async () => {
+    const storeWithoutCountry = createMockStore({
+      auth: { user: { ...mockUser, zoneinfo: null } },
+    });
+
+    renderWithProvider(
+      <YourProfile setHasUnsavedChanges={mockSetHasUnsavedChanges} />,
+      storeWithoutCountry,
+    );
+
+    fireEvent.click(screen.getByText("EDIT"));
+
+    const countrySelect = await screen.findByLabelText(/COUNTRY/);
+    expect(countrySelect).not.toBeDisabled();
+    expect(countrySelect).toHaveValue("");
+
+    fireEvent.change(countrySelect, { target: { value: "CA" } });
+
+    expect(countrySelect).toHaveValue("CA");
+    expect(mockSetHasUnsavedChanges).toHaveBeenCalledWith(true);
+  });
+
   it("sends verification and navigates when email is changed and saved", async () => {
     const { updateUserAttributes } = require("aws-amplify/auth");
 


### PR DESCRIPTION
Updated the profile country behavior so users cannot change their country once it already exists on their profile.

## Changes

- Keeps the Country field disabled when a profile already has a country value.
- Allows the Country dropdown on Your Profile only when the country is missing or null, which can happen for external identity provider sign-ins.
- Keeps Personal Info country non-editable.
- Removes the helper text: “To change your country, update it in Your Profile.”
- Adds tests for locked and missing-country behavior on Your Profile.
