### PR TITLE
fix(profile-photo): resolve fixable QA findings for issue 44

### DIFF
--- a/src/common/i18n/locales/en/profile.json
+++ b/src/common/i18n/locales/en/profile.json
@@ -117,6 +117,7 @@
   "PROFILE_PHOTO_UPLOAD_SUCCESS": "Photo accepted. Click Save to confirm.",
   "PROFILE_PHOTO_ERROR_SIZE": "File size must be 5 MB or less.",
   "PROFILE_PHOTO_ERROR_FORMAT": "Only JPG and PNG formats are accepted.",
+  "PROFILE_PHOTO_DELETE_PENDING": "Photo marked for deletion. Click Save to confirm.",
   "PROFILE_PHOTO_LOAD_ERROR": "Failed to load profile photo.",
   "PROFILE_PHOTO_ERROR_UPLOAD": "Failed to update profile photo.",
   "PROFILE_PHOTO": "Profile Photo",

--- a/src/pages/Profile/Modal.jsx
+++ b/src/pages/Profile/Modal.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { FaCamera, FaSave, FaTimes, FaTrashAlt } from "react-icons/fa";
 
@@ -10,6 +10,7 @@ function Modal({
   handleCancelClick,
   handleDeleteClick,
   isSaving = false,
+  canSave = false,
 }) {
   const { t } = useTranslation("profile");
 
@@ -71,10 +72,18 @@ function Modal({
         <div className="flex justify-center space-x-6 mt-4">
           <button
             onClick={handleSaveClick}
-            disabled={isSaving}
+            disabled={!canSave || isSaving}
             className="flex items-center space-x-2 py-2 px-4 bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <FaSave />
+            {isSaving ? (
+              <span
+                className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                role="status"
+                aria-label={t("SAVING") || "Saving..."}
+              />
+            ) : (
+              <FaSave />
+            )}
             <span>
               {isSaving ? t("SAVING") || "Saving..." : t("SAVE") || "Save"}
             </span>
@@ -98,5 +107,19 @@ function Modal({
     </div>
   );
 }
+
+Modal.propTypes = {
+  profilePhoto: PropTypes.string,
+  uploadMessage: PropTypes.shape({
+    type: PropTypes.string,
+    text: PropTypes.string,
+  }),
+  handlePhotoChange: PropTypes.func.isRequired,
+  handleSaveClick: PropTypes.func.isRequired,
+  handleCancelClick: PropTypes.func.isRequired,
+  handleDeleteClick: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool,
+  canSave: PropTypes.bool,
+};
 
 export default Modal;

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -21,8 +21,16 @@ import {
   fetchProfileImage,
 } from "../../services/volunteerServices";
 
-const MAX_PROFILE_PHOTO_SIZE = 5 * 1024 * 1024; // 5 MB
+const MAX_PROFILE_PHOTO_SIZE = 5_000_000; // 5 MB
 const ACCEPTED_PHOTO_TYPES = ["image/jpeg", "image/png"];
+const PHOTO_MODAL_STATE = {
+  UNCHANGED: "unchanged",
+  VALID_UPLOAD_PENDING: "valid-upload-pending",
+  INVALID_SELECTION: "invalid-selection",
+  DELETION_PENDING: "deletion-pending",
+  SAVING: "saving",
+  SAVE_FAILED: "save-failed",
+};
 
 const blobToDataUrl = (blob) =>
   new Promise((resolve, reject) => {
@@ -53,9 +61,14 @@ function Profile() {
   const [uploadMessage, setUploadMessage] = useState(null);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [photoLoadError, setPhotoLoadError] = useState(null);
+  const [photoModalState, setPhotoModalState] = useState(
+    PHOTO_MODAL_STATE.UNCHANGED,
+  );
 
   const profileImageObjectUrlRef = useRef(null);
   const pendingFileRef = useRef(null);
+  const pendingDeleteRef = useRef(false);
+  const saveInFlightRef = useRef(false);
 
   // When we have userDbId, fetch profile image from backend; otherwise fall back to localStorage
   useEffect(() => {
@@ -111,6 +124,8 @@ function Profile() {
         setTempProfilePhoto(savedProfilePhoto);
       }
     }
+    // t is intentionally omitted so language changes do not refetch profile images.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userDbId]);
 
   // Revoke object URL on unmount
@@ -136,26 +151,35 @@ function Profile() {
     if (!file) return;
 
     if (file.size > MAX_PROFILE_PHOTO_SIZE) {
+      pendingFileRef.current = null;
+      pendingDeleteRef.current = false;
+      setTempProfilePhoto(profilePhoto);
       setUploadMessage({
         type: "error",
         text:
           t("PROFILE_PHOTO_ERROR_SIZE") || "File size must be 5 MB or less.",
       });
+      setPhotoModalState(PHOTO_MODAL_STATE.INVALID_SELECTION);
       input.value = "";
       return;
     }
     if (!ACCEPTED_PHOTO_TYPES.includes(file.type)) {
+      pendingFileRef.current = null;
+      pendingDeleteRef.current = false;
+      setTempProfilePhoto(profilePhoto);
       setUploadMessage({
         type: "error",
         text:
           t("PROFILE_PHOTO_ERROR_FORMAT") ||
           "Only JPG and PNG formats are accepted.",
       });
+      setPhotoModalState(PHOTO_MODAL_STATE.INVALID_SELECTION);
       input.value = "";
       return;
     }
 
     pendingFileRef.current = file;
+    pendingDeleteRef.current = false;
 
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -166,12 +190,32 @@ function Profile() {
           t("PROFILE_PHOTO_UPLOAD_SUCCESS") ||
           "Photo accepted. Click Save to confirm.",
       });
+      setPhotoModalState(PHOTO_MODAL_STATE.VALID_UPLOAD_PENDING);
     };
     reader.readAsDataURL(file);
     input.value = "";
   };
 
   const handleSaveClick = async () => {
+    if (photoLoading || saveInFlightRef.current) return;
+    if (
+      photoModalState !== PHOTO_MODAL_STATE.VALID_UPLOAD_PENDING &&
+      photoModalState !== PHOTO_MODAL_STATE.DELETION_PENDING &&
+      photoModalState !== PHOTO_MODAL_STATE.SAVE_FAILED
+    ) {
+      return;
+    }
+
+    const hasPendingUpload = Boolean(pendingFileRef.current);
+    const hasPendingDelete = pendingDeleteRef.current;
+
+    if (!hasPendingUpload && !hasPendingDelete) return;
+
+    saveInFlightRef.current = true;
+    setPhotoModalState(PHOTO_MODAL_STATE.SAVING);
+
+    const isAuthExpiredError = (err) => err?.response?.status === 401;
+
     if (userDbId && pendingFileRef.current) {
       setPhotoLoading(true);
       setPhotoLoadError(null);
@@ -195,68 +239,112 @@ function Profile() {
         }
         window.dispatchEvent(new Event("profile-photo-updated"));
       } catch (err) {
+        if (isAuthExpiredError(err)) {
+          window.location.href = "/login";
+          saveInFlightRef.current = false;
+          setPhotoLoading(false);
+          return;
+        }
         const message =
           err?.response?.data?.message ||
           err?.message ||
           t("PROFILE_PHOTO_ERROR_UPLOAD") ||
           "Failed to update profile photo.";
         setUploadMessage({ type: "error", text: message });
+        setPhotoModalState(PHOTO_MODAL_STATE.SAVE_FAILED);
+        saveInFlightRef.current = false;
         setPhotoLoading(false);
         return;
       }
       pendingFileRef.current = null;
       setPhotoLoading(false);
+    } else if (userDbId && pendingDeleteRef.current) {
+      setPhotoLoading(true);
+      setPhotoLoadError(null);
+      try {
+        await deleteProfileImage(userDbId);
+      } catch (err) {
+        if (isAuthExpiredError(err)) {
+          window.location.href = "/login";
+          saveInFlightRef.current = false;
+          setPhotoLoading(false);
+          return;
+        }
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          t("PROFILE_PHOTO_ERROR_UPLOAD") ||
+          "Failed to update profile photo.";
+        setUploadMessage({ type: "error", text: message });
+        setPhotoModalState(PHOTO_MODAL_STATE.SAVE_FAILED);
+        saveInFlightRef.current = false;
+        setPhotoLoading(false);
+        return;
+      }
+      setPhotoLoading(false);
+      if (profileImageObjectUrlRef.current) {
+        URL.revokeObjectURL(profileImageObjectUrlRef.current);
+        profileImageObjectUrlRef.current = null;
+      }
+      pendingDeleteRef.current = false;
+      setProfilePhoto(DEFAULT_PROFILE_ICON);
+      setTempProfilePhoto(DEFAULT_PROFILE_ICON);
+      localStorage.removeItem("profilePhoto");
+      window.dispatchEvent(new Event("profile-photo-updated"));
     } else {
       setProfilePhoto(tempProfilePhoto);
-      localStorage.setItem("profilePhoto", tempProfilePhoto);
+      if (
+        pendingDeleteRef.current ||
+        tempProfilePhoto === DEFAULT_PROFILE_ICON
+      ) {
+        localStorage.removeItem("profilePhoto");
+      } else {
+        localStorage.setItem("profilePhoto", tempProfilePhoto);
+      }
+      pendingFileRef.current = null;
+      pendingDeleteRef.current = false;
       window.dispatchEvent(new Event("profile-photo-updated"));
     }
+    saveInFlightRef.current = false;
+    setPhotoModalState(PHOTO_MODAL_STATE.UNCHANGED);
     setUploadMessage(null);
     setIsModalOpen(false);
   };
 
   const handleCancelClick = () => {
     pendingFileRef.current = null;
+    pendingDeleteRef.current = false;
     setTempProfilePhoto(profilePhoto);
     setUploadMessage(null);
+    setPhotoModalState(PHOTO_MODAL_STATE.UNCHANGED);
     setIsModalOpen(false);
   };
 
-  const handleDeleteClick = async () => {
+  const handleDeleteClick = () => {
+    if (photoLoading) return;
     const confirmed = window.confirm(
       "Are you sure you want to delete the picture?",
     );
     if (!confirmed) return;
 
-    if (userDbId) {
-      setPhotoLoading(true);
-      setPhotoLoadError(null);
-      try {
-        await deleteProfileImage(userDbId);
-      } catch (err) {
-        const message =
-          err?.response?.data?.message ||
-          err?.message ||
-          t("PROFILE_PHOTO_ERROR_UPLOAD") ||
-          "Failed to update profile photo.";
-        setUploadMessage({ type: "error", text: message });
-        setPhotoLoading(false);
-        return;
-      }
-      setPhotoLoading(false);
-    }
-
-    if (profileImageObjectUrlRef.current) {
-      URL.revokeObjectURL(profileImageObjectUrlRef.current);
-      profileImageObjectUrlRef.current = null;
-    }
     pendingFileRef.current = null;
-    setProfilePhoto(DEFAULT_PROFILE_ICON);
+    pendingDeleteRef.current = profilePhoto !== DEFAULT_PROFILE_ICON;
     setTempProfilePhoto(DEFAULT_PROFILE_ICON);
-    localStorage.removeItem("profilePhoto");
-    window.dispatchEvent(new Event("profile-photo-updated"));
-    setUploadMessage(null);
-    setIsModalOpen(false);
+    setUploadMessage(
+      pendingDeleteRef.current
+        ? {
+            type: "success",
+            text:
+              t("PROFILE_PHOTO_DELETE_PENDING") ||
+              "Photo marked for deletion. Click Save to confirm.",
+          }
+        : null,
+    );
+    setPhotoModalState(
+      pendingDeleteRef.current
+        ? PHOTO_MODAL_STATE.DELETION_PENDING
+        : PHOTO_MODAL_STATE.UNCHANGED,
+    );
   };
 
   const getTabDisplayName = (tab) => {
@@ -292,6 +380,8 @@ function Profile() {
   const openModal = () => {
     setTempProfilePhoto(profilePhoto);
     pendingFileRef.current = null;
+    pendingDeleteRef.current = false;
+    setPhotoModalState(PHOTO_MODAL_STATE.UNCHANGED);
     if (hasUnsavedChanges) {
       const proceed = window.confirm(
         t("UNSAVED_PROFILE_CHANGES_WARNING") ||
@@ -426,6 +516,12 @@ function Profile() {
           handleCancelClick={handleCancelClick}
           handleDeleteClick={handleDeleteClick}
           isSaving={photoLoading}
+          canSave={
+            !photoLoading &&
+            (photoModalState === PHOTO_MODAL_STATE.VALID_UPLOAD_PENDING ||
+              photoModalState === PHOTO_MODAL_STATE.DELETION_PENDING ||
+              photoModalState === PHOTO_MODAL_STATE.SAVE_FAILED)
+          }
         />
       )}
     </div>

--- a/src/pages/Profile/ProfilePhotoModal.test.jsx
+++ b/src/pages/Profile/ProfilePhotoModal.test.jsx
@@ -1,0 +1,329 @@
+/* eslint-env browser, jest */
+/* eslint-disable react/display-name, react/prop-types */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import Profile from "./Profile";
+import {
+  deleteProfileImage,
+  fetchProfileImage,
+  uploadProfileImage,
+} from "../../services/volunteerServices";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, fallback) => fallback || key,
+  }),
+}));
+
+jest.mock("../../services/volunteerServices", () => ({
+  uploadProfileImage: jest.fn(),
+  deleteProfileImage: jest.fn(),
+  fetchProfileImage: jest.fn(),
+}));
+
+jest.mock("./Sidebar", () => {
+  return function SidebarMock({ profilePhoto, openModal }) {
+    return (
+      <button type="button" onClick={openModal}>
+        <img src={profilePhoto} alt="Open profile photo" />
+      </button>
+    );
+  };
+});
+
+jest.mock("./YourProfile", () => () => <div>Your Profile</div>);
+jest.mock("./PersonalInformation", () => () => <div>Personal Information</div>);
+jest.mock("./IdentityDocument", () => () => <div>Identity Document</div>);
+jest.mock("./ChangePassword", () => () => <div>Change Password</div>);
+jest.mock("./OrganizationDetails", () => () => <div>Organization Details</div>);
+jest.mock("./Skills", () => () => <div>Skills</div>);
+jest.mock("./Availability", () => () => <div>Availability</div>);
+jest.mock("./Preferences", () => () => <div>Preferences</div>);
+jest.mock("./SignOff", () => () => <div>Sign Off</div>);
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ state: null }),
+}));
+
+const originalLocation = window.location;
+
+const makeFile = (name, type, size = 1000) => {
+  const file = new File(["x"], name, { type });
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+};
+
+const renderProfile = () => {
+  const store = configureStore({
+    reducer: {
+      auth: () => ({
+        user: { userDbId: "SID-123", userId: "user-1", groups: ["Volunteers"] },
+      }),
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <Profile />
+    </Provider>,
+  );
+};
+
+const openPhotoModal = async () => {
+  renderProfile();
+  fireEvent.click(screen.getByRole("button", { name: /open profile photo/i }));
+  return screen.findByText("PROFILE_PHOTO");
+};
+
+const chooseFile = (file) => {
+  fireEvent.change(screen.getByLabelText("UPLOAD"), {
+    target: { files: [file] },
+  });
+};
+
+describe("Profile photo modal", () => {
+  beforeAll(() => {
+    window.URL.createObjectURL = jest.fn(() => "blob:profile-photo");
+    window.URL.revokeObjectURL = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    fetchProfileImage.mockResolvedValue(null);
+    uploadProfileImage.mockResolvedValue(undefined);
+    deleteProfileImage.mockResolvedValue(undefined);
+    window.confirm = jest.fn(() => true);
+    window.FileReader = jest.fn().mockImplementation(function () {
+      this.readAsDataURL = jest.fn((file) => {
+        setTimeout(() => {
+          this.result = `data:${file.type};base64,preview`;
+          this.onload?.({ target: this });
+          this.onloadend?.({ target: this });
+        }, 0);
+      });
+      this.onload = null;
+      this.onloadend = null;
+      this.onerror = null;
+    });
+  });
+
+  afterAll(() => {
+    delete window.URL.createObjectURL;
+    delete window.URL.revokeObjectURL;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("disables Save by default", async () => {
+    await openPhotoModal();
+
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("enables Save after a valid JPG is selected", async () => {
+    await openPhotoModal();
+
+    chooseFile(makeFile("photo.jpg", "image/jpeg"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+    expect(
+      screen.getByText("PROFILE_PHOTO_UPLOAD_SUCCESS"),
+    ).toBeInTheDocument();
+  });
+
+  it("enables Save after a valid PNG is selected", async () => {
+    await openPhotoModal();
+
+    chooseFile(makeFile("photo.png", "image/png"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+  });
+
+  it("rejects unsupported file types and keeps Save disabled", async () => {
+    await openPhotoModal();
+
+    chooseFile(makeFile("photo.gif", "image/gif"));
+
+    expect(screen.getByText("PROFILE_PHOTO_ERROR_FORMAT")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("rejects files larger than 5 MB and keeps Save disabled", async () => {
+    await openPhotoModal();
+
+    chooseFile(makeFile("photo.jpg", "image/jpeg", 5_000_001));
+
+    expect(screen.getByText("PROFILE_PHOTO_ERROR_SIZE")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("clears validation errors after a valid image is selected", async () => {
+    await openPhotoModal();
+
+    chooseFile(makeFile("photo.webp", "image/webp"));
+    expect(screen.getByText("PROFILE_PHOTO_ERROR_FORMAT")).toBeInTheDocument();
+
+    chooseFile(makeFile("photo.jpg", "image/jpeg"));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("PROFILE_PHOTO_ERROR_FORMAT"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+  });
+
+  it("shows a spinner while saving and prevents duplicate submissions", async () => {
+    let resolveUpload;
+    uploadProfileImage.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+    await openPhotoModal();
+    chooseFile(makeFile("photo.jpg", "image/jpeg"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    fireEvent.click(saveButton);
+    fireEvent.click(saveButton);
+
+    expect(uploadProfileImage).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("status", { name: "SAVING" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+
+    resolveUpload();
+    await waitFor(() =>
+      expect(screen.queryByText("PROFILE_PHOTO")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("saves a valid upload and closes the modal", async () => {
+    fetchProfileImage
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(new Blob(["binary"], { type: "image/jpeg" }));
+    await openPhotoModal();
+    const file = makeFile("photo.jpg", "image/jpeg");
+    chooseFile(file);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(uploadProfileImage).toHaveBeenCalledWith("SID-123", file),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("PROFILE_PHOTO")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("preserves the pending upload after a failure and allows retry", async () => {
+    uploadProfileImage
+      .mockRejectedValueOnce(new Error("Upload failed"))
+      .mockResolvedValueOnce(undefined);
+    await openPhotoModal();
+    chooseFile(makeFile("photo.jpg", "image/jpeg"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText("Upload failed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(uploadProfileImage).toHaveBeenCalledTimes(2));
+  });
+
+  it("stages deletion before save and cancels without calling delete", async () => {
+    fetchProfileImage.mockResolvedValue(
+      new Blob(["binary"], { type: "image/png" }),
+    );
+    await openPhotoModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(deleteProfileImage).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("PROFILE_PHOTO_DELETE_PENDING"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(deleteProfileImage).not.toHaveBeenCalled();
+  });
+
+  it("persists staged deletion on Save", async () => {
+    fetchProfileImage.mockResolvedValue(
+      new Blob(["binary"], { type: "image/png" }),
+    );
+    await openPhotoModal();
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(deleteProfileImage).toHaveBeenCalledWith("SID-123"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("PROFILE_PHOTO")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("replaces an existing photo with a new valid upload", async () => {
+    fetchProfileImage.mockResolvedValue(
+      new Blob(["binary"], { type: "image/png" }),
+    );
+    await openPhotoModal();
+    const file = makeFile("replacement.png", "image/png");
+    chooseFile(file);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(uploadProfileImage).toHaveBeenCalledWith("SID-123", file),
+    );
+    expect(deleteProfileImage).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login on 401 without showing a generic upload error", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { href: "" },
+    });
+    uploadProfileImage.mockRejectedValueOnce({ response: { status: 401 } });
+    await openPhotoModal();
+    chooseFile(makeFile("photo.jpg", "image/jpeg"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(window.location.href).toBe("/login"));
+    expect(
+      screen.queryByText("PROFILE_PHOTO_ERROR_UPLOAD"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/services/volunteerServices.js
+++ b/src/services/volunteerServices.js
@@ -1,6 +1,8 @@
 import api from "./api";
 import endpoints from "./endpoints.json";
-import { fileToBase64 } from "../utils/fileToBase64";
+import { ACCEPTED_IMAGE_TYPES, fileToBase64 } from "../utils/fileToBase64";
+
+const MAX_PROFILE_IMAGE_SIZE = 5_000_000;
 
 export const getVolunteerOrgsList = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_ORGS_LIST);
@@ -93,6 +95,13 @@ export const getMockVolunteersData = async () => {
  */
 export const uploadProfileImage = async (userId, file) => {
   if (!userId) throw new Error("User ID is required");
+  if (!file || !(file instanceof File)) throw new Error("Invalid file");
+  if (!ACCEPTED_IMAGE_TYPES.includes((file.type || "").toLowerCase())) {
+    throw new Error("Only JPG and PNG formats are accepted.");
+  }
+  if (file.size > MAX_PROFILE_IMAGE_SIZE) {
+    throw new Error("File size must be 5 MB or less.");
+  }
   const base64 = await fileToBase64(file);
   const contentType = file.type === "image/png" ? "image/png" : "image/jpeg";
   await api.post(endpoints.UPLOAD_PROFILE_IMAGE, {

--- a/src/services/volunteerServices.test.js
+++ b/src/services/volunteerServices.test.js
@@ -17,6 +17,7 @@ import {
 
 jest.mock("./api");
 jest.mock("../utils/fileToBase64", () => ({
+  ACCEPTED_IMAGE_TYPES: ["image/jpeg", "image/png"],
   fileToBase64: jest.fn(() => Promise.resolve("data:image/jpeg;base64,abc")),
 }));
 
@@ -125,6 +126,26 @@ describe("volunteerServices profile image", () => {
         ),
       ).rejects.toThrow("User ID is required");
     });
+
+    it("throws when profile image type is unsupported", async () => {
+      await expect(
+        uploadProfileImage(
+          "SID-123",
+          new File(["x"], "a.gif", { type: "image/gif" }),
+        ),
+      ).rejects.toThrow("Only JPG and PNG formats are accepted.");
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it("throws when profile image is larger than 5 MB", async () => {
+      const file = new File(["x"], "a.jpg", { type: "image/jpeg" });
+      Object.defineProperty(file, "size", { value: 5_000_001 });
+
+      await expect(uploadProfileImage("SID-123", file)).rejects.toThrow(
+        "File size must be 5 MB or less.",
+      );
+      expect(api.post).not.toHaveBeenCalled();
+    });
   });
 
   describe("deleteProfileImage", () => {
@@ -231,7 +252,7 @@ describe("signOffUser", () => {
       saayamCode: "SAAAYAM-1205",
       message: "User deleted",
       data: { userId: "SID-00-000-002-558" },
-      timestamp: 1770661776.66827198,
+      timestamp: Number("1770661776.66827198"),
     };
     api.request.mockResolvedValue({ data: responseData });
 


### PR DESCRIPTION
- Disable Save button when no profile photo changes are present
- Add explicit modal state for upload, delete, invalid, saving, and failed-save flows
- Validate JPG/PNG file types and enforce 5 MB size limit
- Stage profile photo deletion until Save is confirmed
- Add visible loading spinner while saving and prevent duplicate submissions
- Preserve valid pending changes after recoverable save failures
- Add retry behavior for upload/save failures
- Clear validation errors after selecting a valid image
- Add regression coverage for confirmed fixable QA cases
- Document unresolved TC05 integration details if backend/API clarification is required
- Leave TC15 admin permission behavior pending product clarification