### PR TITLE
fix navbar search reset on logout

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -105,6 +105,12 @@ const Navbar = () => {
   const { t } = useTranslation();
 
   useEffect(() => {
+    if (!user?.userId) {
+      setSearchText("");
+    }
+  }, [user?.userId]);
+
+  useEffect(() => {
     const savedProfilePhoto = localStorage.getItem("profilePhoto");
     if (savedProfilePhoto) setProfileIcon(savedProfilePhoto);
   }, []);
@@ -353,6 +359,7 @@ const Navbar = () => {
   };
 
   const handleSignOut = () => {
+    setSearchText("");
     dispatch(logout());
     setIsLogoutModalOpen(false);
     navigate("/login");
@@ -418,6 +425,8 @@ const Navbar = () => {
         {user?.userId && (
           <div className="flex flex-col md:hidden flex-1 mx-2">
             <TextField
+              name="navbar-search"
+              autoComplete="off"
               value={searchText}
               onChange={handleSearchChange}
               onKeyDown={handleSearchKeyDown}
@@ -481,6 +490,8 @@ const Navbar = () => {
           {user?.userId && (
             <div className="flex flex-col w-full max-w-[800px] mr-4">
               <TextField
+                name="navbar-search"
+                autoComplete="off"
                 value={searchText}
                 onChange={handleSearchChange}
                 onKeyDown={handleSearchKeyDown}

--- a/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
+++ b/src/common/components/Navbar/__snapshots__/navbar.test.js.snap
@@ -52,9 +52,11 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
+                  autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":r0:"
                   maxlength="80"
+                  name="navbar-search"
                   placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                   type="text"
                   value=""
@@ -140,9 +142,11 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                   </div>
                   <input
                     aria-invalid="false"
+                    autocomplete="off"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r2:"
                     maxlength="80"
+                    name="navbar-search"
                     placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                     type="text"
                     value=""
@@ -453,9 +457,11 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
               </div>
               <input
                 aria-invalid="false"
+                autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                 id=":r0:"
                 maxlength="80"
+                name="navbar-search"
                 placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                 type="text"
                 value=""
@@ -541,9 +547,11 @@ exports[`Navbar renders correctly when user is logged in 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
+                  autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":r2:"
                   maxlength="80"
+                  name="navbar-search"
                   placeholder="mockTranslate(SEARCH_PLACEHOLDER)"
                   type="text"
                   value=""

--- a/src/common/components/Navbar/navbar.test.js
+++ b/src/common/components/Navbar/navbar.test.js
@@ -1,8 +1,13 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithProviders } from "#utils/test-utils";
 import {
   MOCK_STATE_LOGGED_IN,
   MOCK_STATE_LOGGED_OUT,
 } from "#utils/test-utils.jsx";
+import {
+  loginSuccess,
+  logoutSuccess,
+} from "../../../redux/features/authentication/authSlice";
 import Navbar from "./Navbar";
 
 beforeAll(() => {
@@ -27,5 +32,34 @@ describe("Navbar", () => {
       preloadedState: MOCK_STATE_LOGGED_OUT,
     });
     expect(tree).toMatchSnapshot();
+  });
+
+  it("clears the navbar search text when the user logs out and logs back in", async () => {
+    const { store } = renderWithProviders(<Navbar />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    const searchInput = screen.getAllByRole("textbox")[0];
+
+    fireEvent.change(searchInput, { target: { value: "example query" } });
+    expect(searchInput.value).toBe("example query");
+
+    act(() => {
+      store.dispatch(logoutSuccess());
+    });
+
+    act(() => {
+      store.dispatch(
+        loginSuccess({
+          user: {
+            userId: "mockUser2",
+          },
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("textbox")[0].value).toBe(""),
+    );
   });
 });


### PR DESCRIPTION
## Summary
## Issue #1544 
- Fixed the navbar search so it clears on logout instead of keeping the previous query.
- Reduced email autofill in the search input by setting a unique field name and disabling autocomplete.
- Added a regression test to verify the search field resets across logout and login.
- Updated the related navbar snapshot to match the new input attributes.
- Verified the change with the targeted Jest test for the navbar.