### PR TITLE
fix: show actual creator and beneficiary names on Request Details page

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1639,7 +1639,11 @@ const Dashboard = ({ userRole }) => {
                     ? `/request/${request[resolveKey(header)]}`
                     : null
                 }
-                getLinkState={(request) => request}
+                getLinkState={(request) => ({
+                  ...request,
+                  sourceDashboard: DASHBOARDS.BENEFICIARY,
+                  sourceTab: activeTab,
+                })}
                 searchFilters={dashboardSearchFilters}
               />
             )}

--- a/src/pages/RequestDetails/RequestDetails.jsx
+++ b/src/pages/RequestDetails/RequestDetails.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { IoPersonCircle } from "react-icons/io5";
 import { RiUserStarLine } from "react-icons/ri";
+import { useSelector } from "react-redux";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import RequestButton from "../../common/components/RequestButton/RequestButton";
 import { getComments, getMyRequests } from "../../services/requestServices";
@@ -37,6 +38,7 @@ const RequestDetails = () => {
   const [showEmergency, setShowEmergency] = useState(false);
   const requestId = id || location.state?.id;
   const [showAttachmentsDialog, setShowAttachmentsDialog] = useState(false);
+  const currentUser = useSelector((state) => state.auth.user);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteReason, setDeleteReason] = useState("");
@@ -73,15 +75,55 @@ const RequestDetails = () => {
       .catch(() => {});
   }, []);
 
+  const getFullName = (...parts) => parts.filter(Boolean).join(" ").trim();
+
+  const currentUserName =
+    getFullName(currentUser?.given_name, currentUser?.family_name) ||
+    getFullName(currentUser?.firstName, currentUser?.lastName) ||
+    currentUser?.name ||
+    currentUser?.email ||
+    "";
+
+  const creatorName =
+    requestData?.creatorName ||
+    requestData?.createdByName ||
+    requestData?.requesterName ||
+    getFullName(requestData?.creatorFirstName, requestData?.creatorLastName) ||
+    getFullName(
+      requestData?.createdByFirstName,
+      requestData?.createdByLastName,
+    ) ||
+    getFullName(
+      requestData?.requesterFirstName,
+      requestData?.requesterLastName,
+    ) ||
+    currentUserName;
+  t("CREATOR");
+
+  const beneficiaryName =
+    requestData?.beneficiaryName ||
+    requestData?.beneficiaryFullName ||
+    getFullName(
+      requestData?.beneficiaryFirstName,
+      requestData?.beneficiaryLastName,
+    ) ||
+    getFullName(requestData?.reqFname, requestData?.reqLname) ||
+    getFullName(
+      requestData?.guestDetails?.reqFname,
+      requestData?.guestDetails?.reqLname,
+    ) ||
+    currentUserName;
+  ("Beneficiary");
+
   const attributes = [
     {
-      context: "Peter parker",
+      context: beneficiaryName,
       type: "Beneficiary",
       icon: <IoPersonCircle size={26} />,
       isClickable: true,
     },
     {
-      context: "John Doe",
+      context: creatorName,
       type: "CREATOR",
       icon: <IoPersonCircle size={26} />,
       isClickable: true,
@@ -129,9 +171,6 @@ const RequestDetails = () => {
   // NEW: handlers (same behavior you had before)
   const handleDeleteRequest = async () => {
     try {
-      console.log("Deleting request:", requestData?.id);
-      console.log("Reason:", deleteReason);
-
       setDeleteDialogOpen(false);
       setDeleteReason("");
       navigate("/dashboard");
@@ -142,9 +181,6 @@ const RequestDetails = () => {
 
   const handleChangeVolunteer = async () => {
     try {
-      console.log("Changing volunteer for request:", requestData?.id);
-      console.log("Reason:", volunteerChangeReason);
-
       setChangeVolunteerDialogOpen(false);
       setVolunteerChangeReason("");
       navigate("/dashboard");

--- a/src/pages/RequestDetails/RequestDetails.test.jsx
+++ b/src/pages/RequestDetails/RequestDetails.test.jsx
@@ -3,8 +3,10 @@ import { fireEvent, screen, act, waitFor } from "@testing-library/react";
 import { renderWithProviders, MOCK_STATE_LOGGED_IN } from "#utils/test-utils";
 import RequestDetails from "./RequestDetails";
 
+let mockLocationState = { id: "123", subject: "Test Request" };
+
 jest.mock("react-router-dom", () => ({
-  useLocation: () => ({ state: { id: "123", subject: "Test Request" } }),
+  useLocation: () => ({ state: mockLocationState }),
   useNavigate: () => jest.fn(),
   useParams: () => ({ id: "123" }),
 }));
@@ -46,6 +48,10 @@ jest.mock("../../common/components/BreadCrumbs/breadcrumbUtils", () => ({
 }));
 
 describe("RequestDetails - Tab Translation Tests", () => {
+  beforeEach(() => {
+    mockLocationState = { id: "123", subject: "Test Request" };
+  });
+
   it("renders action buttons in the orange area on Details tab", () => {
     renderWithProviders(<RequestDetails />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
@@ -87,11 +93,41 @@ describe("RequestDetails - Tab Translation Tests", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("LEAD_VOLUNTEER")).toBeInTheDocument();
   });
+
+  it("shows actual beneficiary and creator names for beneficiary My Requests", () => {
+    mockLocationState = {
+      id: "123",
+      subject: "Test Request",
+      sourceTab: "myRequests",
+      reqFname: "Ben",
+      reqLname: "Person",
+    };
+
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: {
+        auth: {
+          user: {
+            userDbId: "SID-123",
+            given_name: "Chris",
+            family_name: "Creator",
+          },
+        },
+      },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Ben Person" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Chris Creator" }),
+    ).toBeInTheDocument();
+  });
 });
 
 describe("RequestDetails - Edit onClose refreshes data", () => {
   beforeEach(() => {
     capturedOnClose = null;
+    mockLocationState = { id: "123", subject: "Test Request" };
   });
 
   it("updates displayed subject after onClose receives updated data", async () => {


### PR DESCRIPTION
Closes #1618

## Problem
The Request Details page was showing hardcoded placeholder names
"Peter Parker" (Beneficiary) and "John Doe" (Creator) instead of
real user data.

## Fix
- Replaced hardcoded names with the logged-in user's real name
  pulled from Redux (state.auth.user)
- Added forward-compatible fallback chain that tries real API
  fields first so it auto-upgrades when backend adds those fields
- Pass sourceDashboard and sourceTab from Dashboard.jsx via
  getLinkState so the source context is available in RequestDetails
- Updated tests to use configurable mockLocationState

## Files Changed
- src/pages/RequestDetails/RequestDetails.jsx
- src/pages/Dashboard/Dashboard.jsx
- src/pages/RequestDetails/RequestDetails.test.jsx

## Testing
- Verified correct name shows when navigating via My Requests → click request
- Verified correct name shows when directly refreshing the URL

<img width="1409" height="956" alt="Screenshot 2026-07-05 at 10 59 40 PM" src="https://github.com/user-attachments/assets/8edb7113-356e-4419-94aa-3986dc78f159" />
