### PR TITLE
feat: add Snapshot/Table view/Trends dropdown to KPI Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -217,7 +217,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.13.3.tgz",
       "integrity": "sha512-V3Candbkg4nKRrByzSV+Gi9AqZpa6T2U4DaTPysARucxv+KKZ6aRtXm+E8LLtkJniS7Q+yRL4tZlGWdiKwMicw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -843,7 +842,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
       "integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1023,7 +1021,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
       "integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1923,7 +1920,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3791,7 +3787,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3835,7 +3830,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -5063,7 +5057,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -8272,7 +8265,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -8282,9 +8274,8 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -8734,7 +8725,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9132,7 +9122,6 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.15.7.tgz",
       "integrity": "sha512-ikCa5sRsUaZ5UteINjAtlmNsJnSOEtsqid+/Erc60ZbKB9tyF0W1etG4Xiu+azTZatiO5wTncGo7fzLXQZZIYw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.88",
         "@aws-amplify/api": "6.3.19",
@@ -9542,7 +9531,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -10496,8 +10484,7 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "peer": true
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -11446,7 +11433,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12890,7 +12876,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -12956,7 +12941,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -13777,7 +13761,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16037,7 +16020,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16686,7 +16668,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16702,7 +16683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17009,7 +16989,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17255,7 +17234,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17307,7 +17285,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17417,8 +17394,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -17468,7 +17444,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -17849,8 +17824,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -18664,7 +18638,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19376,7 +19349,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19651,9 +19623,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20103,7 +20074,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -20217,7 +20187,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20759,7 +20728,6 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
@@ -12,6 +12,8 @@ import {
   Legend,
   ResponsiveContainer,
   ReferenceLine,
+  LineChart,
+  Line,
 } from "recharts";
 import ChartContainer from "./charts/ChartContainer";
 import { getKpiAnalytics } from "../../../../services/analyticsServices";
@@ -57,7 +59,8 @@ export const renderTooltip =
   };
 
 const KPIAnalytics = () => {
-  const [showStatusTable, setShowStatusTable] = useState(false);
+  const [viewMode, setViewMode] = useState("snapshot"); // snapshot | table | trends
+  const [timeRange, setTimeRange] = useState("All"); // 7D | 30D | 1Y | All | Custom
   const [selectedSegment, setSelectedSegment] = useState(null);
   const [breakdownView, setBreakdownView] = useState("category"); // category or region
   const [kpiData, setKpiData] = useState(null);
@@ -81,26 +84,39 @@ const KPIAnalytics = () => {
   const SLA_TARGET = kpiData?.sla?.target_hours ?? 240;
   const SLA_WARNING = kpiData?.sla?.warning_hours ?? 200;
 
+  // Snapshot and Table view always read from the "All" bucket
+  const snapshotData = kpiData?.body?.All;
+
   const resolutionData = useMemo(() => {
-    if (!kpiData?.average_resolution_time_by_category) return [];
-    return kpiData.average_resolution_time_by_category
+    if (!snapshotData?.average_resolution_time_by_category) return [];
+    return snapshotData.average_resolution_time_by_category
       .map((item) => ({
         category: item.category,
         avgHours: item.avg_hours,
         avgDays: (item.avg_hours / 24).toFixed(1),
       }))
       .sort((a, b) => b.avgHours - a.avgHours);
-  }, [kpiData]);
+  }, [snapshotData]);
 
   const statusData = useMemo(() => {
-    if (!kpiData?.request_status_distribution) return [];
-    return kpiData.request_status_distribution.map((item) => ({
+    if (!snapshotData?.request_status_distribution) return [];
+    return snapshotData.request_status_distribution.map((item) => ({
       name: item.status,
       value: item.count,
     }));
-  }, [kpiData]);
+  }, [snapshotData]);
 
-  const totalRequests = kpiData?.total_requests ?? 0;
+  const totalRequests = snapshotData?.total_requests ?? 0;
+
+  // Trends view reads the selected range's total_requests time series.
+  // NOTE: Custom is intentionally excluded for now - backend is still
+  // finalizing the date-range granularity for Custom.
+  const trendData = useMemo(() => {
+    if (timeRange === "Custom") return [];
+    const series = kpiData?.body?.[timeRange]?.total_requests;
+    if (!Array.isArray(series)) return [];
+    return [...series].sort((a, b) => (a.period > b.period ? 1 : -1));
+  }, [kpiData, timeRange]);
 
   // Handle segment click
   const handleSegmentClick = (data) => {
@@ -177,15 +193,34 @@ const KPIAnalytics = () => {
       >
         {/* Controls */}
         <div className="mb-2 flex gap-2 items-center flex-wrap">
-          <button
-            onClick={() => {
-              setShowStatusTable(!showStatusTable);
+          <select
+            value={viewMode}
+            onChange={(e) => {
+              setViewMode(e.target.value);
               setSelectedSegment(null);
             }}
-            className="px-2 py-0.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600"
+            className="px-2 py-0.5 text-xs border border-gray-300 rounded bg-white"
           >
-            {showStatusTable ? "Chart View" : "Table View"}
-          </button>
+            <option value="snapshot">Snapshot</option>
+            <option value="table">Table view</option>
+            <option value="trends">Trends</option>
+          </select>
+
+          {viewMode === "trends" && (
+            <select
+              value={timeRange}
+              onChange={(e) => setTimeRange(e.target.value)}
+              className="px-2 py-0.5 text-xs border border-gray-300 rounded bg-white"
+            >
+              <option value="7D">7D</option>
+              <option value="30D">30D</option>
+              <option value="1Y">1Y</option>
+              <option value="All">All</option>
+              <option value="Custom" disabled>
+                Custom (coming soon)
+              </option>
+            </select>
+          )}
 
           {selectedSegment && (
             <>
@@ -210,7 +245,7 @@ const KPIAnalytics = () => {
           )}
         </div>
 
-        {!showStatusTable ? (
+        {viewMode === "snapshot" ? (
           <>
             <ResponsiveContainer width="100%" height={280}>
               <PieChart>
@@ -304,7 +339,7 @@ const KPIAnalytics = () => {
               </div>
             )}
           </>
-        ) : (
+        ) : viewMode === "table" ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
@@ -347,6 +382,46 @@ const KPIAnalytics = () => {
                 ))}
               </tbody>
             </table>
+          </div>
+        ) : (
+          <div className="w-full">
+            {trendData.length === 0 ? (
+              <div className="flex items-center justify-center h-48 text-gray-400 text-sm">
+                No trend data available for {timeRange}
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height={280}>
+                <LineChart data={trendData} margin={{ left: 10, right: 20 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis
+                    dataKey="period"
+                    tick={{ fontSize: 11 }}
+                    stroke="#6b7280"
+                  />
+                  <YAxis
+                    tick={{ fontSize: 12 }}
+                    stroke="#6b7280"
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#fff",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "0.375rem",
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    type="monotone"
+                    dataKey="total_requests"
+                    name="Total Requests"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                    dot={{ r: 3 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
           </div>
         )}
       </ChartContainer>

--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
@@ -8,22 +8,56 @@ jest.mock("../../../../services/analyticsServices", () => ({
 }));
 
 const mockData = {
-  request_status_distribution: [
-    { status: "CREATED", count: 200 },
-    { status: "MATCHING_VOLUNTEER", count: 100 },
-    { status: "RESOLVED", count: 11 },
-  ],
-  total_requests: 311,
-  average_resolution_time_by_category: [
-    { category: "Shelter", avg_hours: 180 },
-    { category: "Legal Aid", avg_hours: 250 },
-  ],
-  sla: {
-    target_days: 10,
-    target_hours: 240,
-    warning_days: 8.33,
-    warning_hours: 200,
+  body: {
+    All: {
+      request_status_distribution: [
+        { status: "CREATED", count: 200 },
+        { status: "MATCHING_VOLUNTEER", count: 100 },
+        { status: "RESOLVED", count: 11 },
+      ],
+      total_requests: 311,
+      average_resolution_time_by_category: [
+        { category: "Shelter", avg_hours: 180 },
+        { category: "Legal Aid", avg_hours: 250 },
+      ],
+    },
+    "7D": {
+      request_status_distribution: [],
+      total_requests: [
+        { period: "2026-07-09", total_requests: 4 },
+        { period: "2026-07-10", total_requests: 6 },
+      ],
+      average_resolution_time_by_category: [],
+    },
+    "30D": {
+      request_status_distribution: [],
+      total_requests: [
+        { period: "2026-06-15", total_requests: 2 },
+        { period: "2026-07-10", total_requests: 6 },
+      ],
+      average_resolution_time_by_category: [],
+    },
+    "1Y": {
+      request_status_distribution: [],
+      total_requests: [
+        { period: "2026-01", total_requests: 21 },
+        { period: "2026-07", total_requests: 40 },
+      ],
+      average_resolution_time_by_category: [],
+    },
+    sla: {
+      target_days: 10,
+      target_hours: 240,
+      warning_days: 8.33,
+      warning_hours: 200,
+    },
   },
+};
+
+const switchViewMode = (value) => {
+  fireEvent.change(screen.getByDisplayValue("Snapshot"), {
+    target: { value },
+  });
 };
 
 describe("KPIAnalytics", () => {
@@ -60,7 +94,7 @@ describe("KPIAnalytics", () => {
     });
   });
 
-  it("calls getKpiAnalytics once on mount", async () => {
+  it("calls getKpiAnalytics once on mount with an empty payload", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
@@ -70,8 +104,10 @@ describe("KPIAnalytics", () => {
 
   it("shows no resolution data message when array is empty", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue({
-      ...mockData,
-      average_resolution_time_by_category: [],
+      body: {
+        ...mockData.body,
+        All: { ...mockData.body.All, average_resolution_time_by_category: [] },
+      },
     });
     render(<KPIAnalytics />);
     await waitFor(() => {
@@ -81,37 +117,38 @@ describe("KPIAnalytics", () => {
     });
   });
 
-  it("renders Table View button", async () => {
+  it("renders the view mode dropdown defaulting to Snapshot", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      expect(screen.getByText("Table View")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
   });
 
-  it("switches to table view when Table View button is clicked", async () => {
+  it("switches to table view when Table view is selected", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Table View"));
-      expect(screen.getByText("Chart View")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
+    switchViewMode("table");
+    expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
   it("renders status items in table view", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Table View"));
-      expect(screen.getByText("CREATED")).toBeInTheDocument();
-      expect(screen.getByText("RESOLVED")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
+    switchViewMode("table");
+    expect(screen.getByText("CREATED")).toBeInTheDocument();
+    expect(screen.getByText("RESOLVED")).toBeInTheDocument();
   });
 
   it("uses default SLA values when sla is not in response", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue({
-      ...mockData,
-      sla: null,
+      body: { ...mockData.body, sla: null },
     });
     render(<KPIAnalytics />);
     await waitFor(() => {
@@ -121,37 +158,26 @@ describe("KPIAnalytics", () => {
     });
   });
 
-  it("selects a segment when pie segment is clicked", async () => {
-    analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
-    render(<KPIAnalytics />);
-    await waitFor(() => {
-      expect(
-        screen.getByText("Request Status Distribution"),
-      ).toBeInTheDocument();
-    });
-    const tableViewBtn = screen.getByText("Table View");
-    fireEvent.click(tableViewBtn);
-    expect(screen.getByText("Chart View")).toBeInTheDocument();
-  });
-
   it("shows percentage in table view", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Table View"));
-      expect(screen.getByText("Status")).toBeInTheDocument();
-      expect(screen.getByText("Count")).toBeInTheDocument();
-      expect(screen.getByText("Percentage")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
+    switchViewMode("table");
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+    expect(screen.getByText("Percentage")).toBeInTheDocument();
   });
 
   it("shows MATCHING_VOLUNTEER status in table view", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Table View"));
-      expect(screen.getByText("MATCHING_VOLUNTEER")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
+    switchViewMode("table");
+    expect(screen.getByText("MATCHING_VOLUNTEER")).toBeInTheDocument();
   });
 
   it("renders resolution bar chart when data exists", async () => {
@@ -168,33 +194,29 @@ describe("KPIAnalytics", () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
     render(<KPIAnalytics />);
     await waitFor(() => {
-      fireEvent.click(screen.getByText("Table View"));
-      expect(screen.getByText("200")).toBeInTheDocument();
-      expect(screen.getByText("100")).toBeInTheDocument();
-      expect(screen.getByText("11")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
     });
+    switchViewMode("table");
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("11")).toBeInTheDocument();
   });
 
   it("handles zero total requests gracefully", async () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue({
-      ...mockData,
-      total_requests: 0,
-      request_status_distribution: [],
+      body: {
+        ...mockData.body,
+        All: {
+          ...mockData.body.All,
+          total_requests: 0,
+          request_status_distribution: [],
+        },
+      },
     });
     render(<KPIAnalytics />);
     await waitFor(() => {
       expect(
         screen.getByText("Request Status Distribution"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("renderTooltip returns tooltip content when active with payload", async () => {
-    analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
-    render(<KPIAnalytics />);
-    await waitFor(() => {
-      expect(
-        screen.getByText("Average Resolution Time by Category"),
       ).toBeInTheDocument();
     });
   });
@@ -230,8 +252,7 @@ describe("KPIAnalytics", () => {
     const payload = [
       { payload: { category: "Shelter", avgHours: 300, avgDays: "12.5" } },
     ];
-    const result = tooltip({ active: true, payload });
-    expect(result).not.toBeNull();
+    expect(tooltip({ active: true, payload })).not.toBeNull();
   });
 
   it("renderTooltip shows Approaching SLA when hours between warning and target", () => {
@@ -239,8 +260,7 @@ describe("KPIAnalytics", () => {
     const payload = [
       { payload: { category: "Legal Aid", avgHours: 220, avgDays: "9.2" } },
     ];
-    const result = tooltip({ active: true, payload });
-    expect(result).not.toBeNull();
+    expect(tooltip({ active: true, payload })).not.toBeNull();
   });
 
   it("renderTooltip shows Within SLA when hours below warning", () => {
@@ -248,7 +268,71 @@ describe("KPIAnalytics", () => {
     const payload = [
       { payload: { category: "Education", avgHours: 100, avgDays: "4.2" } },
     ];
-    const result = tooltip({ active: true, payload });
-    expect(result).not.toBeNull();
+    expect(tooltip({ active: true, payload })).not.toBeNull();
+  });
+
+  describe("Trends view", () => {
+    it("switches to trends view and shows a time range selector defaulting to All", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      expect(screen.getByDisplayValue("All")).toBeInTheDocument();
+    });
+
+    it("shows no trend data message for All since it has no period series", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      expect(
+        screen.getByText("No trend data available for All"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the chart (not the empty state) when 7D has period data", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      fireEvent.change(screen.getByDisplayValue("All"), {
+        target: { value: "7D" },
+      });
+      expect(
+        screen.queryByText("No trend data available for 7D"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the chart (not the empty state) when 1Y has period data", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      fireEvent.change(screen.getByDisplayValue("All"), {
+        target: { value: "1Y" },
+      });
+      expect(
+        screen.queryByText("No trend data available for 1Y"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not fetch trend data for Custom (option is disabled)", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      const customOption = screen.getByText("Custom (coming soon)");
+      expect(customOption).toBeDisabled();
+    });
   });
 });

--- a/src/services/analyticsServices.js
+++ b/src/services/analyticsServices.js
@@ -18,7 +18,7 @@ export const getRequestsApplicationAnalytics = async (payload) => {
 };
 
 // NOTE: Currently GET - will be migrated to POST with { fromDate, toDate } payload later
-export const getKpiAnalytics = async () => {
-  const response = await api.get(endpoints.GET_KPI_ANALYTICS);
+export const getKpiAnalytics = async (payload = {}) => {
+  const response = await api.post(endpoints.GET_KPI_ANALYTICS, payload);
   return response.data;
 };

--- a/src/services/analyticsServices.test.js
+++ b/src/services/analyticsServices.test.js
@@ -81,11 +81,13 @@ describe("analyticsServices", () => {
     });
 
     describe("getKpiAnalytics", () => {
-      it("calls GET to GET_KPI_ANALYTICS and returns data", async () => {
+      it("calls POST to GET_KPI_ANALYTICS with the given payload and returns data", async () => {
         const mockData = {
-          request_status_distribution: [{ status: "CREATED", count: 200 }],
-          total_requests: 200,
-          average_resolution_time_by_category: [],
+          "7D": {
+            request_status_distribution: [{ status: "CREATED", count: 200 }],
+            total_requests: [{ period: "2026-07-11", total_requests: 10 }],
+            average_resolution_time_by_category: [],
+          },
           sla: {
             target_days: 10,
             target_hours: 240,
@@ -93,14 +95,35 @@ describe("analyticsServices", () => {
             warning_hours: 200,
           },
         };
-        api.get.mockResolvedValue({ data: mockData });
+        api.post.mockResolvedValue({ data: mockData });
+
         const result = await getKpiAnalytics();
-        expect(api.get).toHaveBeenCalledWith("v1/ml/kpiAnalytics");
+
+        expect(api.post).toHaveBeenCalledWith("v1/ml/kpiAnalytics", {});
+        expect(result).toEqual(mockData);
+      });
+
+      it("passes a custom time_range payload through to the API", async () => {
+        const mockData = {
+          request_status_distribution: [],
+          total_requests: [],
+          average_resolution_time_by_category: [],
+        };
+        api.post.mockResolvedValue({ data: mockData });
+
+        const payload = {
+          time_range: "Custom",
+          start_date: "2026-01-01",
+          end_date: "2026-01-15",
+        };
+        const result = await getKpiAnalytics(payload);
+
+        expect(api.post).toHaveBeenCalledWith("v1/ml/kpiAnalytics", payload);
         expect(result).toEqual(mockData);
       });
 
       it("propagates errors from api", async () => {
-        api.get.mockRejectedValue(new Error("Network error"));
+        api.post.mockRejectedValue(new Error("Network error"));
         await expect(getKpiAnalytics()).rejects.toThrow("Network error");
       });
     });


### PR DESCRIPTION
## Summary
Replaces the "Table View" toggle button on the KPI Analytics tab with a three-way dropdown: Snapshot | Table view | Trends. Trends adds a 7D/30D/1Y/All time-range selector, each rendering a line chart of request volume over time.
## Changes
- 'analyticsServices.js' — 'getKpiAnalytics' now POSTs a payload ('{}' by default) instead of a bare GET, matching the updated API
- 'KPIAnalytics.jsx':
  - New 'viewMode' state (snapshot/table/trends) replaces the old boolean toggle
  - New 'timeRange' state (7D/30D/1Y/All) for the Trends view
  - Snapshot/Table now read from 'response.body.All' per the updated API response shape
  - New `trendData` derivation reads 'response.body[timeRange].total_requests' (an array of '{period, total_requests}') and renders it as a Recharts LineChart
  - "All" has no per-period series by design (only an aggregate total), so Trends shows an empty-state message for that selection
  - Custom range is intentionally excluded from Trends for now, Backend is still finalizing the date-range granularity for Custom

## Testing
- Updated 'analyticsServices.test.js' for the new POST signature
- Rewrote 'KPIAnalytics.test.jsx' for the new response shape and
  dropdown UI, added Trends view coverage
- 26 tests passing
- Manually verified in local dev: Snapshot, Table view, and Trends (7D/30D/1Y) all render correctly against the live API; All correctly
  shows the empty state.