### PR TITLE
feat: Internationalization support for Search in the Navbar (#1545)

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -421,7 +421,7 @@ const Navbar = () => {
               value={searchText}
               onChange={handleSearchChange}
               onKeyDown={handleSearchKeyDown}
-              placeholder="Ask for Saayam"
+              placeholder={t("SEARCH_PLACEHOLDER")}
               size="small"
               fullWidth
               inputProps={{ maxLength: 80 }}
@@ -441,10 +441,7 @@ const Navbar = () => {
               }}
             />
             <p className="text-xs text-gray-500 mt-0.5 pl-4">
-              google with human touch
-              <span title="Trademark pending" className="cursor-help">
-                *
-              </span>
+              {t("SEARCH_TAGLINE")}
             </p>
           </div>
         )}
@@ -487,7 +484,7 @@ const Navbar = () => {
                 value={searchText}
                 onChange={handleSearchChange}
                 onKeyDown={handleSearchKeyDown}
-                placeholder="Ask for Saayam"
+                placeholder={t("SEARCH_PLACEHOLDER")}
                 size="small"
                 fullWidth
                 inputProps={{ maxLength: 80 }}
@@ -507,10 +504,7 @@ const Navbar = () => {
                 }}
               />
               <p className="text-xs text-gray-500 mt-0.5 pl-4">
-                google with human touch
-                <span title="Trademark pending" className="cursor-help">
-                  *
-                </span>
+                {t("SEARCH_TAGLINE")}
               </p>
             </div>
           )}

--- a/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
+++ b/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
@@ -55,7 +55,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":r0:"
                   maxlength="80"
-                  placeholder="Ask for Saayam"
+                  placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                   type="text"
                   value=""
                 />
@@ -79,13 +79,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
             <p
               class="text-xs text-gray-500 mt-0.5 pl-4"
             >
-              google with human touch
-              <span
-                class="cursor-help"
-                title="Trademark pending"
-              >
-                *
-              </span>
+              mockTranslate(SEARCH_TAGLINE)
             </p>
           </div>
           <div
@@ -149,7 +143,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r2:"
                     maxlength="80"
-                    placeholder="Ask for Saayam"
+                    placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                     type="text"
                     value=""
                   />
@@ -173,13 +167,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
               <p
                 class="text-xs text-gray-500 mt-0.5 pl-4"
               >
-                google with human touch
-                <span
-                  class="cursor-help"
-                  title="Trademark pending"
-                >
-                  *
-                </span>
+                mockTranslate(SEARCH_TAGLINE)
               </p>
             </div>
             <div
@@ -468,7 +456,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                 id=":r0:"
                 maxlength="80"
-                placeholder="Ask for Saayam"
+                placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                 type="text"
                 value=""
               />
@@ -492,13 +480,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
           <p
             class="text-xs text-gray-500 mt-0.5 pl-4"
           >
-            google with human touch
-            <span
-              class="cursor-help"
-              title="Trademark pending"
-            >
-              *
-            </span>
+            mockTranslate(SEARCH_TAGLINE)
           </p>
         </div>
         <div
@@ -562,7 +544,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":r2:"
                   maxlength="80"
-                  placeholder="Ask for Saayam"
+                  placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                   type="text"
                   value=""
                 />
@@ -586,13 +568,7 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
             <p
               class="text-xs text-gray-500 mt-0.5 pl-4"
             >
-              google with human touch
-              <span
-                class="cursor-help"
-                title="Trademark pending"
-              >
-                *
-              </span>
+              mockTranslate(SEARCH_TAGLINE)
             </p>
           </div>
           <div

--- a/src/common/i18n/locales/ar/common.json
+++ b/src/common/i18n/locales/ar/common.json
@@ -508,7 +508,7 @@
   "SCAN_ON_DONATE": "يمكنك المسح الضوئي أو النقر على التبرع",
   "SCAN_QR_CODE": "امسح رمز QR للتبرع",
   "SEARCH": "بحث",
-  "SEARCH_PLACEHOLDER": "ابحث هنا…",
+  "SEARCH_PLACEHOLDER": "اطلب المساعدة من Saayam",
   "SECOND LANGUAGE PREFERENCE": "تفضيل اللغة الثانية",
   "SECOND_LANGUAGE_PREFERENCE": "تفضيل اللغة الثانية",
   "SECONDARY PHONE": "هاتف إضافي",
@@ -756,5 +756,6 @@
   "FIND_BY_EMAIL": "البحث بالبريد الإلكتروني",
   "FIND_BY_PHONE": "البحث بالهاتف",
   "ENTER_VOLUNTEER_EMAIL": "أدخل بريد المتطوع الإلكتروني",
-  "ENTER_VOLUNTEER_PHONE": "أدخل هاتف المتطوع"
+  "ENTER_VOLUNTEER_PHONE": "أدخل هاتف المتطوع",
+  "SEARCH_TAGLINE": "جوجل بلمسة إنسانية*"
 }

--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -493,7 +493,7 @@
   "SCAN_ON_DONATE": "আপনি স্ক্যান করতে পারেন অথবা Donate এ ক্লিক করতে পারেন।",
   "SCAN_QR_CODE": "দান করতে QR কোড স্ক্যান করুন",
   "SEARCH": "অনুসন্ধান",
-  "SEARCH_PLACEHOLDER": "অনুসন্ধান প্লেসহোল্ডার",
+  "SEARCH_PLACEHOLDER": "Saayam-এর কাছে সাহায্য চান",
   "SECOND LANGUAGE PREFERENCE": "দ্বিতীয় ভাষা পছন্দ",
   "SECONDARY PHONE": "মাধ্যমিক ফোন",
   "SECONDARY_EMAIL": "সেকেন্ডারি ইমেল",
@@ -756,5 +756,6 @@
   "FIND_BY_EMAIL": "ইমেইল দিয়ে খুঁজুন",
   "FIND_BY_PHONE": "ফোন দিয়ে খুঁজুন",
   "ENTER_VOLUNTEER_EMAIL": "স্বেচ্ছাসেবকের ইমেইল লিখুন",
-  "ENTER_VOLUNTEER_PHONE": "স্বেচ্ছাসেবকের ফোন লিখুন"
+  "ENTER_VOLUNTEER_PHONE": "স্বেচ্ছাসেবকের ফোন লিখুন",
+  "SEARCH_TAGLINE": "মানবিক স্পর্শ সহ গুগল*"
 }

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -506,7 +506,7 @@
   "SCAN_ON_DONATE": "Sie können scannen oder auf Spenden klicken",
   "SCAN_QR_CODE": "QR-Code scannen, um zu spenden",
   "SEARCH": "SUCHEN",
-  "SEARCH_PLACEHOLDER": "Suchplatzhalter",
+  "SEARCH_PLACEHOLDER": "Frag Saayam um Hilfe",
   "SECOND LANGUAGE PREFERENCE": "Zweite Sprachpräferenz",
   "SECONDARY PHONE": "Zweittelefon",
   "SECONDARY_EMAIL": "Sekundäre E-Mail",
@@ -756,5 +756,6 @@
   "FIND_BY_EMAIL": "Nach E-Mail suchen",
   "FIND_BY_PHONE": "Nach Telefon suchen",
   "ENTER_VOLUNTEER_EMAIL": "Freiwilligen-E-Mail eingeben",
-  "ENTER_VOLUNTEER_PHONE": "Freiwilligentelefon eingeben"
+  "ENTER_VOLUNTEER_PHONE": "Freiwilligentelefon eingeben",
+  "SEARCH_TAGLINE": "google mit menschlichem Touch*"
 }

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -513,7 +513,7 @@
   "SCAN_ON_DONATE": "You can scan or click on Donate",
   "SCAN_QR_CODE": "Scan QR Code to Donate",
   "SEARCH": "SEARCH",
-  "SEARCH_PLACEHOLDER": "Search Placeholder",
+  "SEARCH_PLACEHOLDER": "Ask for Saayam",
   "SECOND LANGUAGE PREFERENCE": "Second Language Preference",
   "SECONDARY PHONE": "Secondary Phone",
   "SECONDARY_EMAIL": "Secondary Email",
@@ -784,5 +784,6 @@
   "FIND_BY_EMAIL": "Find by Email",
   "FIND_BY_PHONE": "Find by Phone",
   "ENTER_VOLUNTEER_EMAIL": "Enter volunteer email",
-  "ENTER_VOLUNTEER_PHONE": "Enter volunteer phone"
+  "ENTER_VOLUNTEER_PHONE": "Enter volunteer phone",
+  "SEARCH_TAGLINE": "google with human touch*"
 }

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -494,7 +494,7 @@
   "SCAN_ON_DONATE": "Puedes escanear o hacer clic en Donar",
   "SCAN_QR_CODE": "Scan QR Code to Donate",
   "SEARCH": "SEARCH",
-  "SEARCH_PLACEHOLDER": "Search Placeholder",
+  "SEARCH_PLACEHOLDER": "Pide ayuda a Saayam",
   "SECOND LANGUAGE PREFERENCE": "Second Language Preference",
   "SECONDARY PHONE": "Teléfono secundario",
   "SECONDARY_EMAIL": "Correo electrónico secundario",
@@ -756,5 +756,6 @@
   "FIND_BY_EMAIL": "Buscar por correo electrónico",
   "FIND_BY_PHONE": "Buscar por teléfono",
   "ENTER_VOLUNTEER_EMAIL": "Ingresar correo electrónico del voluntario",
-  "ENTER_VOLUNTEER_PHONE": "Ingresar teléfono del voluntario"
+  "ENTER_VOLUNTEER_PHONE": "Ingresar teléfono del voluntario",
+  "SEARCH_TAGLINE": "google con toque humano*"
 }

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -493,7 +493,7 @@
   "SCAN_ON_DONATE": "Vous pouvez scanner ou cliquer sur Faire un don",
   "SCAN_QR_CODE": "Scannez le code QR pour faire un don",
   "SEARCH": "RECHERCHER",
-  "SEARCH_PLACEHOLDER": "Espace réservé de recherche",
+  "SEARCH_PLACEHOLDER": "Demandez à Saayam",
   "SECOND LANGUAGE PREFERENCE": "Deuxième langue préférée",
   "SECONDARY PHONE": "Téléphone secondaire",
   "SECONDARY_EMAIL": "E-mail secondaire",
@@ -755,5 +755,6 @@
   "FIND_BY_EMAIL": "Rechercher par e-mail",
   "FIND_BY_PHONE": "Rechercher par téléphone",
   "ENTER_VOLUNTEER_EMAIL": "Entrer l'e-mail du bénévole",
-  "ENTER_VOLUNTEER_PHONE": "Entrer le téléphone du bénévole"
+  "ENTER_VOLUNTEER_PHONE": "Entrer le téléphone du bénévole",
+  "SEARCH_TAGLINE": "google avec une touche humaine*"
 }

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -494,7 +494,7 @@
   "SCAN_ON_DONATE": "आप स्कैन कर सकते हैं या दान पर क्लिक कर सकते हैं",
   "SCAN_QR_CODE": "Scan QR Code to Donate",
   "SEARCH": "SEARCH",
-  "SEARCH_PLACEHOLDER": "Search Placeholder",
+  "SEARCH_PLACEHOLDER": "Saayam से मदद माँगें",
   "SECOND LANGUAGE PREFERENCE": "दूसरी भाषा प्राथमिकता",
   "SECONDARY PHONE": "द्वितीयक फ़ोन",
   "SECONDARY_EMAIL": "द्वितीयक ईमेल",
@@ -757,5 +757,6 @@
   "FIND_BY_EMAIL": "ईमेल से खोजें",
   "FIND_BY_PHONE": "फ़ोन से खोजें",
   "ENTER_VOLUNTEER_EMAIL": "स्वयंसेवक का ईमेल दर्ज करें",
-  "ENTER_VOLUNTEER_PHONE": "स्वयंसेवक का फ़ोन दर्ज करें"
+  "ENTER_VOLUNTEER_PHONE": "स्वयंसेवक का फ़ोन दर्ज करें",
+  "SEARCH_TAGLINE": "मानवीय स्पर्श के साथ गूगल*"
 }

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -501,7 +501,7 @@
   "SCAN_ON_DONATE": "Você pode escanear ou clicar em doar",
   "SCAN_QR_CODE": "Escanear Código QR para Doar",
   "SEARCH": "PESQUISAR",
-  "SEARCH_PLACEHOLDER": "Placeholder de Pesquisa",
+  "SEARCH_PLACEHOLDER": "Peça ajuda ao Saayam",
   "SECOND LANGUAGE PREFERENCE": "Segunda preferência de idioma",
   "SECONDARY PHONE": "Telefone secundário",
   "SECONDARY_EMAIL": "E-mail secundário",
@@ -764,5 +764,6 @@
   "FIND_BY_EMAIL": "Buscar por e-mail",
   "FIND_BY_PHONE": "Buscar por telefone",
   "ENTER_VOLUNTEER_EMAIL": "Inserir e-mail do voluntário",
-  "ENTER_VOLUNTEER_PHONE": "Inserir telefone do voluntário"
+  "ENTER_VOLUNTEER_PHONE": "Inserir telefone do voluntário",
+  "SEARCH_TAGLINE": "google com toque humano*"
 }

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -494,7 +494,7 @@
   "SCAN_ON_DONATE": "Вы можете отсканировать или нажать на Пожертвовать",
   "SCAN_QR_CODE": "Scan QR Code to Donate",
   "SEARCH": "SEARCH",
-  "SEARCH_PLACEHOLDER": "Search Placeholder",
+  "SEARCH_PLACEHOLDER": "Попросите помощи у Saayam",
   "SECOND LANGUAGE PREFERENCE": "Second Language Preference",
   "SECONDARY PHONE": "Дополнительный телефон",
   "SECONDARY_EMAIL": "Дополнительный адрес электронной почты",
@@ -756,5 +756,6 @@
   "FIND_BY_EMAIL": "Найти по email",
   "FIND_BY_PHONE": "Найти по телефону",
   "ENTER_VOLUNTEER_EMAIL": "Введите email волонтёра",
-  "ENTER_VOLUNTEER_PHONE": "Введите телефон волонтёра"
+  "ENTER_VOLUNTEER_PHONE": "Введите телефон волонтёра",
+  "SEARCH_TAGLINE": "гугл с человеческим прикосновением*"
 }

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -491,7 +491,7 @@
   "SCAN_ON_DONATE": "మీరు స్కాన్ చేయవచ్చు లేదా డొనేట్ పై క్లిక్ చేయవచ్చు",
   "SCAN_QR_CODE": "విరాళం చేయడానికి QR కోడ్‌ను స్కాన్ చేయండి",
   "SEARCH": "వెతకండి",
-  "SEARCH_PLACEHOLDER": "వెతకండి...",
+  "SEARCH_PLACEHOLDER": "Saayam సహాయం అడగండి",
   "SECOND LANGUAGE PREFERENCE": "రెండవ భాష ప్రాధాన్యత",
   "SECONDARY PHONE": "సెకండరీ ఫోన్",
   "SECONDARY_EMAIL": "ద్వితీయ ఇమెయిల్",
@@ -755,5 +755,6 @@
   "FIND_BY_EMAIL": "ఇమెయిల్‌తో వెతకండి",
   "FIND_BY_PHONE": "ఫోన్‌తో వెతకండి",
   "ENTER_VOLUNTEER_EMAIL": "వాలంటీర్ ఇమెయిల్ నమోదు చేయండి",
-  "ENTER_VOLUNTEER_PHONE": "వాలంటీర్ ఫోన్ నమోదు చేయండి"
+  "ENTER_VOLUNTEER_PHONE": "వాలంటీర్ ఫోన్ నమోదు చేయండి",
+  "SEARCH_TAGLINE": "మానవ స్పర్శతో గూగుల్*"
 }

--- a/src/common/i18n/locales/ur/common.json
+++ b/src/common/i18n/locales/ur/common.json
@@ -416,5 +416,7 @@
   "FIND_BY_EMAIL": "ای میل سے تلاش کریں",
   "FIND_BY_PHONE": "فون سے تلاش کریں",
   "ENTER_VOLUNTEER_EMAIL": "رضاکار کا ای میل درج کریں",
-  "ENTER_VOLUNTEER_PHONE": "رضاکار کا فون درج کریں"
+  "ENTER_VOLUNTEER_PHONE": "رضاکار کا فون درج کریں",
+  "SEARCH_PLACEHOLDER": "Saayam سے مدد مانگیں",
+  "SEARCH_TAGLINE": "انسانی لمس کے ساتھ گوگل*"
 }

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -496,7 +496,7 @@
   "SCAN_ON_DONATE": "您可以扫描或点击捐赠",
   "SCAN_QR_CODE": "Scan QR Code to Donate",
   "SEARCH": "SEARCH",
-  "SEARCH_PLACEHOLDER": "Search Placeholder",
+  "SEARCH_PLACEHOLDER": "向 Saayam 寻求帮助",
   "SECOND_LANGUAGE_PREFERENCE": "第二语言偏好",
   "SECONDARY_PHONE": "辅助电话",
   "SECONDARY_EMAIL": "次要电子邮件",
@@ -751,5 +751,6 @@
   "FIND_BY_EMAIL": "按电子邮件查找",
   "FIND_BY_PHONE": "按电话查找",
   "ENTER_VOLUNTEER_EMAIL": "输入志愿者电子邮件",
-  "ENTER_VOLUNTEER_PHONE": "输入志愿者电话"
+  "ENTER_VOLUNTEER_PHONE": "输入志愿者电话",
+  "SEARCH_TAGLINE": "有人情味的谷歌*"
 }


### PR DESCRIPTION
## Summary
Fixes #1545

## Changes
- Replaced hardcoded `"Ask for Saayam"` placeholder in Navbar with `t("SEARCH_PLACEHOLDER")`
- Replaced hardcoded `"google with human touch*"` tagline in Navbar with `t("SEARCH_TAGLINE")`
- Added `SEARCH_PLACEHOLDER` and `SEARCH_TAGLINE` translation keys to `common.json` for all 12 supported languages:
  English, Mandarin Chinese, Hindi, Spanish, French, Arabic, Bengali, Portuguese, Russian, Urdu, German, Telugu

## Testing
- All 568 tests passing
- Snapshot updated