### PR TITLE
fix: auto-set preferred language from profile when creating request f…

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -100,6 +100,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
   );
   const groups = useSelector((state) => state.auth.user?.groups);
   const userDbId = useSelector((state) => state.auth.user?.userDbId);
+  const user = useSelector((state) => state.auth.user);
   const [location, setLocation] = useState("");
   const { inputRef, suggestions, handleSearchChange, handleSelectSuggestion } =
     usePlacesSearchBox(setLocation);
@@ -194,7 +195,10 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     gender: "Select",
     lead_volunteer: "Ethan Marshall",
     is_calamity: false,
-    preferred_language: "",
+    preferred_language: (() => {
+      const saved = JSON.parse(localStorage.getItem("userPreferences") || "{}");
+      return saved.languagePreference1 || "";
+    })(),
     category: "General",
     request_type: "REMOTE",
     location: "",
@@ -1811,8 +1815,24 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
                       className="appearance-none bg-white border p-2 w-full rounded-lg text-gray-700"
                       onChange={(e) => {
                         const selected = e.target.value;
-                        setFormData({ ...formData, request_for: selected });
-                        setSelfFlag(selected === enums?.requestFor?.[0]); // "SELF" means true, "OTHER" means false
+                        const isOther = selected !== enums?.requestFor?.[0]; // not SELF = OTHER
+                        const savedPrefs = JSON.parse(
+                          localStorage.getItem("userPreferences") || "{}",
+                        );
+                        const profileLang =
+                          savedPrefs.languagePreference1 ||
+                          user?.["custom:pref_first_language"] ||
+                          user?.first_language_preference ||
+                          "";
+                        setFormData({
+                          ...formData,
+                          request_for: selected,
+                          preferred_language:
+                            isOther && profileLang
+                              ? profileLang
+                              : formData.preferred_language,
+                        });
+                        setSelfFlag(!isOther); // "SELF" means true, "OTHER" means false
                       }}
                     >
                       {enums?.requestFor &&

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1839,3 +1839,83 @@ describe("HelpRequestForm — selectedCategoryId tracking (patch coverage)", () 
     ).not.toBeInTheDocument();
   });
 });
+
+describe("HelpRequestForm — preferred language auto-set from profile (#1547)", () => {
+  beforeEach(() => {
+    mockT.mockReset();
+    mockT.mockImplementation((text) => `mockTranslate(${text})`);
+
+    localStorage.setItem(
+      "enums",
+      JSON.stringify({
+        requestType: { IN_PERSON: "IN_PERSON", REMOTE: "REMOTE" },
+        requestPriority: { MEDIUM: 2 },
+        requestFor: { SELF: "SELF", OTHER: "OTHER" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    mockSuggestions = [];
+  });
+
+  it("auto-sets preferred_language from profile when For Self is switched to OTHER", async () => {
+    localStorage.setItem(
+      "userPreferences",
+      JSON.stringify({ languagePreference1: "Hindi" }),
+    );
+
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("preferred_language").value).toBe("Hindi");
+    });
+  });
+
+  it("does not override preferred_language when switching to OTHER with no profile language set", async () => {
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("preferred_language")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("preferred_language"), {
+        target: { value: "Spanish" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "SELF" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("preferred_language").value).toBe(
+        "Spanish",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #1547

When creating a request for Others (For Self = Other), the Preferred 
Language field now auto-populates with the user's First Language 
Preference saved in Profile → Preferences tab.

Changes:
- HelpRequestForm.jsx: read user's first language on form init from localStorage
- HelpRequestForm.jsx: apply profile language when toggling For Self to Other
- Fallback chain: localStorage → Cognito custom:pref_first_language → empty

Testing:
- Set a language in Profile > Preferences, open Create Request, switch 
  For Self to Other → Preferred Language shows that language pre-selected
- All 108 existing tests pass