### PR TITLE
Remove Back navigation button from Sitemap page

### DIFF
--- a/src/pages/Sitemap/Sitemap.jsx
+++ b/src/pages/Sitemap/Sitemap.jsx
@@ -1,22 +1,12 @@
 import React from "react";
 import "./Sitemap.css";
-import { useNavigate } from "react-router-dom";
 import HorizontalAd from "#components/Ads/HorizontalAd";
 
 const Sitemap = () => {
-  const navigate = useNavigate();
-
   return (
     <div className="sitemap-container">
       <div className="sitemap-inner">
-        <div className="w-full mb-4">
-          <button
-            onClick={() => navigate(-1)}
-            className="text-blue-600 hover:text-blue-800 font-semibold text-lg flex items-center"
-          >
-            <span className="text-2xl mr-2">&lt;</span> Back
-          </button>
-        </div>
+        <div className="w-full mb-4"></div>
         <h1 className="sitemap-title">Sitemap</h1>
         <div className="sitemap-content-wrapper">
           {/* Row 1: Home */}


### PR DESCRIPTION
Removed the Back navigation button from the Sitemap page since breadcrumbs already provide navigation.

Testing:
- Verified only Sitemap.jsx was changed
- Removed unused navigation code
- Verified the Back navigation button is removed

Refs #1568