### PR TITLE
Fix Request Details priority reset after Edit -> Cancel

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -2316,7 +2316,13 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
               {isSubmitting && <LoadingIndicator size="24px" />}
             </button>
             <button
-              onClick={isEdit ? onClose : closeForm}
+              onClick={() => {
+                if (isEdit) {
+                  onClose?.(undefined);
+                  return;
+                }
+                closeForm();
+              }}
               type="button"
               className="py-2 px-4 bg-gray-500 text-white rounded-md hover:bg-gray-600"
             >

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -180,7 +180,11 @@ const mockCategories = [
   },
 ];
 
-function renderForm({ isEdit = false, editRequestData } = {}) {
+function renderForm({
+  isEdit = false,
+  editRequestData,
+  onClose = jest.fn(),
+} = {}) {
   const store = configureStore({
     reducer: { auth: authReducer, request: requestReducer },
     preloadedState: {
@@ -193,7 +197,7 @@ function renderForm({ isEdit = false, editRequestData } = {}) {
       <NotificationProvider>
         <HelpRequestForm
           isEdit={isEdit}
-          onClose={jest.fn()}
+          onClose={onClose}
           editRequestData={editRequestData}
         />
       </NotificationProvider>
@@ -1080,6 +1084,30 @@ describe("HelpRequestForm — successful submission", () => {
     await act(async () => {
       jest.advanceTimersByTime(1200);
     });
+  });
+
+  it("calls onClose(undefined) when Cancel is clicked in edit mode", async () => {
+    const onClose = jest.fn();
+    const mockEditData = {
+      requestId: "REQ-00-000-000-0009",
+      id: "REQ-00-000-000-0009",
+      category: "COLLEGE_APPLICATION_HELP",
+      subject: "Existing Request Subject",
+      description: "Existing request description",
+      priority: "MEDIUM",
+      request_type: "REMOTE",
+      is_self: "yes",
+      helpCategory: { catId: "cat-edu" },
+      attachments: ["http://test.com/file1.jpg"],
+    };
+
+    renderForm({ isEdit: true, editRequestData: mockEditData, onClose });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(CANCEL)" }),
+    );
+
+    expect(onClose).toHaveBeenCalledWith(undefined);
   });
 });
 

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1109,6 +1109,18 @@ describe("HelpRequestForm — successful submission", () => {
 
     expect(onClose).toHaveBeenCalledWith(undefined);
   });
+
+  it("does not call onClose when Cancel is clicked in create mode", () => {
+    const onClose = jest.fn();
+
+    renderForm({ isEdit: false, onClose });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mockTranslate(CANCEL)" }),
+    );
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });
 
 describe("HelpRequestForm — edit mode submission", () => {


### PR DESCRIPTION
@rishabh-bing  fixed the root cause in the edit flow so Cancel no longer forwards the click event into the parent and corrupts the request state. This prevents **priority** from becoming undefined after closing the dialog.

@apurvaanil77 added the regression test for the Edit -> Cancel flow and verify the Details tab keeps rendering priority correctly after the dialog is closed.

Resolves issue #1625.


<img width="1360" height="522" alt="image" src="https://github.com/user-attachments/assets/bc7e3c62-8c61-4d8a-9dfd-27edce3d57c3" />