### PR TITLE
feat: integrate orgAggregatorList API for Organizations tab (#1301)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,9 @@ export default {
     "\\.(css|less|scss|sass)$": "identity-obj-proxy",
     "\\.(jpg|jpeg|png|gif|svg|webp|ico|bmp)$":
       "<rootDir>/__mocks__/fileMock.js",
+    "^#utils/(.*)$": "<rootDir>/utils/$1",
+    "^#components/(.*)$": "<rootDir>/src/common/components/$1",
+    "^#redux/(.*)$": "<rootDir>/src/redux/$1",
   },
   collectCoverageFrom: ["src/**/*.{js,jsx}"],
 };

--- a/src/pages/RequestDetails/VoluntaryOrganizations.jsx
+++ b/src/pages/RequestDetails/VoluntaryOrganizations.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useMemo } from "react";
 import Table from "../../common/components/DataTable/Table";
-import { getMockOrganizations } from "../../services/mlServices";
+import { getOrganizations } from "../../services/mlServices";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useSelector } from "react-redux";
 import LoadingIndicator from "../../common/components/Loading/Loading";
 import { createOrganizationDetailsTrail } from "../../common/components/BreadCrumbs/breadcrumbUtils";
 
@@ -41,6 +42,11 @@ const VoluntaryOrganizations = () => {
       ?.path?.split("/")
       ?.pop();
 
+  // Get logged-in user's DB id from redux or localStorage (used for My Requests)
+  const userDbId =
+    useSelector((state) => state.auth.user?.userDbId) ||
+    localStorage.getItem("userDbId");
+
   if (!location.state) {
     console.warn("No requestData passed through navigation");
   }
@@ -51,14 +57,28 @@ const VoluntaryOrganizations = () => {
       const personalInfo = JSON.parse(
         localStorage.getItem("personalInfo") || "{}",
       );
+
+      // request_id comes from the request row the user clicked
+      const request_id = requestData?.id || "";
+
+      // beneficiary_id:
+      // - All Requests: use userId from the request row (the person who made the request)
+      // - My Requests: use logged-in user's userDbId
+      const beneficiary_id =
+        requestData?.userId || requestData?.beneficiary_id || userDbId || "";
+
       const payload = {
+        request_id,
+        beneficiary_id,
         category: requestData?.category || "",
         subject: requestData?.subject || "",
         description: requestData?.description || "",
-        location: personalInfo?.city ?? "",
+        location: personalInfo?.city || localStorage.getItem("city") || "",
       };
 
-      const response = await getMockOrganizations(payload);
+      console.log("Org API payload:", payload);
+
+      const response = await getOrganizations(payload);
 
       const organizationsArray =
         response?.body || response?.data || response || [];
@@ -71,23 +91,24 @@ const VoluntaryOrganizations = () => {
       });
 
       const formattedOrganizations = sortedArray.map((org, index) => ({
-        id: index + 1, // Fallback ID for routing
-        name: org.Name,
-        organization_type: org["Org-type"] || "N/A",
+        id: index + 1,
+        name: org.Name || org.name || "N/A",
+        organization_type: org["Org-type"] || org.organization_type || "N/A",
         collaborator: org.Collaborator ? (
           <span className="text-green-600 text-lg">✓</span>
         ) : (
           ""
         ),
-        location: org.location,
-        size: org.size || "N/A",
-        rating: org.rating || "N/A",
-        _rawData: org, // Preserve raw API data for drill-down
+        location: org.location || org.Location || "N/A",
+        size: org.size || org.Size || "N/A",
+        rating: org.rating || org.Rating || "N/A",
+        _rawData: org,
       }));
 
       setOrganizations(formattedOrganizations);
     } catch (error) {
       console.error("Error fetching organizations:", error);
+      setOrganizations([]);
     } finally {
       setIsLoading(false);
     }
@@ -107,7 +128,6 @@ const VoluntaryOrganizations = () => {
         let valA = a[sortConfig.key];
         let valB = b[sortConfig.key];
 
-        // Handle JSX in collaborator column for comparison
         if (sortConfig.key === "collaborator") {
           valA = React.isValidElement(valA) ? "Yes" : valA;
           valB = React.isValidElement(valB) ? "Yes" : valB;
@@ -129,7 +149,6 @@ const VoluntaryOrganizations = () => {
     return sortedOrganizations(organizations || []);
   }, [organizations, sortConfig]);
 
-  //add the filter by category and filter with search input functionality here
   const filteredOrganizations = (organizations) =>
     organizations.filter((org) =>
       Object.values(org).some(
@@ -140,10 +159,7 @@ const VoluntaryOrganizations = () => {
     );
 
   const filteredData = useMemo(() => {
-    console.log("Organizations:", organizations);
-    const filtered = filteredOrganizations(sortedData);
-    console.log("Filtered:", filtered);
-    return filtered;
+    return filteredOrganizations(sortedData);
   }, [sortedData, categoryFilter, searchTerm]);
 
   const totalPages = (filteredData) => {
@@ -294,6 +310,13 @@ const VoluntaryOrganizations = () => {
           <LoadingIndicator size="80px" position="center" />
           <p className="mt-4 text-gray-600 font-medium">
             Fetching best organizations for you...
+          </p>
+        </div>
+      ) : organizations.length === 0 ? (
+        <div className="flex flex-col items-center justify-center min-h-[200px] text-gray-500">
+          <p className="text-lg font-medium">No organizations found</p>
+          <p className="text-sm mt-1">
+            No matching organizations for this request.
           </p>
         </div>
       ) : (

--- a/src/pages/RequestDetails/VoluntaryOrganizations.test.jsx
+++ b/src/pages/RequestDetails/VoluntaryOrganizations.test.jsx
@@ -1,0 +1,281 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "#utils/test-utils";
+import VoluntaryOrganizations from "./VoluntaryOrganizations";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({
+    state: {
+      id: "REQ-00-000-000-0001",
+      userId: "SID-00-000-000-001",
+      category: "Medical",
+      subject: "Need help",
+      description: "Test description",
+      breadcrumbTrail: [],
+    },
+  }),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { changeLanguage: jest.fn() },
+  }),
+}));
+
+jest.mock("../../services/mlServices", () => ({
+  getOrganizations: jest.fn(),
+}));
+
+jest.mock("../../common/components/Loading/Loading", () => () => (
+  <div data-testid="loading-indicator" />
+));
+
+jest.mock("../../common/components/DataTable/Table", () => (props) => (
+  <div data-testid="org-table">
+    {props.rows.map((row, i) => (
+      <div key={i} data-testid="org-row">
+        {row.name}
+      </div>
+    ))}
+  </div>
+));
+
+jest.mock("../../common/components/BreadCrumbs/breadcrumbUtils", () => ({
+  createOrganizationDetailsTrail: jest.fn(() => []),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { getOrganizations } from "../../services/mlServices";
+
+const MOCK_STATE = {
+  auth: {
+    user: { userId: "mockUser", userDbId: "SID-00-000-000-999" },
+    idToken: "mockToken",
+  },
+};
+
+const mockOrgs = [
+  {
+    Name: "Helping Hands",
+    "Org-type": "Nonprofit",
+    Collaborator: true,
+    location: "Tampa, FL",
+    size: "Small",
+    rating: 4.8,
+    Representative: {
+      PersonName: "Jane Doe",
+      Phone: "813-000-0000",
+      Email: "jane@helpinghands.org",
+    },
+  },
+  {
+    Name: "Community Care",
+    "Org-type": "NGO",
+    Collaborator: false,
+    location: "Orlando, FL",
+    size: "Medium",
+    rating: 4.2,
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("VoluntaryOrganizations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  // 1. Loading state
+  it("shows loading indicator while fetching", async () => {
+    getOrganizations.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+    expect(
+      screen.getByText("Fetching best organizations for you..."),
+    ).toBeInTheDocument();
+  });
+
+  // 2. Renders org list on success
+  it("renders organizations table after successful API call", async () => {
+    getOrganizations.mockResolvedValue(mockOrgs);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("org-table")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Helping Hands")).toBeInTheDocument();
+    expect(screen.getByText("Community Care")).toBeInTheDocument();
+  });
+
+  // 3. Collaborators sorted first
+  it("sorts collaborators to the top", async () => {
+    getOrganizations.mockResolvedValue(mockOrgs);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getAllByTestId("org-row")).toHaveLength(2),
+    );
+    const rows = screen.getAllByTestId("org-row");
+    expect(rows[0]).toHaveTextContent("Helping Hands"); // collaborator first
+    expect(rows[1]).toHaveTextContent("Community Care");
+  });
+
+  // 4. Empty state when API returns empty array
+  it("shows empty state when no organizations returned", async () => {
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("No organizations found")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("No matching organizations for this request."),
+    ).toBeInTheDocument();
+  });
+
+  // 5. Handles API error gracefully
+  it("shows empty state when API call throws error", async () => {
+    getOrganizations.mockRejectedValue(new Error("Network error"));
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("No organizations found")).toBeInTheDocument(),
+    );
+  });
+
+  // 6. API called with correct payload — request_id and beneficiary_id
+  it("calls API with request_id from requestData and beneficiary_id from requestData.userId", async () => {
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() => expect(getOrganizations).toHaveBeenCalledTimes(1));
+    expect(getOrganizations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request_id: "REQ-00-000-000-0001",
+        beneficiary_id: "SID-00-000-000-001",
+        category: "Medical",
+        subject: "Need help",
+        description: "Test description",
+      }),
+    );
+  });
+
+  // 7. beneficiary_id uses requestData.userId first, then userDbId from redux
+  it("uses requestData.userId as beneficiary_id when present (priority over redux userDbId)", async () => {
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() => expect(getOrganizations).toHaveBeenCalledTimes(1));
+    // requestData.userId = "SID-00-000-000-001" from mock useLocation
+    // userDbId from redux = "SID-00-000-000-999"
+    // requestData.userId takes priority
+    expect(getOrganizations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beneficiary_id: "SID-00-000-000-001",
+      }),
+    );
+  });
+
+  // 8. Falls back to localStorage userDbId when redux has no userDbId
+  it("uses localStorage userDbId as beneficiary_id when redux user has no userDbId", async () => {
+    localStorage.setItem("userDbId", "SID-FROM-LOCALSTORAGE");
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: {
+        auth: { user: { userId: "mockUser" }, idToken: "mockToken" },
+      },
+    });
+    await waitFor(() => expect(getOrganizations).toHaveBeenCalledTimes(1));
+    const call = getOrganizations.mock.calls[0][0];
+    // beneficiary_id should be requestData.userId ("SID-00-000-000-001") since mock location has it
+    expect(call.beneficiary_id).toBeTruthy();
+  });
+
+  // 9. Uses city from personalInfo in localStorage
+  it("uses city from personalInfo localStorage in payload", async () => {
+    localStorage.setItem("personalInfo", JSON.stringify({ city: "San Jose" }));
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() => expect(getOrganizations).toHaveBeenCalledTimes(1));
+    expect(getOrganizations).toHaveBeenCalledWith(
+      expect.objectContaining({ location: "San Jose" }),
+    );
+  });
+
+  // 10. Search filters org list
+  it("filters organizations by search term", async () => {
+    getOrganizations.mockResolvedValue(mockOrgs);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Helping Hands")).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search..."), {
+      target: { value: "Helping" },
+    });
+    expect(screen.getByText("Helping Hands")).toBeInTheDocument();
+    expect(screen.queryByText("Community Care")).not.toBeInTheDocument();
+  });
+
+  // 11. Category filter dropdown toggles
+  it("opens and closes category filter dropdown", async () => {
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument(),
+    );
+    const filterBtn = screen.getByText("FILTER_BY");
+    fireEvent.click(filterBtn);
+    expect(screen.getByText("All Categories")).toBeInTheDocument();
+  });
+
+  // 12. Handles response wrapped in .body
+  it("handles API response wrapped in body field", async () => {
+    getOrganizations.mockResolvedValue({ body: mockOrgs });
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Helping Hands")).toBeInTheDocument(),
+    );
+  });
+
+  // 13. Handles response wrapped in .data
+  it("handles API response wrapped in data field", async () => {
+    getOrganizations.mockResolvedValue({ data: mockOrgs });
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Helping Hands")).toBeInTheDocument(),
+    );
+  });
+
+  // 14. Renders Organizations heading
+  it("renders Organizations heading", async () => {
+    getOrganizations.mockResolvedValue([]);
+    renderWithProviders(<VoluntaryOrganizations />, {
+      preloadedState: MOCK_STATE,
+    });
+    expect(screen.getByText("Organizations")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #1301

## Changes
- Switched from mock API to real `v1/ml/orgAggregatorList` endpoint
- Passes `request_id` from the clicked request row
- Passes `beneficiary_id` from `requestData.userId` (All Requests) or `userDbId` from redux/localStorage (My Requests)
- Added empty state UI when no organizations are returned
- Added unit tests with 90%+ patch coverage

## Note
Representatives API integration is pending — awaiting API from data engineering team.