### PR TITLE
Fix donate page layout and scrollbar related to issue #1551.

### DIFF
--- a/src/Layout/Layout.jsx
+++ b/src/Layout/Layout.jsx
@@ -19,6 +19,7 @@ const Layout = () => {
   const shouldHideBreadcrumbs = hideBreadcrumbRoutes.includes(
     location.pathname.toLowerCase(),
   );
+  const isDonateRoute = location.pathname.toLowerCase() === "/donate";
 
   return (
     <div className="flex flex-col h-screen">
@@ -34,7 +35,9 @@ const Layout = () => {
             {showAds && <LeftAds />}
           </aside>
 
-          <main className="flex-[6] overflow-auto">
+          <main
+            className={`flex-[6] ${isDonateRoute ? "overflow-visible" : "overflow-auto"}`}
+          >
             {!shouldHideBreadcrumbs && <Breadcrumbs />}
             <Suspense fallback={<MainLoader />}>
               <Outlet />

--- a/src/pages/Donate/Donate.css
+++ b/src/pages/Donate/Donate.css
@@ -307,24 +307,25 @@
 .donate-image-overlay-bg {
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: 70vh;
   min-height: 500px;
   max-height: 700px;
   overflow: hidden;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
+  margin: 0 auto 2rem auto;
+  padding: 0;
+  border-radius: 10px;
 }
 
 .donate-bg-image {
   position: absolute;
   top: 0;
   left: 0;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  display: block;
   object-position: center;
   z-index: 1;
   filter: brightness(0.92);
@@ -432,7 +433,7 @@
 
 @media (max-width: 900px) {
   .donate-image-overlay-bg {
-    height: 100vh;
+    height: 60vh;
     min-height: 400px;
     max-height: 600px;
     width: 100%;
@@ -479,7 +480,6 @@ body {
   padding: 0;
   width: 100%;
   height: 100%;
-  overflow-x: hidden;
 }
 
 .donation-option-btn {
@@ -548,7 +548,7 @@ body {
     position: absolute;
     left: 50%;
     top: 54%;
-    transform: translate(-50%);
+    transform: translateY(-50%);
     max-width: 90%;
     width: 310px; /* Larger card for tablet-sized screens */
     z-index: 2;
@@ -567,20 +567,21 @@ body {
   }
 
   .donate-bg-image {
-    position: absolute;
-    inset: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     object-position: center;
-    display: block;
-    z-index: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    filter: brightness(0.9);
   }
 
   .donate-card-overlay {
     position: absolute;
     top: 50%;
-    left: 50%; /* Slight right alignment */
+    left: 70%; /* Slight right alignment */
     transform: translate(-50%, -50%);
     width: 230px;
     height: 230px; /* Square card */
@@ -623,8 +624,7 @@ body {
   .donate-card-overlay {
     width: 170px;
     height: 170px; /* Smaller square card */
-    left: 50%;
-    transform: translate(-50%, -50%);
+    left: 72%; /* Further right to accommodate narrower view */
     padding: 0.25rem;
     border-radius: 12px;
   }


### PR DESCRIPTION
Changes: 
1) In src/pages/Donate/Donate.css, I restored the Donate page CSS from the dev branch to restore the hero height, card alignment, and responsive layout.
2) In src/Layout/Layout.jsx, I added a Donate-route check and changed the main container so /donate uses overflow-visible instead of overflow-auto. This removes the extra inner scrollbar only on the Donate page. Other routes still use overflow-auto as before.
The Donate route still has leaveAdSpace: true, so side ads remain enabled.