### PR TITLE
fix: ensure subject is never null on request submission (#1548)

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -1130,6 +1130,11 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       return;
     }
 
+    // Capture the resolved subject in a local variable so it is available
+    // synchronously for both submissionData and checkProfanity regardless of
+    // whether React has flushed the setFormData state update yet.
+    let resolvedSubject = formData.subject;
+
     if (
       !isEdit &&
       !hasUserEditedSubjectRef.current &&
@@ -1139,6 +1144,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
         const response = await generateSubject(formData.description);
         const generatedSubject = response?.body?.subject;
         if (generatedSubject) {
+          resolvedSubject = generatedSubject;
           setFormData((prev) => ({ ...prev, subject: generatedSubject }));
         }
       } catch (error) {
@@ -1146,15 +1152,23 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       }
     }
 
+    // Fallback: if the API failed or returned nothing and the user left the
+    // subject blank, derive a subject from the description so it is never null.
+    if (!resolvedSubject || resolvedSubject.trim() === "") {
+      resolvedSubject = formData.description.trim().slice(0, 70);
+      setFormData((prev) => ({ ...prev, subject: resolvedSubject }));
+    }
+
     const submissionData = {
       ...formData,
+      subject: resolvedSubject,
       location,
     };
 
     setIsSubmitting(true);
     try {
       const res = await checkProfanity({
-        subject: formData.subject,
+        subject: resolvedSubject,
         description: formData.description,
       });
 

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -850,11 +850,96 @@ describe("HelpRequestForm — generateSubject auto-fill", () => {
     expect(generateSubject).not.toHaveBeenCalled();
   });
 
-  it("logs error and leaves subject empty when generateSubject API fails", async () => {
+  it("falls back to description (first 70 chars) as subject when generateSubject API fails", async () => {
     const { generateSubject } = require("../../services/requestServices");
+    const {
+      checkProfanity,
+      createRequest,
+    } = require("../../services/requestServices");
     generateSubject.mockRejectedValue(new Error("API error"));
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    createRequest.mockResolvedValue({ data: { requestId: "REQ-FALLBACK" } });
 
     renderForm();
+
+    // Select a non-General category to bypass the predict-categories modal
+    selectSubcategory();
+
+    const description = "I need help picking up groceries from the store.";
+    await act(async () => {
+      fireEvent.change(document.getElementById("description"), {
+        target: { name: "description", value: description },
+      });
+    });
+
+    // generateSubject should NOT be called while typing
+    expect(generateSubject).not.toHaveBeenCalled();
+
+    // generateSubject is called on submit, fails, then fallback kicks in
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form"));
+    });
+
+    expect(generateSubject).toHaveBeenCalled();
+
+    // Subject field should be populated with the first 70 chars of description
+    await waitFor(() => {
+      expect(document.getElementById("subject").value).toBe(
+        description.slice(0, 70),
+      );
+    });
+
+    // The request should still be submitted (not blocked by blank subject)
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+  });
+
+  it("falls back to description when generateSubject returns empty body", async () => {
+    const { generateSubject } = require("../../services/requestServices");
+    const {
+      checkProfanity,
+      createRequest,
+    } = require("../../services/requestServices");
+    generateSubject.mockResolvedValue({ body: null });
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+    createRequest.mockResolvedValue({ data: { requestId: "REQ-NOBODY" } });
+
+    renderForm();
+
+    selectSubcategory();
+
+    const description = "Help me with my apartment lease review please.";
+    await act(async () => {
+      fireEvent.change(document.getElementById("description"), {
+        target: { name: "description", value: description },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.submit(document.querySelector("form"));
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("subject").value).toBe(
+        description.slice(0, 70),
+      );
+    });
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+  });
+
+  it("passes resolved subject (not stale formData.subject) to checkProfanity", async () => {
+    const {
+      generateSubject,
+      checkProfanity,
+    } = require("../../services/requestServices");
+    generateSubject.mockResolvedValue({
+      body: { subject: "AI Generated Subject", max_length: 70 },
+    });
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
+
+    renderForm();
+
+    selectSubcategory();
 
     await act(async () => {
       fireEvent.change(document.getElementById("description"), {
@@ -865,16 +950,16 @@ describe("HelpRequestForm — generateSubject auto-fill", () => {
       });
     });
 
-    //generateSubject should NOT be called while typing
-    expect(generateSubject).not.toHaveBeenCalled();
-
-    //generateSubject should be called on submit
     await act(async () => {
       fireEvent.submit(document.querySelector("form"));
     });
 
-    expect(generateSubject).toHaveBeenCalled();
-    expect(document.getElementById("subject").value).toBe("");
+    await waitFor(() => expect(checkProfanity).toHaveBeenCalled());
+
+    // checkProfanity must receive the AI-generated subject, not the original ""
+    expect(checkProfanity).toHaveBeenCalledWith(
+      expect.objectContaining({ subject: "AI Generated Subject" }),
+    );
   });
 
   it("does not overwrite subject the user has manually typed", async () => {


### PR DESCRIPTION
Summary

- Root cause: `generateSubject` is async, but the code only used its result to call `setFormData` (a React async state update). When `submissionData` was built immediately after `await`, it spread `...formData` which still held the old empty `subject` — React hadn't re-rendered yet. This propagated a blank `requestSubject` to the backend.
- Fix: Introduced a `resolvedSubject` local variable that is updated synchronously with the API result, then used explicitly in `submissionData` and `checkProfanity`.
- Fallback added: If `generateSubject` fails or returns nothing, `resolvedSubject` is derived from the first 70 characters of the description, and `setFormData` is also called so the UI subject field reflects the value.
- `checkProfanity` fixed: Now receives `resolvedSubject` instead of the stale `formData.subject` (empty string).

Test plan

- Replaced stale test with correct fallback-behaviour test
- Added test: falls back to description (first 70 chars) when generateSubject API fails
- Added test: falls back to description when generateSubject returns empty body
- Added test: passes resolved subject (not stale formData.subject) to checkProfanity
- All 48 tests pass

Closes #1548