### PR TITLE
feat: increase identity document upload limit to 5MB

### DIFF
--- a/src/common/i18n/locales/en/identity.json
+++ b/src/common/i18n/locales/en/identity.json
@@ -10,9 +10,9 @@
   "UPLOAD": "Upload",
   "UPLOADING": "Uploading...",
   "REMOVE": "Remove",
-  "FILE_SIZE_ERROR": "File size should not exceed 2MB",
+  "FILE_SIZE_ERROR": "File size should not exceed 5MB",
   "FILE_TYPE_ERROR": "Only JPEG, JPG, PNG, and PDF files are allowed. File type detected: {{fileType}}, extension: {{extension}}",
-  "FILE_TYPE_REQUIREMENT": "Only JPEG, JPG, PNG, or PDF files. Max size: 2MB.",
+  "FILE_TYPE_REQUIREMENT": "Only JPEG, JPG, PNG, or PDF files. Max size: 5MB.",
   "UPLOAD_SUCCESS": "File uploaded successfully",
   "UPLOAD_FAILED": "File upload failed",
   "UPLOAD_ERROR": "An error occurred during file upload"

--- a/src/pages/Profile/IdentityDocument.jsx
+++ b/src/pages/Profile/IdentityDocument.jsx
@@ -24,7 +24,9 @@ const IdentityDocument = ({ setHasUnsavedChanges }) => {
     console.log("File size:", selectedFile.size);
 
     // Validate file size (2MB)
-    if (selectedFile.size > 2 * 1024 * 1024) {
+    console.log("Selected file size:", selectedFile.size);
+    console.log("5MB limit:", 5 * 1024 * 1024);
+    if (selectedFile.size > 5 * 1024 * 1024) {
       setError(t("FILE_SIZE_ERROR"));
       setFile(null);
       setPreview("");

--- a/src/pages/Volunteer/steps/VolunteerCourse.jsx
+++ b/src/pages/Volunteer/steps/VolunteerCourse.jsx
@@ -21,7 +21,7 @@ const VolunteerCourse = ({ selectedFile, setSelectedFile, setIsUploaded }) => {
       console.log("File type:", uploadedFile.type);
       console.log("File size:", uploadedFile.size);
 
-      if (uploadedFile.size > 2 * 1024 * 1024) {
+      if (uploadedFile.size > 5 * 1024 * 1024) {
         setError(t("FILE_SIZE_ERROR"));
         setFile(null);
         setPreview("");


### PR DESCRIPTION
#1579 
Updated file upload validation limits from 2MB to 5MB for Identity Document uploads. Modified file size validation logic and updated user-facing error messages to reflect the new upload limit. Verified that files up to 5MB are accepted and files exceeding the limit are appropriately rejected.
