### PR TITLE
Added page title to Notifications screen

### DIFF
--- a/src/pages/Notifications/Notifications.jsx
+++ b/src/pages/Notifications/Notifications.jsx
@@ -88,6 +88,10 @@ export default function NotificationUI() {
 
   return (
     <div className="p-4 sm:p-6 bg-gray-50 min-h-screen">
+      <h1 className="mb-4 text-3xl font-bold text-gray-800">
+        {t("NOTIFICATIONS")}
+      </h1>
+
       <div className="bg-white p-4 rounded-lg shadow mb-6 flex flex-wrap gap-4 items-center">
         {["all", "volunteer", "help"].map((type) => (
           <button

--- a/src/pages/Notifications/Notifications.jsx
+++ b/src/pages/Notifications/Notifications.jsx
@@ -88,9 +88,11 @@ export default function NotificationUI() {
 
   return (
     <div className="p-4 sm:p-6 bg-gray-50 min-h-screen">
-      <h1 className="mb-4 text-3xl font-bold text-gray-800">
-        {t("NOTIFICATIONS")}
-      </h1>
+      <div className="mb-4 w-full">
+        <h1 className="text-2xl font-semibold text-center text-gray-800">
+          {t("NOTIFICATIONS")}
+        </h1>
+      </div>
 
       <div className="bg-white p-4 rounded-lg shadow mb-6 flex flex-wrap gap-4 items-center">
         {["all", "volunteer", "help"].map((type) => (

--- a/src/pages/Notifications/Notifications.test.jsx
+++ b/src/pages/Notifications/Notifications.test.jsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import NotificationUI from "./Notifications";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock("react-redux", () => ({
+  useSelector: () => ({ user: {} }),
+}));
+
+jest.mock("../../context/NotificationContext", () => ({
+  useNotifications: () => ({
+    dispatch: jest.fn(),
+    state: { notifications: [] },
+  }),
+  NotificationProvider: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("../../common/components/Pagination/Pagination", () => () => (
+  <div data-testid="pagination" />
+));
+
+describe("NotificationUI", () => {
+  it("renders the notifications page title", () => {
+    render(<NotificationUI />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "NOTIFICATIONS" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds the missing page title to the Notifications screen so it matches the styling and structure of other pages.

Closes #1670 

<img width="919" height="597" alt="Screenshot 2026-07-17 at 3 48 24 PM" src="https://github.com/user-attachments/assets/37d5cfae-76e7-4e41-93ec-559160e871bc" />
