### PR TITLE
feat: add hover tooltip to category field in request details (#1654)

### DIFF
--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -101,10 +101,15 @@ const RequestDescription = ({ requestData }) => {
               {t("UPDATED_DATE")}
             </div>
           </li>
-          {/* Category */}
-          <li className="flex items-center gap-2">
+          {/* Category with tooltip - issue #1654 */}
+          <li className="flex items-center gap-2 group relative">
             <TbTriangleSquareCircle size={22} />
-            {categoryLabel}
+            <span className="cursor-help border-b border-dashed border-gray-400">
+              {categoryLabel}
+            </span>
+            <div className="absolute top-6 left-0 z-10 px-3 py-1 bg-gray-800 text-white text-xs rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap pointer-events-none">
+              {t("CATEGORY")}
+            </div>
           </li>
 
           {/* Status with tooltip - issue #1456 */}

--- a/src/pages/RequestDetails/RequestDescription.test.jsx
+++ b/src/pages/RequestDetails/RequestDescription.test.jsx
@@ -268,4 +268,50 @@ describe("RequestDescription", () => {
       expect(priorityDiamond).toBeInTheDocument();
     });
   });
+
+  describe("Issue #1654 - Category hover tooltip", () => {
+    it("renders the category label text", () => {
+      renderWithProviders(
+        <RequestDescription requestData={mockRequestData} />,
+        { preloadedState: MOCK_STATE_LOGGED_IN },
+      );
+
+      expect(screen.getByText("Maintenance")).toBeInTheDocument();
+    });
+
+    it("renders the category tooltip with CATEGORY key in the DOM", () => {
+      const { container } = renderWithProviders(
+        <RequestDescription requestData={mockRequestData} />,
+        { preloadedState: MOCK_STATE_LOGGED_IN },
+      );
+
+      // Tooltip div is always in the DOM (opacity controlled by CSS group-hover)
+      const tooltip = container.querySelector(
+        ".opacity-0.group-hover\\:opacity-100",
+      );
+      expect(tooltip).not.toBeNull();
+      // At least one tooltip contains the CATEGORY key text
+      const tooltips = container.querySelectorAll(
+        ".opacity-0.group-hover\\:opacity-100",
+      );
+      const categoryTooltip = Array.from(tooltips).find((el) =>
+        el.textContent.includes("CATEGORY"),
+      );
+      expect(categoryTooltip).not.toBeNull();
+    });
+
+    it("category span has cursor-help and dashed underline classes", () => {
+      const { container } = renderWithProviders(
+        <RequestDescription requestData={mockRequestData} />,
+        { preloadedState: MOCK_STATE_LOGGED_IN },
+      );
+
+      const spans = container.querySelectorAll("span.cursor-help");
+      const categorySpan = Array.from(spans).find((el) =>
+        el.textContent.includes("Maintenance"),
+      );
+      expect(categorySpan).not.toBeNull();
+      expect(categorySpan).toHaveClass("border-b", "border-dashed");
+    });
+  });
 });


### PR DESCRIPTION
Apply the same group/group-hover Tailwind tooltip pattern used by the creation and updated date fields to the category field in the Details tab of the Request Details page. The category text now shows a dashed underline with cursor-help, and hovering displays a dark tooltip with the translated CATEGORY label.

Tests: added 3 new assertions under Issue #1654 describe block — label renders, tooltip div is in the DOM, span has cursor-help/dashed classes. All 20 tests pass.