### PR TITLE
feat: prefill In Person location from Other person's location

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -234,6 +234,37 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     detected_language: "", // Language detected from audio transcription (e.g., "hi", "en", "es")
   });
 
+  // One-time prefill: when requesting on behalf of someone else (For Self
+  // = Other) with an In Person request, default the In Person location to
+  // the Other person's location - it's logically the same place (e.g. a
+  // roadside location, a friend's address). Fires once; both fields are
+  // freely/independently editable afterward.
+  const hasPrefilledInPersonFromOtherRef = useRef(false);
+  useEffect(() => {
+    if (
+      formData.request_for === "OTHER" &&
+      formData.request_type === "IN_PERSON" &&
+      otherPersonLocation &&
+      !hasPrefilledInPersonFromOtherRef.current
+    ) {
+      hasPrefilledInPersonFromOtherRef.current = true;
+      setLocation(otherPersonLocation);
+      setFormData((prev) => ({ ...prev, location: otherPersonLocation }));
+      if (otherPersonLocationCoordinates) {
+        setLocationCoordinates(otherPersonLocationCoordinates);
+        setFormData((prev) => ({
+          ...prev,
+          locationCoordinates: otherPersonLocationCoordinates,
+        }));
+      }
+    }
+  }, [
+    formData.request_for,
+    formData.request_type,
+    otherPersonLocation,
+    otherPersonLocationCoordinates,
+  ]);
+
   // If user changes category to a non-elderly option, ensure any open ElderlySupport panel is closed
   useEffect(() => {
     // Resolve whether current formData.category corresponds to an Elderly subcategory
@@ -2240,7 +2271,14 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
                           ...formData,
                           request_type: value,
                         });
-                        if (value === "IN_PERSON") {
+                        // Skip browser geolocation when requesting on behalf
+                        // of someone else - the In Person location prefills
+                        // from the Other person's location instead (see the
+                        // hasPrefilledInPersonFromOtherRef effect above).
+                        if (
+                          value === "IN_PERSON" &&
+                          formData.request_for !== "OTHER"
+                        ) {
                           getUserLocation();
                         }
                       }}

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -2098,6 +2098,49 @@ describe("HelpRequestForm — prefill In Person location from Other person's loc
 
     expect(mockGetCurrentPosition).not.toHaveBeenCalled();
   });
+
+  it("also copies coordinates when the Other person's location included them", async () => {
+    capturedSetCoordinates = null;
+
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        document.getElementById("other_person_location"),
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("other_person_location"), {
+        target: { value: "133rd Terrace, Overland Park, Kansas" },
+      });
+    });
+
+    expect(capturedSetCoordinates).not.toBeNull();
+
+    await act(async () => {
+      capturedSetCoordinates({ latitude: 38.886491, longitude: -94.649869 });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location").value).toBe(
+        "133rd Terrace, Overland Park, Kansas",
+      );
+    });
+  });
 });
 
 describe("HelpRequestForm — DynamicAdditionalFields category id", () => {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -1944,6 +1944,162 @@ describe("HelpRequestForm — IN_PERSON location auto-detection", () => {
   });
 });
 
+describe("HelpRequestForm — prefill In Person location from Other person's location (#1622 follow-up)", () => {
+  beforeEach(() => {
+    mockT.mockReset();
+    mockT.mockImplementation((text) => `mockTranslate(${text})`);
+    localStorage.setItem(
+      "enums",
+      JSON.stringify({
+        requestType: { IN_PERSON: "IN_PERSON", REMOTE: "REMOTE" },
+        requestPriority: { MEDIUM: 2 },
+        requestFor: { SELF: "SELF", OTHER: "OTHER" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    mockSuggestions = [];
+  });
+
+  it("prefills the In Person location from the Other person's location", async () => {
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        document.getElementById("other_person_location"),
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("other_person_location"), {
+        target: { value: "133rd Terrace, Overland Park, Kansas" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location").value).toBe(
+        "133rd Terrace, Overland Park, Kansas",
+      );
+    });
+  });
+
+  it("still prefills if Type is switched to In Person before the Other location is typed", async () => {
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    // No prefill yet - Other location was empty when In Person was selected
+    expect(document.getElementById("location").value).toBe("");
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("other_person_location"), {
+        target: { value: "West 151st Terrace, Overland Park, Kansas" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location").value).toBe(
+        "West 151st Terrace, Overland Park, Kansas",
+      );
+    });
+  });
+
+  it("keeps the two location fields independently editable after the one-time prefill", async () => {
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("other_person_location"), {
+        target: { value: "133rd Terrace, Overland Park, Kansas" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("location").value).toBe(
+        "133rd Terrace, Overland Park, Kansas",
+      );
+    });
+
+    // Edit the In Person location afterward
+    await act(async () => {
+      fireEvent.change(document.getElementById("location"), {
+        target: { value: "West 151st Terrace, Overland Park, Kansas" },
+      });
+    });
+
+    // Other person's location must stay untouched
+    expect(document.getElementById("other_person_location").value).toBe(
+      "133rd Terrace, Overland Park, Kansas",
+    );
+    expect(document.getElementById("location").value).toBe(
+      "West 151st Terrace, Overland Park, Kansas",
+    );
+  });
+
+  it("does not trigger browser geolocation when For Self is Other", async () => {
+    const mockGetCurrentPosition = jest.fn();
+    Object.defineProperty(global.navigator, "geolocation", {
+      value: { getCurrentPosition: mockGetCurrentPosition },
+      configurable: true,
+    });
+
+    renderForm();
+    fireEvent.click(screen.getByText("mockTranslate(DETAILS)"));
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("request_for"), {
+        target: { value: "OTHER" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.getElementById("requestType"), {
+        target: { value: "IN_PERSON" },
+      });
+    });
+
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled();
+  });
+});
+
 describe("HelpRequestForm — DynamicAdditionalFields category id", () => {
   beforeEach(() => {
     mockT.mockReset();


### PR DESCRIPTION
- When For Self = Other and Type = In Person, the In Person location field now defaults to the Other person's location (they are logically the same place - e.g. a friend or someone found roadside who needs help at that location)
- Prefill is one-time only, guarded by a ref; both location fields remain fully and independently editable afterward
- Skips the existing browser geolocation auto-detect for In Person when the request is for someone else, since the location is now sourced from the Other person's location instead
- Added 4 new tests covering: prefill on typing then switching Type, prefill on switching Type then typing, independent editability after prefill, and geolocation being skipped when For Self = Other
- All 74 tests in HelpRequestForm.test.jsx passing