### PR TITLE
Add request status i18n translations

### DIFF
--- a/src/common/i18n/locales/ar/common.json
+++ b/src/common/i18n/locales/ar/common.json
@@ -757,5 +757,13 @@
   "FIND_BY_PHONE": "البحث بالهاتف",
   "ENTER_VOLUNTEER_EMAIL": "أدخل بريد المتطوع الإلكتروني",
   "ENTER_VOLUNTEER_PHONE": "أدخل هاتف المتطوع",
-  "SEARCH_TAGLINE": "جوجل بلمسة إنسانية*"
+  "SEARCH_TAGLINE": "جوجل بلمسة إنسانية*",
+  "CREATED": "تم الإنشاء",
+  "MATCHING_VOLUNTEER": "جاري مطابقة المتطوع",
+  "IN_PROGRESS": "قيد التنفيذ",
+  "RESOLVED": "تم الحل",
+  "CANCELLED": "تم الإلغاء",
+  "DELETED": "تم الحذف",
+  "RATED_BY_REQUESTER": "تم التقييم بواسطة مقدم الطلب",
+  "RATED_BY_VOLUNTEER": "تم التقييم بواسطة المتطوع"
 }

--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -757,5 +757,13 @@
   "FIND_BY_PHONE": "ফোন দিয়ে খুঁজুন",
   "ENTER_VOLUNTEER_EMAIL": "স্বেচ্ছাসেবকের ইমেইল লিখুন",
   "ENTER_VOLUNTEER_PHONE": "স্বেচ্ছাসেবকের ফোন লিখুন",
-  "SEARCH_TAGLINE": "মানবিক স্পর্শ সহ গুগল*"
+  "SEARCH_TAGLINE": "মানবিক স্পর্শ সহ গুগল*",
+  "CREATED": "তৈরি হয়েছে",
+  "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক মিলানো হচ্ছে",
+  "IN_PROGRESS": "চলমান",
+  "RESOLVED": "সমাধান হয়েছে",
+  "CANCELLED": "বাতিল হয়েছে",
+  "DELETED": "মুছে ফেলা হয়েছে",
+  "RATED_BY_REQUESTER": "অনুরোধকারীর দ্বারা রেট করা হয়েছে",
+  "RATED_BY_VOLUNTEER": "স্বেচ্ছাসেবকের দ্বারা রেট করা হয়েছে"
 }

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -757,5 +757,13 @@
   "FIND_BY_PHONE": "Nach Telefon suchen",
   "ENTER_VOLUNTEER_EMAIL": "Freiwilligen-E-Mail eingeben",
   "ENTER_VOLUNTEER_PHONE": "Freiwilligentelefon eingeben",
-  "SEARCH_TAGLINE": "google mit menschlichem Touch*"
+  "SEARCH_TAGLINE": "google mit menschlichem Touch*",
+  "CREATED": "Erstellt",
+  "MATCHING_VOLUNTEER": "Freiwilliger wird zugeordnet",
+  "IN_PROGRESS": "In Bearbeitung",
+  "RESOLVED": "Gelöst",
+  "CANCELLED": "Storniert",
+  "DELETED": "Gelöscht",
+  "RATED_BY_REQUESTER": "Vom Anfragenden bewertet",
+  "RATED_BY_VOLUNTEER": "Vom Freiwilligen bewertet"
 }

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -785,5 +785,13 @@
   "FIND_BY_PHONE": "Find by Phone",
   "ENTER_VOLUNTEER_EMAIL": "Enter volunteer email",
   "ENTER_VOLUNTEER_PHONE": "Enter volunteer phone",
-  "SEARCH_TAGLINE": "google with human touch*"
+  "SEARCH_TAGLINE": "google with human touch*",
+  "CREATED": "Created",
+  "MATCHING_VOLUNTEER": "Matching Volunteer",
+  "IN_PROGRESS": "In Progress",
+  "RESOLVED": "Resolved",
+  "CANCELLED": "Cancelled",
+  "DELETED": "Deleted",
+  "RATED_BY_REQUESTER": "Rated by Requester",
+  "RATED_BY_VOLUNTEER": "Rated by Volunteer"
 }

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -757,5 +757,13 @@
   "FIND_BY_PHONE": "Buscar por teléfono",
   "ENTER_VOLUNTEER_EMAIL": "Ingresar correo electrónico del voluntario",
   "ENTER_VOLUNTEER_PHONE": "Ingresar teléfono del voluntario",
-  "SEARCH_TAGLINE": "google con toque humano*"
+  "SEARCH_TAGLINE": "google con toque humano*",
+  "CREATED": "Creado",
+  "MATCHING_VOLUNTEER": "Asignando voluntario",
+  "IN_PROGRESS": "En progreso",
+  "RESOLVED": "Resuelto",
+  "CANCELLED": "Cancelado",
+  "DELETED": "Eliminado",
+  "RATED_BY_REQUESTER": "Valorado por el solicitante",
+  "RATED_BY_VOLUNTEER": "Valorado por el voluntario"
 }

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -756,5 +756,13 @@
   "FIND_BY_PHONE": "Rechercher par téléphone",
   "ENTER_VOLUNTEER_EMAIL": "Entrer l'e-mail du bénévole",
   "ENTER_VOLUNTEER_PHONE": "Entrer le téléphone du bénévole",
-  "SEARCH_TAGLINE": "google avec une touche humaine*"
+  "SEARCH_TAGLINE": "google avec une touche humaine*",
+  "CREATED": "Créé",
+  "MATCHING_VOLUNTEER": "Mise en relation avec un bénévole",
+  "IN_PROGRESS": "En cours",
+  "RESOLVED": "Résolu",
+  "CANCELLED": "Annulé",
+  "DELETED": "Supprimé",
+  "RATED_BY_REQUESTER": "Évalué par le demandeur",
+  "RATED_BY_VOLUNTEER": "Évalué par le bénévole"
 }

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -758,5 +758,13 @@
   "FIND_BY_PHONE": "फ़ोन से खोजें",
   "ENTER_VOLUNTEER_EMAIL": "स्वयंसेवक का ईमेल दर्ज करें",
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवक का फ़ोन दर्ज करें",
-  "SEARCH_TAGLINE": "मानवीय स्पर्श के साथ गूगल*"
+  "SEARCH_TAGLINE": "मानवीय स्पर्श के साथ गूगल*",
+  "CREATED": "बनाया गया",
+  "MATCHING_VOLUNTEER": "स्वयंसेवक मिलान हो रहा है",
+  "IN_PROGRESS": "प्रगति में",
+  "RESOLVED": "समाधान हो गया",
+  "CANCELLED": "रद्द किया गया",
+  "DELETED": "हटाया गया",
+  "RATED_BY_REQUESTER": "अनुरोधकर्ता द्वारा रेट किया गया",
+  "RATED_BY_VOLUNTEER": "स्वयंसेवक द्वारा रेट किया गया"
 }

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -765,5 +765,13 @@
   "FIND_BY_PHONE": "Buscar por telefone",
   "ENTER_VOLUNTEER_EMAIL": "Inserir e-mail do voluntário",
   "ENTER_VOLUNTEER_PHONE": "Inserir telefone do voluntário",
-  "SEARCH_TAGLINE": "google com toque humano*"
+  "SEARCH_TAGLINE": "google com toque humano*",
+  "CREATED": "Criado",
+  "MATCHING_VOLUNTEER": "A associar voluntário",
+  "IN_PROGRESS": "Em progresso",
+  "RESOLVED": "Resolvido",
+  "CANCELLED": "Cancelado",
+  "DELETED": "Eliminado",
+  "RATED_BY_REQUESTER": "Avaliado pelo requerente",
+  "RATED_BY_VOLUNTEER": "Avaliado pelo voluntário"
 }

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -757,5 +757,13 @@
   "FIND_BY_PHONE": "Найти по телефону",
   "ENTER_VOLUNTEER_EMAIL": "Введите email волонтёра",
   "ENTER_VOLUNTEER_PHONE": "Введите телефон волонтёра",
-  "SEARCH_TAGLINE": "гугл с человеческим прикосновением*"
+  "SEARCH_TAGLINE": "гугл с человеческим прикосновением*",
+  "CREATED": "Создано",
+  "MATCHING_VOLUNTEER": "Подбирается волонтёр",
+  "IN_PROGRESS": "В процессе",
+  "RESOLVED": "Решено",
+  "CANCELLED": "Отменено",
+  "DELETED": "Удалено",
+  "RATED_BY_REQUESTER": "Оценено заявителем",
+  "RATED_BY_VOLUNTEER": "Оценено волонтёром"
 }

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -756,5 +756,13 @@
   "FIND_BY_PHONE": "ఫోన్‌తో వెతకండి",
   "ENTER_VOLUNTEER_EMAIL": "వాలంటీర్ ఇమెయిల్ నమోదు చేయండి",
   "ENTER_VOLUNTEER_PHONE": "వాలంటీర్ ఫోన్ నమోదు చేయండి",
-  "SEARCH_TAGLINE": "మానవ స్పర్శతో గూగుల్*"
+  "SEARCH_TAGLINE": "మానవ స్పర్శతో గూగుల్*",
+  "CREATED": "సృష్టించబడింది",
+  "MATCHING_VOLUNTEER": "వాలంటీర్‌ను సరిపోలుస్తున్నారు",
+  "IN_PROGRESS": "ప్రగతిలో ఉంది",
+  "RESOLVED": "పరిష్కరించబడింది",
+  "CANCELLED": "రద్దు చేయబడింది",
+  "DELETED": "తొలగించబడింది",
+  "RATED_BY_REQUESTER": "అభ్యర్థి రేటింగ్ ఇచ్చారు",
+  "RATED_BY_VOLUNTEER": "వాలంటీర్ రేటింగ్ ఇచ్చారు"
 }

--- a/src/common/i18n/locales/ur/common.json
+++ b/src/common/i18n/locales/ur/common.json
@@ -418,5 +418,13 @@
   "ENTER_VOLUNTEER_EMAIL": "رضاکار کا ای میل درج کریں",
   "ENTER_VOLUNTEER_PHONE": "رضاکار کا فون درج کریں",
   "SEARCH_PLACEHOLDER": "Saayam سے مدد مانگیں",
-  "SEARCH_TAGLINE": "انسانی لمس کے ساتھ گوگل*"
+  "SEARCH_TAGLINE": "انسانی لمس کے ساتھ گوگل*",
+  "CREATED": "بنایا گیا",
+  "MATCHING_VOLUNTEER": "رضاکار ملایا جا رہا ہے",
+  "IN_PROGRESS": "جاری ہے",
+  "RESOLVED": "حل ہو گیا",
+  "CANCELLED": "منسوخ کر دیا گیا",
+  "DELETED": "حذف کر دیا گیا",
+  "RATED_BY_REQUESTER": "درخواست گزار کی طرف سے درجہ بندی کی گئی",
+  "RATED_BY_VOLUNTEER": "رضاکار کی طرف سے درجہ بندی کی گئی"
 }

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -752,5 +752,13 @@
   "FIND_BY_PHONE": "按电话查找",
   "ENTER_VOLUNTEER_EMAIL": "输入志愿者电子邮件",
   "ENTER_VOLUNTEER_PHONE": "输入志愿者电话",
-  "SEARCH_TAGLINE": "有人情味的谷歌*"
+  "SEARCH_TAGLINE": "有人情味的谷歌*",
+  "CREATED": "已创建",
+  "MATCHING_VOLUNTEER": "正在匹配志愿者",
+  "IN_PROGRESS": "进行中",
+  "RESOLVED": "已解决",
+  "CANCELLED": "已取消",
+  "DELETED": "已删除",
+  "RATED_BY_REQUESTER": "请求者已评分",
+  "RATED_BY_VOLUNTEER": "志愿者已评分"
 }


### PR DESCRIPTION
Closes #1590

Summary:

* Added i18n keys matching backend request status enum values directly.
* Added translations for request status values in supported locale files.
* Used direct enum keys such as CREATED, MATCHING_VOLUNTEER, IN_PROGRESS, RESOLVED, CANCELLED, DELETED, RATED_BY_REQUESTER, and RATED_BY_VOLUNTEER.

Testing:

* Validated locale JSON files.
* Confirmed no REQUEST_STATUS_ i18n prefix keys were added.
