### PR TITLE
fix: preserve additional info selections across help request tab switches

### DIFF
--- a/src/pages/HelpRequest/Categories/DynamicAdditionalFields.jsx
+++ b/src/pages/HelpRequest/Categories/DynamicAdditionalFields.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 const LABEL_WORD_OVERRIDES = {
@@ -33,6 +33,8 @@ const toTitleCase = (str) =>
     })
     .join(" ");
 
+const EMPTY_FIELD_VALUES = {};
+
 /**
  * DynamicAdditionalFields
  *
@@ -41,12 +43,15 @@ const toTitleCase = (str) =>
  *
  * Props:
  *   catId        – currently selected category ID (e.g. "1.1", "6.4")
- *   onChange      – callback receiving { [fieldId]: value } on every change
- *   initialValues – optional pre-filled values (for edit mode)
+ *   value        – current field values owned by the parent form
+ *   onChange     – callback receiving { [fieldId]: value } on every change
  */
-const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
+const DynamicAdditionalFields = ({
+  catId,
+  value = EMPTY_FIELD_VALUES,
+  onChange,
+}) => {
   const { t } = useTranslation("metadata");
-  const [fieldValues, setFieldValues] = useState({});
 
   // ── Resolve metadata for the current catId ──────────────────────────
   const metadataFields = useMemo(() => {
@@ -73,48 +78,44 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
     }
   }, [catId]);
 
-  // ── Reset field values when catId changes ───────────────────────────
-  useEffect(() => {
-    if (initialValues) {
-      setFieldValues(initialValues);
-    } else {
-      setFieldValues({});
-    }
-  }, [catId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── Propagate changes to parent ─────────────────────────────────────
-  useEffect(() => {
-    if (metadataFields.length > 0) {
-      onChange(fieldValues);
-    }
-  }, [fieldValues]); // eslint-disable-line react-hooks/exhaustive-deps
-
   // ── Nothing to render ───────────────────────────────────────────────
   if (metadataFields.length === 0) return null;
 
   // ── Helpers ─────────────────────────────────────────────────────────
-  const updateField = (fieldId, value) => {
-    setFieldValues((prev) => ({ ...prev, [fieldId]: value }));
+  const updateField = (fieldId, nextValue) => {
+    onChange({ ...value, [fieldId]: nextValue });
   };
 
   const toggleCheckbox = (fieldId, itemValue) => {
-    setFieldValues((prev) => {
-      const current = Array.isArray(prev[fieldId]) ? prev[fieldId] : [];
-      const next = current.includes(itemValue)
-        ? current.filter((v) => v !== itemValue)
-        : [...current, itemValue];
-      return { ...prev, [fieldId]: next };
+    const current = Array.isArray(value[fieldId]) ? value[fieldId] : [];
+    const next = current.includes(itemValue)
+      ? current.filter((v) => v !== itemValue)
+      : [...current, itemValue];
+    onChange({ ...value, [fieldId]: next });
+  };
+
+  const updateListItemValue = (fieldId, itemId, nextValue) => {
+    const current =
+      value[fieldId] !== null &&
+      typeof value[fieldId] === "object" &&
+      !Array.isArray(value[fieldId])
+        ? value[fieldId]
+        : {};
+    onChange({
+      ...value,
+      [fieldId]: { ...current, [itemId]: nextValue },
     });
   };
 
-  const updateListItemValue = (fieldId, itemId, value) => {
-    setFieldValues((prev) => {
-      const current =
-        typeof prev[fieldId] === "object" && !Array.isArray(prev[fieldId])
-          ? prev[fieldId]
-          : {};
-      return { ...prev, [fieldId]: { ...current, [itemId]: value } };
-    });
+  const getFieldValue = (fieldId) => value[fieldId] ?? "";
+
+  const getNestedFieldValue = (fieldId, itemId) => {
+    const current = value[fieldId];
+    return current !== null &&
+      typeof current === "object" &&
+      !Array.isArray(current)
+      ? (current[itemId] ?? "")
+      : "";
   };
 
   const translateMetadataLabel = (key, fallback) => {
@@ -142,8 +143,8 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
               name={fieldId}
               value={item.itemId}
               checked={
-                Array.isArray(fieldValues[fieldId]) &&
-                fieldValues[fieldId].includes(item.itemId)
+                Array.isArray(value[fieldId]) &&
+                value[fieldId].includes(item.itemId)
               }
               onChange={() => updateField(fieldId, [item.itemId])}
               className="rounded"
@@ -158,8 +159,8 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
           <label key={key} className="flex items-center space-x-2">
             <input
               type="checkbox"
-              checked={(Array.isArray(fieldValues[fieldId])
-                ? fieldValues[fieldId]
+              checked={(Array.isArray(value[fieldId])
+                ? value[fieldId]
                 : []
               ).includes(item.itemId)}
               onChange={() => toggleCheckbox(fieldId, item.itemId)}
@@ -178,12 +179,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             </span>
             <input
               type="text"
-              value={
-                (typeof fieldValues[fieldId] === "object" &&
-                  !Array.isArray(fieldValues[fieldId]) &&
-                  fieldValues[fieldId]?.[item.itemId]) ||
-                ""
-              }
+              value={getNestedFieldValue(fieldId, item.itemId)}
               onChange={(e) =>
                 updateListItemValue(fieldId, item.itemId, e.target.value)
               }
@@ -201,12 +197,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             </span>
             <input
               type="number"
-              value={
-                (typeof fieldValues[fieldId] === "object" &&
-                  !Array.isArray(fieldValues[fieldId]) &&
-                  fieldValues[fieldId]?.[item.itemId]) ||
-                ""
-              }
+              value={getNestedFieldValue(fieldId, item.itemId)}
               onChange={(e) =>
                 updateListItemValue(fieldId, item.itemId, e.target.value)
               }
@@ -228,12 +219,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
                 type="number"
                 min="0"
                 step="0.01"
-                value={
-                  (typeof fieldValues[fieldId] === "object" &&
-                    !Array.isArray(fieldValues[fieldId]) &&
-                    fieldValues[fieldId]?.[item.itemId]) ||
-                  ""
-                }
+                value={getNestedFieldValue(fieldId, item.itemId)}
                 onChange={(e) =>
                   updateListItemValue(fieldId, item.itemId, e.target.value)
                 }
@@ -252,12 +238,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             </span>
             <input
               type="date"
-              value={
-                (typeof fieldValues[fieldId] === "object" &&
-                  !Array.isArray(fieldValues[fieldId]) &&
-                  fieldValues[fieldId]?.[`${item.itemId}_date`]) ||
-                ""
-              }
+              value={getNestedFieldValue(fieldId, `${item.itemId}_date`)}
               onChange={(e) =>
                 updateListItemValue(
                   fieldId,
@@ -270,12 +251,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             />
             <input
               type="time"
-              value={
-                (typeof fieldValues[fieldId] === "object" &&
-                  !Array.isArray(fieldValues[fieldId]) &&
-                  fieldValues[fieldId]?.[`${item.itemId}_time`]) ||
-                ""
-              }
+              value={getNestedFieldValue(fieldId, `${item.itemId}_time`)}
               onChange={(e) =>
                 updateListItemValue(
                   fieldId,
@@ -309,7 +285,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             </label>
             <input
               type="text"
-              value={fieldValues[fieldId] || ""}
+              value={getFieldValue(fieldId)}
               onChange={(e) => updateField(fieldId, e.target.value)}
               className="w-full rounded-lg border border-gray-300 py-2 px-3"
               data-testid={`field-${fieldId}`}
@@ -328,7 +304,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             <input
               type="number"
               min="0"
-              value={fieldValues[fieldId] || ""}
+              value={getFieldValue(fieldId)}
               onChange={(e) => updateField(fieldId, e.target.value)}
               className="w-full rounded-lg border border-gray-300 py-2 px-3"
               data-testid={`field-${fieldId}`}
@@ -342,7 +318,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
           <div key={fieldId} className="mt-3 flex items-center space-x-2">
             <input
               type="checkbox"
-              checked={fieldValues[fieldId] === "true"}
+              checked={value[fieldId] === "true"}
               onChange={(e) =>
                 updateField(fieldId, e.target.checked ? "true" : "false")
               }
@@ -363,11 +339,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             <div className="flex gap-2">
               <input
                 type="date"
-                value={
-                  (fieldValues[fieldId] &&
-                    fieldValues[fieldId][`${fieldId}_date`]) ||
-                  ""
-                }
+                value={getNestedFieldValue(fieldId, `${fieldId}_date`)}
                 onChange={(e) =>
                   updateListItemValue(
                     fieldId,
@@ -380,11 +352,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
               />
               <input
                 type="time"
-                value={
-                  (fieldValues[fieldId] &&
-                    fieldValues[fieldId][`${fieldId}_time`]) ||
-                  ""
-                }
+                value={getNestedFieldValue(fieldId, `${fieldId}_time`)}
                 onChange={(e) =>
                   updateListItemValue(
                     fieldId,
@@ -408,7 +376,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
             </label>
             <input
               type="time"
-              value={fieldValues[fieldId] || ""}
+              value={getFieldValue(fieldId)}
               onChange={(e) => updateField(fieldId, e.target.value)}
               className="rounded-lg border border-gray-300 py-2 px-3"
               data-testid={`field-${fieldId}`}
@@ -429,7 +397,7 @@ const DynamicAdditionalFields = ({ catId, onChange, initialValues = null }) => {
                 type="number"
                 min="0"
                 step="0.01"
-                value={fieldValues[fieldId] || ""}
+                value={getFieldValue(fieldId)}
                 onChange={(e) => updateField(fieldId, e.target.value)}
                 className="w-full rounded-lg border border-gray-300 py-2 px-3"
                 data-testid={`field-${fieldId}`}

--- a/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
+++ b/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
@@ -420,9 +420,20 @@ describe("DynamicAdditionalFields", () => {
 
   it("calls onChange correctly when checkbox is toggled off", () => {
     const onChange = jest.fn();
-    render(<DynamicAdditionalFields catId="1.1" onChange={onChange} />);
+    const { rerender } = render(
+      <DynamicAdditionalFields catId="1.1" onChange={onChange} />,
+    );
     // Toggle on
     fireEvent.click(screen.getByTestId("checkbox-1.1.B.1"));
+    const firstCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    rerender(
+      <DynamicAdditionalFields
+        catId="1.1"
+        value={firstCall}
+        onChange={onChange}
+      />,
+    );
+
     // Toggle off
     fireEvent.click(screen.getByTestId("checkbox-1.1.B.1"));
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
@@ -521,13 +532,13 @@ describe("DynamicAdditionalFields", () => {
     expect(lastCall["3.7.B"]["3.7.B_time"]).toBe("14:30");
   });
 
-  it("renders date&time fields with initial values", () => {
+  it("renders date&time fields with controlled values", () => {
     const onChange = jest.fn();
     render(
       <DynamicAdditionalFields
         catId="3.7"
         onChange={onChange}
-        initialValues={{
+        value={{
           "3.7.B": {
             "3.7.B_date": "2026-03-15",
             "3.7.B_time": "14:30",
@@ -553,10 +564,20 @@ describe("DynamicAdditionalFields", () => {
 
   it("calls onChange when standalone checkbox is toggled", () => {
     const onChange = jest.fn();
-    render(<DynamicAdditionalFields catId="3.7" onChange={onChange} />);
+    const { rerender } = render(
+      <DynamicAdditionalFields catId="3.7" onChange={onChange} />,
+    );
     fireEvent.click(screen.getByTestId("field-3.7.D"));
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall["3.7.D"]).toBe("true");
+
+    rerender(
+      <DynamicAdditionalFields
+        catId="3.7"
+        value={lastCall}
+        onChange={onChange}
+      />,
+    );
 
     // Click again to uncheck and verify "false" is sent
     fireEvent.click(screen.getByTestId("field-3.7.D"));
@@ -564,13 +585,13 @@ describe("DynamicAdditionalFields", () => {
     expect(secondCall["3.7.D"]).toBe("false");
   });
 
-  it("renders standalone checkbox with initial 'true' value", () => {
+  it("renders standalone checkbox with controlled 'true' value", () => {
     const onChange = jest.fn();
     render(
       <DynamicAdditionalFields
         catId="3.7"
         onChange={onChange}
-        initialValues={{
+        value={{
           "3.7.D": "true",
         }}
       />,
@@ -578,13 +599,13 @@ describe("DynamicAdditionalFields", () => {
     expect(screen.getByTestId("field-3.7.D")).toBeChecked();
   });
 
-  it("renders standalone checkbox with initial 'false' value", () => {
+  it("renders standalone checkbox with controlled 'false' value", () => {
     const onChange = jest.fn();
     render(
       <DynamicAdditionalFields
         catId="3.7"
         onChange={onChange}
-        initialValues={{
+        value={{
           "3.7.D": "false",
         }}
       />,
@@ -756,15 +777,15 @@ describe("DynamicAdditionalFields", () => {
     expect(screen.queryByText("Unknown")).not.toBeInTheDocument();
   });
 
-  // ── initialValues prop ──────────────────────────────────────────────
+  // ── Controlled value prop ───────────────────────────────────────────
 
-  it("uses initialValues when provided", () => {
+  it("uses controlled value when provided", () => {
     const onChange = jest.fn();
     render(
       <DynamicAdditionalFields
         catId="1.1"
         onChange={onChange}
-        initialValues={{ "1.1.A": ["1.1.A.2"] }}
+        value={{ "1.1.A": ["1.1.A.2"] }}
       />,
     );
     expect(screen.getByTestId("radio-1.1.A.2")).toBeChecked();

--- a/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
+++ b/src/pages/HelpRequest/Categories/DynamicAdditionalFields.test.jsx
@@ -291,6 +291,25 @@ const sampleMetadata = [
     ],
   },
   {
+    catId: "unknown-list-item",
+    fields: [
+      {
+        fieldId: "uli.A",
+        fieldNameKey: "UNKNOWN_LIST_ITEM",
+        fieldType: "list",
+        status: "active",
+        catId: "unknown-list-item",
+        listItems: [
+          {
+            itemId: "uli.A.1",
+            itemValue: "UNSUPPORTED_OPTION",
+            itemType: "unsupportedType",
+          },
+        ],
+      },
+    ],
+  },
+  {
     catId: "unknown-type",
     fields: [
       {
@@ -766,6 +785,16 @@ describe("DynamicAdditionalFields", () => {
     expect(screen.getByTestId("text-ml.A.2")).toBeInTheDocument();
   });
 
+  it("skips unsupported list item types", () => {
+    const onChange = jest.fn();
+    render(
+      <DynamicAdditionalFields catId="unknown-list-item" onChange={onChange} />,
+    );
+
+    expect(screen.getByText("Unknown List Item")).toBeInTheDocument();
+    expect(screen.queryByText("Unsupported Option")).not.toBeInTheDocument();
+  });
+
   // ── Unknown field type ──────────────────────────────────────────────
 
   it("renders the wrapper but skips unknown field types", () => {
@@ -789,6 +818,25 @@ describe("DynamicAdditionalFields", () => {
       />,
     );
     expect(screen.getByTestId("radio-1.1.A.2")).toBeChecked();
+  });
+
+  it("preserves controlled zero values", () => {
+    const onChange = jest.fn();
+    render(
+      <DynamicAdditionalFields
+        catId="3.6"
+        onChange={onChange}
+        value={{
+          "3.6.D": 0,
+          "3.6.J": {
+            "3.6.J.1": 0,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("field-3.6.D")).toHaveValue(0);
+    expect(screen.getByTestId("int-3.6.J.1")).toHaveValue(0);
   });
 
   // ── Sub-sub-category fallback ────────────────────────────────────────

--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -782,8 +782,19 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     };
   }, []);
 
+  const resetAdditionalFields = () => {
+    setAdditionalFieldValues({});
+  };
+
+  const resetAdditionalFieldsForCategoryChange = (nextCategoryId) => {
+    if (nextCategoryId !== selectedCategoryId) {
+      resetAdditionalFields();
+    }
+  };
+
   const handleCategoryClick = (categoryKeyOrId) => {
     const resolvedId = resolveCatNameToId(categoryKeyOrId);
+    resetAdditionalFieldsForCategoryChange(resolvedId);
     setFormData({
       ...formData,
       category: categoryKeyOrId,
@@ -818,6 +829,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       }
 
       // set the category input immediately so the category field shows the selected subcategory
+      resetAdditionalFieldsForCategoryChange(subcategoryId);
       setFormData({
         ...formData,
         category: subcategoryId,
@@ -836,6 +848,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       return;
     } else {
       // Popup modal for subcategory - For other categories, proceed normally
+      resetAdditionalFieldsForCategoryChange(subcategoryId);
       setFormData({
         ...formData,
         category: subcategoryId,
@@ -876,6 +889,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
       ...formData,
       category: subcategory.id,
     });
+    resetAdditionalFieldsForCategoryChange(subcategory.id);
     setSelectedCategoryId(subcategory.id);
     setCategoryConfirmed(false);
 
@@ -907,6 +921,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
         ...formData,
         category: "",
       });
+      resetAdditionalFields();
       setSelectedCategoryId(null);
       setCategoryConfirmed(false);
     }
@@ -930,10 +945,12 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     const matched = suggestedCategories.find(
       (c) => (c.category_number ?? c.name) === newCategory,
     );
+    const nextCategoryId = matched?.category_number ?? newCategory;
     const newCategoryDisplay =
       matched?.hierarchy ?? matched?.displayName ?? newCategory;
     setFormData({ ...formData, category: newCategoryDisplay });
-    setSelectedCategoryId(matched?.category_number ?? newCategory);
+    resetAdditionalFieldsForCategoryChange(nextCategoryId);
+    setSelectedCategoryId(nextCategoryId);
     setCategoryConfirmed(true); // unlock submission
     setShowModal(false);
 
@@ -1598,6 +1615,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
                 {/* Dynamic additional fields from metadata */}
                 <DynamicAdditionalFields
                   catId={selectedCategoryId}
+                  value={additionalFieldValues}
                   onChange={setAdditionalFieldValues}
                 />
 

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1737,7 +1737,11 @@ describe("HelpRequestForm — DynamicAdditionalFields category id", () => {
   });
 
   it("passes selectedCategoryId to DynamicAdditionalFields not hierarchy string", async () => {
-    const { predictCategories } = require("../../services/requestServices");
+    const {
+      checkProfanity,
+      predictCategories,
+    } = require("../../services/requestServices");
+    checkProfanity.mockResolvedValue({ contains_profanity: false });
     predictCategories.mockResolvedValue({
       body: {
         categories: [
@@ -1811,6 +1815,54 @@ describe("HelpRequestForm — DynamicAdditionalFields category id", () => {
     selectSubcategory();
 
     expect(screen.getByTestId("radio-sub-college.A.1")).toBeInTheDocument();
+    localStorage.removeItem("metadata");
+  });
+
+  it("preserves selected additional info values when switching tabs", () => {
+    localStorage.setItem(
+      "metadata",
+      JSON.stringify([
+        {
+          catId: "sub-college",
+          fields: [
+            {
+              fieldId: "sub-college.A",
+              fieldNameKey: "PREFERRED_MEAL_TYPE",
+              fieldType: "list",
+              status: "active",
+              catId: "sub-college",
+              listItems: [
+                {
+                  itemId: "sub-college.A.1",
+                  itemValue: "VEGETARIAN",
+                  itemType: "radiobutton",
+                },
+                {
+                  itemId: "sub-college.A.2",
+                  itemValue: "VEGAN",
+                  itemType: "radiobutton",
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    );
+
+    renderForm();
+    selectSubcategory();
+
+    fireEvent.click(screen.getByTestId("radio-sub-college.A.1"));
+    expect(screen.getByTestId("radio-sub-college.A.1")).toBeChecked();
+
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+    expect(
+      screen.queryByTestId("radio-sub-college.A.1"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("mockTranslate(DESCRIPTION)"));
+    expect(screen.getByTestId("radio-sub-college.A.1")).toBeChecked();
+
     localStorage.removeItem("metadata");
   });
 });


### PR DESCRIPTION
fix: preserve additional info selections across help request tab switches and convert dynamic additional fields to a controlled component so values reset cleanly on cat changes without re-renders