### PR TITLE
fix(profile-photo): restore upload save flow

### DIFF
--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -220,22 +220,31 @@ function Profile() {
       setPhotoLoading(true);
       setPhotoLoadError(null);
       try {
+        const savedPreviewPhoto = tempProfilePhoto;
         await uploadProfileImage(userDbId, pendingFileRef.current);
-        const blob = await fetchProfileImage(userDbId);
-        if (blob) {
-          if (profileImageObjectUrlRef.current) {
-            URL.revokeObjectURL(profileImageObjectUrlRef.current);
+
+        setProfilePhoto(savedPreviewPhoto);
+        setTempProfilePhoto(savedPreviewPhoto);
+        localStorage.setItem("profilePhoto", savedPreviewPhoto);
+
+        try {
+          const blob = await fetchProfileImage(userDbId);
+          if (blob) {
+            if (profileImageObjectUrlRef.current) {
+              URL.revokeObjectURL(profileImageObjectUrlRef.current);
+            }
+            const url = URL.createObjectURL(blob);
+            profileImageObjectUrlRef.current = url;
+            setProfilePhoto(url);
+            setTempProfilePhoto(url);
+            const dataUrl = await blobToDataUrl(blob);
+            localStorage.setItem("profilePhoto", dataUrl);
           }
-          const url = URL.createObjectURL(blob);
-          profileImageObjectUrlRef.current = url;
-          setProfilePhoto(url);
-          setTempProfilePhoto(url);
-          const dataUrl = await blobToDataUrl(blob);
-          localStorage.setItem("profilePhoto", dataUrl);
-        } else {
-          setProfilePhoto(DEFAULT_PROFILE_ICON);
-          setTempProfilePhoto(DEFAULT_PROFILE_ICON);
-          localStorage.removeItem("profilePhoto");
+        } catch (refreshError) {
+          console.warn(
+            "Profile photo uploaded, but refreshing the saved image failed.",
+            refreshError,
+          );
         }
         window.dispatchEvent(new Event("profile-photo-updated"));
       } catch (err) {

--- a/src/pages/Profile/ProfilePhotoModal.test.jsx
+++ b/src/pages/Profile/ProfilePhotoModal.test.jsx
@@ -232,6 +232,65 @@ describe("Profile photo modal", () => {
     );
   });
 
+  it("treats upload as successful when post-upload refresh fails", async () => {
+    const consoleWarn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    fetchProfileImage
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("refresh failed"));
+    await openPhotoModal();
+    const file = makeFile("photo.jpg", "image/jpeg");
+    chooseFile(file);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(uploadProfileImage).toHaveBeenCalledWith("SID-123", file),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("PROFILE_PHOTO")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByAltText("Open profile photo")).toHaveAttribute(
+      "src",
+      "data:image/jpeg;base64,preview",
+    );
+    expect(localStorage.getItem("profilePhoto")).toBe(
+      "data:image/jpeg;base64,preview",
+    );
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Profile photo uploaded, but refreshing the saved image failed.",
+      expect.any(Error),
+    );
+
+    consoleWarn.mockRestore();
+  });
+
+  it("saves a valid PNG upload", async () => {
+    fetchProfileImage
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(new Blob(["binary"], { type: "image/png" }));
+    await openPhotoModal();
+    const file = makeFile("photo.png", "image/png");
+    chooseFile(file);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(uploadProfileImage).toHaveBeenCalledWith("SID-123", file),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("PROFILE_PHOTO")).not.toBeInTheDocument(),
+    );
+  });
+
   it("preserves the pending upload after a failure and allows retry", async () => {
     uploadProfileImage
       .mockRejectedValueOnce(new Error("Upload failed"))


### PR DESCRIPTION
- Restore profile photo upload/save behavior for valid JPG and PNG files
- Preserve existing Base64 JSON upload payload contract
- Separate upload failure handling from post-upload refresh failure
- Treat successful upload as success even if immediate image refresh fails
- Preserve pending selected file after recoverable failures for retry
- Keep existing validation, disabled Save, and loading-state fixes intact
- Add regression coverage for TC05 and related upload/save flows