### PR TITLE
Replaced hardcoded userid and requestID

### DIFF
--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.jsx
@@ -13,9 +13,9 @@ async function translateText(text /*, targetLang */) {
 }
 
 // TODO: replace hardcoded defaults with dynamic user_id and req_id
-const buildPayload = () => ({
-  user_id: "SID-00-000-000-050",
-  req_id: "REQ-00-000-000-0085",
+const buildPayload = (requestData) => ({
+  user_id: requestData?.userId || requestData?.user_id,
+  req_id: requestData?.requestId || requestData?.req_id || requestData?.id,
 });
 
 const counterColorClass = (remaining) => {
@@ -76,7 +76,7 @@ const MoreInfoChatModal = ({
 
     try {
       const payload = {
-        ...buildPayload(),
+        ...buildPayload(requestData),
         conversation_history: nextMessages,
       };
       const rawReply = await moreInformationChat(payload);

--- a/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
+++ b/src/common/components/MoreInfoChatModal/MoreInfoChatModal.test.js
@@ -27,6 +27,8 @@ const { moreInformationChat } = require("../../../services/requestServices");
 
 const mockRequestData = {
   id: "REQ-001",
+  requestId: "REQ-00-000-000-0085",
+  userId: "SID-00-000-000-050",
   subject: "Pick up dry cleaning",
   description: "Need someone to pick up my dry cleaning.",
 };
@@ -267,8 +269,8 @@ describe("MoreInfoChatModal", () => {
     await waitFor(() => {
       expect(moreInformationChat).toHaveBeenCalledWith(
         expect.objectContaining({
-          user_id: "SID-00-000-000-050",
-          req_id: "REQ-00-000-000-0085",
+          user_id: mockRequestData.userId,
+          req_id: mockRequestData.requestId,
           conversation_history: expect.arrayContaining([
             expect.objectContaining({ role: "assistant" }),
             expect.objectContaining({ role: "user", content: "My question" }),

--- a/src/common/components/RequestButton/RequestButton.jsx
+++ b/src/common/components/RequestButton/RequestButton.jsx
@@ -15,7 +15,9 @@ import MoreInfoChatModal from "../MoreInfoChatModal/MoreInfoChatModal";
 const COOLDOWN_MS = 30 * 60 * 1000;
 
 const getCooldownKey = (data) =>
-  `moreInfoCooldown_${data?.id ?? data?.subject ?? "default"}`;
+  `moreInfoCooldown_${
+    data?.requestId || data?.req_id || data?.id || data?.subject || "default"
+  }`;
 
 const isCoolingDown = (data) => {
   const raw = localStorage.getItem(getCooldownKey(data));
@@ -26,10 +28,9 @@ const isCoolingDown = (data) => {
   return false;
 };
 
-// TODO: replace hardcoded defaults with dynamic user_id and req_id
-const buildPayload = () => ({
-  user_id: "SID-00-000-000-050",
-  req_id: "REQ-00-000-000-0085",
+const buildPayload = (requestData, loggedInUserId) => ({
+  user_id: requestData?.userId || requestData?.user_id || loggedInUserId,
+  req_id: requestData?.requestId || requestData?.req_id || requestData?.id,
 });
 
 const RequestButton = ({
@@ -84,7 +85,7 @@ const RequestButton = ({
         setShowModal(true);
         try {
           const aiReply = await moreInformationChat({
-            ...buildPayload(),
+            ...buildPayload(requestData, user?.userDbId),
             conversation_history: [],
           });
           setInitialResponse(aiReply?.body?.answer ?? "");

--- a/src/common/components/RequestButton/RequestButton.test.js
+++ b/src/common/components/RequestButton/RequestButton.test.js
@@ -8,7 +8,16 @@ jest.mock("react-router-dom", () => ({
 }));
 
 jest.mock("react-redux", () => ({
-  useSelector: jest.fn((fn) => fn({ auth: { user: { zoneinfo: "US" } } })),
+  useSelector: jest.fn((fn) =>
+    fn({
+      auth: {
+        user: {
+          zoneinfo: "US",
+          userDbId: "SID-LOGGED-IN-001",
+        },
+      },
+    }),
+  ),
 }));
 
 jest.mock("../../../services/requestServices", () => ({
@@ -33,6 +42,8 @@ const {
 
 const mockRequestData = {
   id: "REQ-001",
+  requestId: "REQ-00-000-000-0085",
+  userId: "SID-00-000-000-050",
   subject: "Pick up dry cleaning",
   description: "Need dry cleaning pickup.",
 };
@@ -129,15 +140,15 @@ describe("RequestButton", () => {
 
     await waitFor(() => {
       expect(moreInformationChat).toHaveBeenCalledWith({
-        user_id: "SID-00-000-000-050",
-        req_id: "REQ-00-000-000-0085",
+        user_id: mockRequestData.userId,
+        req_id: mockRequestData.requestId,
         conversation_history: [],
       });
     });
   });
 
   it("shows cooldown dialog when cooling down", async () => {
-    const key = `moreInfoCooldown_${mockRequestData.id}`;
+    const key = `moreInfoCooldown_${mockRequestData.requestId}`;
     localStorage.setItem(
       key,
       JSON.stringify({ expiresAt: Date.now() + 30 * 60 * 1000 }),
@@ -162,7 +173,7 @@ describe("RequestButton", () => {
   });
 
   it("does not show cooldown when cooldown has expired", async () => {
-    const key = `moreInfoCooldown_${mockRequestData.id}`;
+    const key = `moreInfoCooldown_${mockRequestData.requestId}`;
     localStorage.setItem(key, JSON.stringify({ expiresAt: Date.now() - 1000 }));
 
     moreInformationChat.mockResolvedValue({


### PR DESCRIPTION
- Removed hardcoded user_id and req_id from the More Information payload. 
- Updated the payload to use the dynamic requestId and userId from the selected request.
- Verified by inspecting the Network request that clicking More Information sends the correct dynamic user_id and req_id in the API payload.