### PR TITLE
test: fix authSlice initial-state test broken by auth merge

### DIFF
--- a/src/redux/features/authentication/authSlice.test.js
+++ b/src/redux/features/authentication/authSlice.test.js
@@ -2,13 +2,19 @@ import authReducer, {
   loginRequest,
   loginSuccess,
   loginFailure,
+  logoutSuccess,
 } from "./authSlice";
 
 describe("authSlice", () => {
   describe("initialState", () => {
-    it("starts with loading: true so protected routes wait for auth check", () => {
+    it("starts with authInitialized: false so protected routes wait for auth check", () => {
       const state = authReducer(undefined, { type: "@@INIT" });
-      expect(state.loading).toBe(true);
+      expect(state.authInitialized).toBe(false);
+    });
+
+    it("starts with loading: false", () => {
+      const state = authReducer(undefined, { type: "@@INIT" });
+      expect(state.loading).toBe(false);
     });
 
     it("starts with user: null", () => {
@@ -34,6 +40,14 @@ describe("authSlice", () => {
       expect(state.loading).toBe(false);
       expect(state.user).toEqual(mockUser);
     });
+
+    it("marks auth as initialized so ProtectedRoute stops waiting", () => {
+      const state = authReducer(
+        { loading: true, authInitialized: false, user: null },
+        loginSuccess({ user: { userId: "u1" } }),
+      );
+      expect(state.authInitialized).toBe(true);
+    });
   });
 
   describe("loginFailure", () => {
@@ -44,6 +58,25 @@ describe("authSlice", () => {
       );
       expect(state.loading).toBe(false);
       expect(state.user).toBeNull();
+    });
+
+    it("marks auth as initialized so unauthenticated users get redirected", () => {
+      const state = authReducer(
+        { loading: true, authInitialized: false, user: null },
+        loginFailure("Auth error"),
+      );
+      expect(state.authInitialized).toBe(true);
+    });
+  });
+
+  describe("logoutSuccess", () => {
+    it("clears the user and keeps auth initialized", () => {
+      const state = authReducer(
+        { loading: false, authInitialized: true, user: { userId: "u1" } },
+        logoutSuccess(),
+      );
+      expect(state.user).toBeNull();
+      expect(state.authInitialized).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes the CI failure on `idptest` introduced by #1631. One test in `authSlice.test.js` asserted `initialState.loading === true`, which was the old mechanism for making `ProtectedRoute` wait during the initial auth check. The merged code replaced that mechanism with the `authInitialized` flag: `loading` now starts `false`, and `ProtectedRoute` shows the loader while `loading || !authInitialized`.

## Changes
- Updated the initial-state test to assert `authInitialized: false` (the new wait mechanism) and `loading: false`.
- Added coverage that `loginSuccess`, `loginFailure`, and `logoutSuccess` mark auth as initialized — the load-bearing behavior that prevents the OAuth-callback redirect race.

## Testing
- `authSlice.test.js`: 9/9 passing
- Full local jest run: all 67 suites green (exit 0)