### PR TITLE
Fix lead volunteer label and profile link

### DIFF
--- a/src/pages/RequestDetails/RequestDetails.jsx
+++ b/src/pages/RequestDetails/RequestDetails.jsx
@@ -88,9 +88,9 @@ const RequestDetails = () => {
     },
     {
       context: "Ethan Marshall",
-      type: "Volunteer",
+      type: "LEAD_VOLUNTEER",
       icon: <RiUserStarLine size={22} />,
-      isClickable: false,
+      isClickable: true,
     },
   ];
 
@@ -239,7 +239,7 @@ const RequestDetails = () => {
                   ) : (
                     <span>{header.context}</span>
                   )}
-                  <div className="absolute top-6 px-5 py-2 bg-gray-50 border shadow-md rounded-xl flex opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  <div className="absolute top-6 px-5 py-2 bg-gray-50 border shadow-md rounded-xl flex whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     {t(header.type)}
                   </div>
                 </li>

--- a/src/pages/RequestDetails/RequestDetails.test.jsx
+++ b/src/pages/RequestDetails/RequestDetails.test.jsx
@@ -76,6 +76,17 @@ describe("RequestDetails - Tab Translation Tests", () => {
     fireEvent.click(screen.getByText("VOLUNTEERS"));
     expect(screen.queryByText("No files")).not.toBeInTheDocument();
   });
+
+  it("renders lead volunteer as clickable with LEAD_VOLUNTEER label", async () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Ethan Marshall" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("LEAD_VOLUNTEER")).toBeInTheDocument();
+  });
 });
 
 describe("RequestDetails - Edit onClose refreshes data", () => {


### PR DESCRIPTION
Fixes #1521

Updated the Request Details page to correctly show Ethan Marshall as the Lead Volunteer instead of just Volunteer.

Changes made:
Replaced the hardcoded Volunteer label with the existing LEAD_VOLUNTEER translation key.
Made Ethan Marshall clickable using the existing profile navigation logic already used for Beneficiary and Creator names.


<img width="534" height="181" alt="image" src="https://github.com/user-attachments/assets/6cc7e393-98f3-41d5-a60a-90858b54aa13" />

