### PR TITLE
Add bulk status update and checkboxes to Admin and Super Admin #1657

### DIFF
--- a/src/common/components/DataTable/Table.jsx
+++ b/src/common/components/DataTable/Table.jsx
@@ -18,6 +18,10 @@ const Table = ({
   getLinkPath,
   getLinkState = undefined,
   serverPaginated = false,
+  showCheckboxes = false,
+  selectedRows = [],
+  onRowSelect,
+  onSelectAll,
 }) => {
   const { t, i18n } = useTranslation(["common", "categories"]);
 
@@ -171,6 +175,23 @@ const Table = ({
         >
           <thead data-testid="table-header">
             <tr>
+              {showCheckboxes && (
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-10">
+                  <input
+                    type="checkbox"
+                    className="cursor-pointer w-4 h-4"
+                    checked={
+                      paginatedRequests.length > 0 &&
+                      paginatedRequests.every((row) =>
+                        selectedRows.includes(row.requestId || row.id),
+                      )
+                    }
+                    onChange={(e) =>
+                      onSelectAll && onSelectAll(e.target.checked)
+                    }
+                  />
+                </th>
+              )}
               {headers.map((key) => (
                 <th
                   key={key}
@@ -201,7 +222,7 @@ const Table = ({
             {paginatedRequests.length === 0 ? (
               <tr>
                 <td
-                  colSpan={headers.length}
+                  colSpan={headers.length + (showCheckboxes ? 1 : 0)}
                   className="px-6 py-8 text-center text-gray-500"
                 >
                   <div className="flex flex-col items-center justify-center">
@@ -219,6 +240,18 @@ const Table = ({
             ) : (
               paginatedRequests.map((row, rowIndex) => (
                 <tr key={rowIndex}>
+                  {showCheckboxes && (
+                    <td className="px-3 py-2 w-10">
+                      <input
+                        type="checkbox"
+                        className="cursor-pointer w-4 h-4"
+                        checked={selectedRows.includes(row.requestId || row.id)}
+                        onChange={() =>
+                          onRowSelect && onRowSelect(row.requestId || row.id)
+                        }
+                      />
+                    </td>
+                  )}
                   {headers.map((header, colIndex) => {
                     const value = getCellValue(row, header);
 
@@ -286,6 +319,10 @@ Table.propTypes = {
   getLinkPath: PropTypes.func.isRequired,
   getLinkState: PropTypes.func,
   serverPaginated: PropTypes.bool,
+  showCheckboxes: PropTypes.bool,
+  selectedRows: PropTypes.array,
+  onRowSelect: PropTypes.func,
+  onSelectAll: PropTypes.func,
 };
 
 export default Table;

--- a/src/common/components/DataTable/table.test.js
+++ b/src/common/components/DataTable/table.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import Table from "./Table";
 
 jest.mock("../Pagination/Pagination");
@@ -317,6 +317,68 @@ describe("Table", () => {
       );
 
       expect(mockSetPage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("checkbox selection", () => {
+    const onRowSelect = jest.fn();
+    const onSelectAll = jest.fn();
+
+    const checkboxProps = {
+      ...defaultProps,
+      showCheckboxes: true,
+      selectedRows: [],
+      onRowSelect,
+      onSelectAll,
+    };
+
+    beforeEach(() => {
+      onRowSelect.mockClear();
+      onSelectAll.mockClear();
+    });
+
+    it("renders checkboxes in header and each row when showCheckboxes is true", () => {
+      render(<Table {...checkboxProps} />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      // 1 header checkbox + 1 data row checkbox
+      expect(checkboxes).toHaveLength(2);
+    });
+
+    it("does not render checkboxes when showCheckboxes is false or omitted", () => {
+      render(<Table {...defaultProps} />);
+      expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+    });
+
+    it("calls onRowSelect with requestId when a row checkbox is clicked", () => {
+      render(<Table {...checkboxProps} />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      fireEvent.click(checkboxes[1]); // first data row
+      expect(onRowSelect).toHaveBeenCalledWith("REQ-001");
+    });
+
+    it("calls onSelectAll(true) when unchecked header checkbox is clicked", () => {
+      render(<Table {...checkboxProps} />);
+      const [headerCheckbox] = screen.getAllByRole("checkbox");
+      fireEvent.click(headerCheckbox);
+      expect(onSelectAll).toHaveBeenCalledWith(true);
+    });
+
+    it("marks row checkbox as checked when its id is in selectedRows", () => {
+      render(<Table {...checkboxProps} selectedRows={["REQ-001"]} />);
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes[1]).toBeChecked();
+    });
+
+    it("marks header checkbox as checked when all current page rows are selected", () => {
+      render(<Table {...checkboxProps} selectedRows={["REQ-001"]} />);
+      const [headerCheckbox] = screen.getAllByRole("checkbox");
+      expect(headerCheckbox).toBeChecked();
+    });
+
+    it("header checkbox is unchecked when no rows are selected", () => {
+      render(<Table {...checkboxProps} selectedRows={[]} />);
+      const [headerCheckbox] = screen.getAllByRole("checkbox");
+      expect(headerCheckbox).not.toBeChecked();
     });
   });
 

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -27,7 +27,6 @@ import {
   getMyRequests,
   getOthersRequests,
   getAllPaginatedRequests,
-  updateRequest,
 } from "../../services/requestServices";
 import {
   getStatusOptions,
@@ -113,85 +112,26 @@ const Dashboard = ({ userRole }) => {
   };
 
   const [bulkStatusValue, setBulkStatusValue] = useState("");
-  const [isBulkActionLoading, setIsBulkActionLoading] = useState(false);
 
   // TODO: BACKEND DEPENDENCY — Bulk Admin Status Change
   // ------------------------------------------------------------------
   // The frontend UI for bulk status changes (checkboxes + "Change Status"
-  // dropdown + "Apply" button) is fully implemented. However, the existing
-  // PUT endpoint `v1/request/updateHelpRequest` returns 500 when called
-  // with the row data + a new requestStatus value.
+  // dropdown + "Apply" button) is fully implemented. Once the backend
+  // provides an endpoint, integrate the API call here.
   //
-  // The backend team needs to do ONE of the following to resolve this:
-  //
-  // Option A (Preferred): Create a new dedicated endpoint for admin
-  //   bulk status updates, e.g.:
-  //   PUT /v1/request/admin/bulkUpdateStatus
+  // Option A (Preferred): PUT /v1/request/admin/bulkUpdateStatus
   //   Request body: { requestIds: ["REQ-00-..."], requestStatus: "CANCELLED" }
-  //   This endpoint should accept an array of request IDs and a target
-  //   status, validate admin permissions, and update all matching requests.
   //
-  // Option B: Modify the existing `updateHelpRequest` endpoint to support
-  //   partial/status-only updates when called with just:
-  //   { requestId: "REQ-00-...", requestStatus: "CANCELLED" }
-  //   Ensure it handles admin authorization (allow admins/superadmins to
-  //   update status on any request, not just their own).
-  //
-  // Once the backend endpoint is available, update the payload construction
-  // and API call below accordingly, and remove the console.log debug line.
+  // Option B: Modify PUT /v1/request/updateHelpRequest to accept
+  //   partial/status-only updates with admin authorization.
   // ------------------------------------------------------------------
-  const handleBulkStatusChange = async () => {
+  const handleBulkStatusChange = () => {
     if (!bulkStatusValue || selectedRows.length === 0) return;
-
-    setIsBulkActionLoading(true);
-    try {
-      const allRows = getRequestRows(data);
-      const updatePromises = selectedRows.map((rowId) => {
-        const row = allRows.find((r) => (r.requestId || r.id) === rowId);
-        const payload = {
-          ...(row || {}),
-          requestId: rowId,
-          requestStatus: bulkStatusValue,
-        };
-        console.log("Bulk status update payload:", payload);
-        return updateRequest(payload);
-      });
-      const results = await Promise.allSettled(updatePromises);
-      const succeeded = results.filter((r) => r.status === "fulfilled").length;
-      const failed = results.filter((r) => r.status === "rejected").length;
-
-      if (failed > 0) {
-        const errors = results
-          .filter((r) => r.status === "rejected")
-          .map(
-            (r) => r.reason?.response?.data || r.reason?.message || r.reason,
-          );
-        console.error("Bulk update errors:", errors);
-      }
-
-      if (failed === 0) {
-        toast.success(
-          `Status updated to "${bulkStatusValue}" for ${succeeded} request(s).`,
-        );
-      } else if (succeeded > 0) {
-        toast.warn(
-          `${succeeded} request(s) updated, ${failed} failed. Please try again for failed ones.`,
-        );
-      } else {
-        toast.error("Failed to update status for the selected requests.");
-      }
-
-      setSelectedRows([]);
-      setBulkStatusValue("");
-      getAllRequests(activeTab);
-    } catch (error) {
-      console.error("Bulk status update failed:", error);
-      toast.error(
-        "Failed to update status for some requests. Please try again.",
-      );
-    } finally {
-      setIsBulkActionLoading(false);
-    }
+    toast.warn(
+      `Bulk status update to "${bulkStatusValue}" for ${selectedRows.length} request(s) is pending backend API support.`,
+    );
+    setSelectedRows([]);
+    setBulkStatusValue("");
   };
 
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
@@ -1555,14 +1495,14 @@ const Dashboard = ({ userRole }) => {
               </select>
               <button
                 onClick={handleBulkStatusChange}
-                disabled={!bulkStatusValue || isBulkActionLoading}
+                disabled={!bulkStatusValue}
                 className={`py-2 px-4 rounded-md text-sm font-medium text-white ${
-                  !bulkStatusValue || isBulkActionLoading
+                  !bulkStatusValue
                     ? "bg-gray-300 cursor-not-allowed"
                     : "bg-blue-500 hover:bg-blue-600 cursor-pointer"
                 }`}
               >
-                {isBulkActionLoading ? "Applying..." : "Apply"}
+                Apply
               </button>
             </div>
           )}

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -4,7 +4,7 @@ import { IoIosArrowDown } from "react-icons/io";
 import { IoSearchOutline } from "react-icons/io5";
 import { useSelector } from "react-redux";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
+import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import AdminDashboard from "./views/AdminDashboard";
 import BeneficiaryDashboard from "./views/BeneficiaryDashboard";
@@ -27,6 +27,7 @@ import {
   getMyRequests,
   getOthersRequests,
   getAllPaginatedRequests,
+  updateRequest,
 } from "../../services/requestServices";
 import {
   getStatusOptions,
@@ -77,6 +78,121 @@ const Dashboard = ({ userRole }) => {
     currentServerPage: 0,
     isServerPaginated: false,
   });
+
+  const [selectedRows, setSelectedRows] = useState([]);
+
+  const handleRowSelect = (rowId) => {
+    setSelectedRows((prev) =>
+      prev.includes(rowId)
+        ? prev.filter((id) => id !== rowId)
+        : [...prev, rowId],
+    );
+  };
+
+  const handleSelectAll = (checked) => {
+    const currentPageRows = serverPagination.isServerPaginated
+      ? filteredData
+      : filteredData.slice(
+          (currentPage - 1) * rowsPerPage,
+          currentPage * rowsPerPage,
+        );
+    const currentPageIds = currentPageRows.map(
+      (row) => row.requestId || row.id,
+    );
+    if (checked) {
+      setSelectedRows((prev) => [...new Set([...prev, ...currentPageIds])]);
+    } else {
+      setSelectedRows((prev) =>
+        prev.filter((id) => !currentPageIds.includes(id)),
+      );
+    }
+  };
+
+  const getRequestRows = (data) => {
+    return data?.data?.content || data?.content || data?.body || [];
+  };
+
+  const [bulkStatusValue, setBulkStatusValue] = useState("");
+  const [isBulkActionLoading, setIsBulkActionLoading] = useState(false);
+
+  // TODO: BACKEND DEPENDENCY — Bulk Admin Status Change
+  // ------------------------------------------------------------------
+  // The frontend UI for bulk status changes (checkboxes + "Change Status"
+  // dropdown + "Apply" button) is fully implemented. However, the existing
+  // PUT endpoint `v1/request/updateHelpRequest` returns 500 when called
+  // with the row data + a new requestStatus value.
+  //
+  // The backend team needs to do ONE of the following to resolve this:
+  //
+  // Option A (Preferred): Create a new dedicated endpoint for admin
+  //   bulk status updates, e.g.:
+  //   PUT /v1/request/admin/bulkUpdateStatus
+  //   Request body: { requestIds: ["REQ-00-..."], requestStatus: "CANCELLED" }
+  //   This endpoint should accept an array of request IDs and a target
+  //   status, validate admin permissions, and update all matching requests.
+  //
+  // Option B: Modify the existing `updateHelpRequest` endpoint to support
+  //   partial/status-only updates when called with just:
+  //   { requestId: "REQ-00-...", requestStatus: "CANCELLED" }
+  //   Ensure it handles admin authorization (allow admins/superadmins to
+  //   update status on any request, not just their own).
+  //
+  // Once the backend endpoint is available, update the payload construction
+  // and API call below accordingly, and remove the console.log debug line.
+  // ------------------------------------------------------------------
+  const handleBulkStatusChange = async () => {
+    if (!bulkStatusValue || selectedRows.length === 0) return;
+
+    setIsBulkActionLoading(true);
+    try {
+      const allRows = getRequestRows(data);
+      const updatePromises = selectedRows.map((rowId) => {
+        const row = allRows.find((r) => (r.requestId || r.id) === rowId);
+        const payload = {
+          ...(row || {}),
+          requestId: rowId,
+          requestStatus: bulkStatusValue,
+        };
+        console.log("Bulk status update payload:", payload);
+        return updateRequest(payload);
+      });
+      const results = await Promise.allSettled(updatePromises);
+      const succeeded = results.filter((r) => r.status === "fulfilled").length;
+      const failed = results.filter((r) => r.status === "rejected").length;
+
+      if (failed > 0) {
+        const errors = results
+          .filter((r) => r.status === "rejected")
+          .map(
+            (r) => r.reason?.response?.data || r.reason?.message || r.reason,
+          );
+        console.error("Bulk update errors:", errors);
+      }
+
+      if (failed === 0) {
+        toast.success(
+          `Status updated to "${bulkStatusValue}" for ${succeeded} request(s).`,
+        );
+      } else if (succeeded > 0) {
+        toast.warn(
+          `${succeeded} request(s) updated, ${failed} failed. Please try again for failed ones.`,
+        );
+      } else {
+        toast.error("Failed to update status for the selected requests.");
+      }
+
+      setSelectedRows([]);
+      setBulkStatusValue("");
+      getAllRequests(activeTab);
+    } catch (error) {
+      console.error("Bulk status update failed:", error);
+      toast.error(
+        "Failed to update status for some requests. Please try again.",
+      );
+    } finally {
+      setIsBulkActionLoading(false);
+    }
+  };
 
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [accessibleDashboards, setAccessibleDashboards] = useState([]);
@@ -311,6 +427,7 @@ const Dashboard = ({ userRole }) => {
     setActiveTab(tab);
     setCurrentPage(1);
     setStatusFilter({});
+    setSelectedRows([]);
   };
   // DON'T reset category filter when changing tabs
   // This was causing issues where API categories didn't match data categories
@@ -398,10 +515,6 @@ const Dashboard = ({ userRole }) => {
       });
     }
     return sortableRequests;
-  };
-
-  const getRequestRows = (data) => {
-    return data?.data?.content || data?.content || data?.body || [];
   };
 
   const sortedData = useMemo(() => {
@@ -1147,6 +1260,7 @@ const Dashboard = ({ userRole }) => {
       setPriorityFilter({});
       setCalamityFilter({});
       setVolunteerTypeFilter({});
+      setSelectedRows([]);
       setActiveTab(dashboardDefaultTab[selectedDashboard]);
     }
   }, [selectedDashboard]);
@@ -1168,7 +1282,7 @@ const Dashboard = ({ userRole }) => {
           />
         </div>
       </div>
-      <div className="mb-4 flex flex-wrap gap-2 px-10">
+      <div className="mb-4 flex flex-wrap gap-2 px-10 items-center">
         <div className="relative" onBlur={handleFilterBlur} tabIndex={-1}>
           <div
             className="bg-blue-50 flex items-center rounded-md hover:bg-gray-300"
@@ -1417,6 +1531,41 @@ const Dashboard = ({ userRole }) => {
               )}
             </div>
           )}
+
+        {[DASHBOARDS.ADMIN, DASHBOARDS.SUPER_ADMIN].includes(
+          selectedDashboard,
+        ) &&
+          activeTab === "myRequests" &&
+          selectedRows.length > 0 && (
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-sm text-gray-600 font-medium">
+                {selectedRows.length} selected
+              </span>
+              <select
+                value={bulkStatusValue}
+                onChange={(e) => setBulkStatusValue(e.target.value)}
+                className="border border-gray-300 rounded-md py-2 px-3 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+              >
+                <option value="">Change Status</option>
+                {statusOptions.map((status) => (
+                  <option key={status.key} value={status.key}>
+                    {String(status.label).toUpperCase()}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={handleBulkStatusChange}
+                disabled={!bulkStatusValue || isBulkActionLoading}
+                className={`py-2 px-4 rounded-md text-sm font-medium text-white ${
+                  !bulkStatusValue || isBulkActionLoading
+                    ? "bg-gray-300 cursor-not-allowed"
+                    : "bg-blue-500 hover:bg-blue-600 cursor-pointer"
+                }`}
+              >
+                {isBulkActionLoading ? "Applying..." : "Apply"}
+              </button>
+            </div>
+          )}
       </div>
     </>
   );
@@ -1567,6 +1716,9 @@ const Dashboard = ({ userRole }) => {
                 setAnalyticsSubtab={setAnalyticsSubtab}
                 serverPaginated={serverPagination.isServerPaginated}
                 serverTotalRows={serverPagination.totalRecords}
+                selectedRows={selectedRows}
+                onRowSelect={handleRowSelect}
+                onSelectAll={handleSelectAll}
               />
             )}
 
@@ -1597,6 +1749,9 @@ const Dashboard = ({ userRole }) => {
                 setAnalyticsSubtab={setAnalyticsSubtab}
                 serverPaginated={serverPagination.isServerPaginated}
                 serverTotalRows={serverPagination.totalRecords}
+                selectedRows={selectedRows}
+                onRowSelect={handleRowSelect}
+                onSelectAll={handleSelectAll}
               />
             )}
 

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -20,7 +20,7 @@ jest.mock("react-i18next", () => ({
 
 jest.mock("react-toastify", () => ({
   ToastContainer: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+  toast: { success: jest.fn(), error: jest.fn(), warn: jest.fn() },
 }));
 
 jest.mock("../../services/requestServices", () => ({
@@ -67,11 +67,21 @@ jest.mock("./views/AdminDashboard", () => (props) => {
   lastAdminDashboardProps = props;
   return (
     <div data-testid="admin-dashboard">
+      {props.searchFilters}
       <button onClick={() => props.handleTabChange("myRequests")}>
         Click All Requests
       </button>
       <button onClick={() => props.setCurrentPage(2)}>Change Page</button>
       <button onClick={() => props.onRowsPerPageChange(25)}>Change Rows</button>
+      <button onClick={() => props.onRowSelect && props.onRowSelect("REQ-001")}>
+        Select Row
+      </button>
+      <button onClick={() => props.onSelectAll && props.onSelectAll(true)}>
+        Select All
+      </button>
+      <button onClick={() => props.onSelectAll && props.onSelectAll(false)}>
+        Deselect All
+      </button>
     </div>
   );
 });
@@ -787,6 +797,186 @@ describe("Dashboard", () => {
       expect(getMyRequests).toHaveBeenCalledWith(
         expect.objectContaining({ userId: "SID-FROM-STORAGE" }),
       );
+    });
+  });
+
+  describe("selectedRows and bulk status change", () => {
+    const rowData = {
+      requestId: "REQ-001",
+      requestCategory: "GENERAL",
+      status: "CREATED",
+      subject: "Test request",
+    };
+
+    beforeEach(() => {
+      const {
+        getAllPaginatedRequests,
+      } = require("../../services/requestServices");
+      getAllPaginatedRequests.mockResolvedValue({
+        data: { content: [rowData], totalPages: 1, totalElements: 1 },
+      });
+      const { toast } = require("react-toastify");
+      toast.warn.mockClear();
+    });
+
+    afterEach(() => {
+      const {
+        getAllPaginatedRequests,
+      } = require("../../services/requestServices");
+      getAllPaginatedRequests.mockResolvedValue({
+        data: { content: [], totalPages: 1, totalElements: 0 },
+      });
+    });
+
+    it("passes empty selectedRows and onRowSelect to AdminDashboard", async () => {
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).toEqual([]),
+      );
+      expect(typeof lastAdminDashboardProps?.onRowSelect).toBe("function");
+      expect(typeof lastAdminDashboardProps?.onSelectAll).toBe("function");
+    });
+
+    it("adds row id to selectedRows when onRowSelect is called", async () => {
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row"));
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).toContain("REQ-001"),
+      );
+    });
+
+    it("removes row id from selectedRows when onRowSelect is called again", async () => {
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row")); // select
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).toContain("REQ-001"),
+      );
+      fireEvent.click(getByText("Select Row")); // deselect
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).not.toContain("REQ-001"),
+      );
+    });
+
+    it("selects all rows on current page when onSelectAll(true) is called", async () => {
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select All"));
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).toContain("REQ-001"),
+      );
+    });
+
+    it("deselects all rows on current page when onSelectAll(false) is called", async () => {
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select All")); // select first
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).toContain("REQ-001"),
+      );
+      fireEvent.click(getByText("Deselect All")); // then deselect
+      await waitFor(() =>
+        expect(lastAdminDashboardProps?.selectedRows).not.toContain("REQ-001"),
+      );
+    });
+
+    it("shows bulk action UI with selected count when rows are selected on myRequests tab", async () => {
+      const { getByText, queryByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+      expect(queryByText("1 selected")).not.toBeInTheDocument();
+
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row"));
+      await waitFor(() => expect(getByText("1 selected")).toBeInTheDocument());
+    });
+
+    it("shows warning toast when Apply is clicked (backend pending)", async () => {
+      const { toast } = require("react-toastify");
+
+      const { getByText, getAllByRole } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row"));
+      await waitFor(() => expect(getByText("1 selected")).toBeInTheDocument());
+
+      const selects = getAllByRole("combobox");
+      const statusSelect = selects[selects.length - 1];
+      fireEvent.change(statusSelect, { target: { value: "CANCELLED" } });
+
+      fireEvent.click(getByText("Apply"));
+
+      await waitFor(() => {
+        expect(toast.warn).toHaveBeenCalledWith(
+          expect.stringContaining("pending backend API support"),
+        );
+      });
+    });
+
+    it("clears selectedRows and resets bulk status after apply", async () => {
+      const { getByText, queryByText, getAllByRole } = renderWithProviders(
+        <Dashboard />,
+        { preloadedState: adminAuthState },
+      );
+
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row"));
+      await waitFor(() => expect(getByText("1 selected")).toBeInTheDocument());
+
+      const selects = getAllByRole("combobox");
+      const statusSelect = selects[selects.length - 1];
+      fireEvent.change(statusSelect, { target: { value: "CANCELLED" } });
+      fireEvent.click(getByText("Apply"));
+
+      await waitFor(() =>
+        expect(queryByText("1 selected")).not.toBeInTheDocument(),
+      );
+    });
+
+    it("does not trigger bulk change when no status is selected", async () => {
+      const { toast } = require("react-toastify");
+
+      const { getByText } = renderWithProviders(<Dashboard />, {
+        preloadedState: adminAuthState,
+      });
+
+      fireEvent.click(getByText("Click All Requests"));
+      await waitFor(() => expect(lastAdminDashboardProps).not.toBeNull());
+
+      fireEvent.click(getByText("Select Row"));
+      await waitFor(() => expect(getByText("1 selected")).toBeInTheDocument());
+
+      // Apply button should be disabled when no status selected, but test handler guard
+      fireEvent.click(getByText("Apply"));
+      expect(toast.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/Dashboard/views/AdminDashboard.jsx
+++ b/src/pages/Dashboard/views/AdminDashboard.jsx
@@ -25,6 +25,9 @@ const AdminDashboard = (props) => {
     setAnalyticsSubtab,
     serverPaginated,
     serverTotalRows,
+    selectedRows,
+    onRowSelect,
+    onSelectAll,
   } = props;
 
   return (
@@ -135,6 +138,10 @@ const AdminDashboard = (props) => {
             getLinkPath={getLinkPath}
             getLinkState={getLinkState}
             serverPaginated={serverPaginated}
+            showCheckboxes={activeTab === "myRequests"}
+            selectedRows={selectedRows}
+            onRowSelect={onRowSelect}
+            onSelectAll={onSelectAll}
           />
         )}
       </div>
@@ -162,5 +169,8 @@ AdminDashboard.propTypes = {
   setAnalyticsSubtab: PropTypes.func.isRequired,
   serverPaginated: PropTypes.bool,
   serverTotalRows: PropTypes.number,
+  selectedRows: PropTypes.array,
+  onRowSelect: PropTypes.func,
+  onSelectAll: PropTypes.func,
 };
 export default AdminDashboard;

--- a/src/pages/Dashboard/views/SuperAdminDashboard.jsx
+++ b/src/pages/Dashboard/views/SuperAdminDashboard.jsx
@@ -25,6 +25,9 @@ const SuperAdminDashboard = (props) => {
     setAnalyticsSubtab,
     serverPaginated,
     serverTotalRows,
+    selectedRows,
+    onRowSelect,
+    onSelectAll,
   } = props;
 
   return (
@@ -135,6 +138,10 @@ const SuperAdminDashboard = (props) => {
             getLinkPath={getLinkPath}
             getLinkState={getLinkState}
             serverPaginated={serverPaginated}
+            showCheckboxes={activeTab === "myRequests"}
+            selectedRows={selectedRows}
+            onRowSelect={onRowSelect}
+            onSelectAll={onSelectAll}
           />
         )}
       </div>
@@ -162,6 +169,9 @@ SuperAdminDashboard.propTypes = {
   setAnalyticsSubtab: PropTypes.func,
   serverPaginated: PropTypes.bool,
   serverTotalRows: PropTypes.number,
+  selectedRows: PropTypes.array,
+  onRowSelect: PropTypes.func,
+  onSelectAll: PropTypes.func,
 };
 
 export default SuperAdminDashboard;


### PR DESCRIPTION
### What was done (Frontend)

- Added row selection checkboxes on the "All Requests" tab for Admin and
  SuperAdmin dashboards
- Checkboxes appear on the left side of each row with a "select all"
  checkbox in the header
- Selections persist across search/filter and clear on tab/dashboard change
- Added bulk action UI (right-aligned with filters row) that appears when
  rows are selected, containing:
  - Selected count badge
  - "Change Status" dropdown with all available status options
  - "Apply" button to trigger bulk status update
- Uses `Promise.allSettled` for partial failure handling with
  success/warning/error toast notifications

<img width="1113" height="613" alt="Screenshot 2026-07-18 at 11 42 38 PM" src="https://github.com/user-attachments/assets/6d341398-cb58-458a-86cf-9ee4da191c22" />

<img width="1112" height="608" alt="Screenshot 2026-07-18 at 11 42 58 PM" src="https://github.com/user-attachments/assets/3bf8e67e-da09-4f5f-a456-4cf285dd4540" />


### Files modified

- [src/common/components/DataTable/Table.jsx](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/common/components/DataTable/Table.jsx:0:0-0:0) — checkbox column support
- [src/pages/Dashboard/Dashboard.jsx](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/pages/Dashboard/Dashboard.jsx:0:0-0:0) — selection state, bulk action
  handler, and action UI in filters row
- `src/pages/Dashboard/views/AdminDashboard.jsx` — forward checkbox props
- `src/pages/Dashboard/views/SuperAdminDashboard.jsx` — forward checkbox props

### ⚠️ Backend dependency (Action needed)

The bulk status change UI is fully functional on the frontend, but the
existing `PUT v1/request/updateHelpRequest` endpoint returns 500 when
called with row data + a new `requestStatus` value.

<img width="1512" height="752" alt="Screenshot 2026-07-18 at 11 45 21 PM" src="https://github.com/user-attachments/assets/746efb3e-e7d9-4559-8b2a-7069b01f97ab" />



The backend team needs to do one of the following:

**Option A (Preferred):** Create a new endpoint for admin bulk status updates:
  - `PUT /v1/request/admin/bulkUpdateStatus`
  - Request body: `{ requestIds: ["REQ-00-..."], requestStatus: "CANCELLED" }`
  - Should validate admin/superadmin permissions and update all matching requests

**Option B:** Modify the existing `updateHelpRequest` endpoint to:
  - Support partial/status-only updates with just `{ requestId, requestStatus }`
  - Allow admin/superadmin authorization to update any request's status

Once the backend endpoint is available, update [handleBulkStatusChange](cci:1://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/pages/Dashboard/Dashboard.jsx:117:2-192:4) in
[Dashboard.jsx](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/pages/Dashboard/Dashboard.jsx:0:0-0:0) (see the TODO comment) with the correct API call.