### PR TITLE
feat: convert KPI Trends time-range selector from dropdown to button row

### DIFF
--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
@@ -207,19 +207,30 @@ const KPIAnalytics = () => {
           </select>
 
           {viewMode === "trends" && (
-            <select
-              value={timeRange}
-              onChange={(e) => setTimeRange(e.target.value)}
-              className="px-2 py-0.5 text-xs border border-gray-300 rounded bg-white"
-            >
-              <option value="7D">7D</option>
-              <option value="30D">30D</option>
-              <option value="1Y">1Y</option>
-              <option value="All">All</option>
-              <option value="Custom" disabled>
-                Custom (coming soon)
-              </option>
-            </select>
+            <div className="flex gap-1">
+              {["7D", "30D", "1Y", "All"].map((range) => (
+                <button
+                  key={range}
+                  type="button"
+                  onClick={() => setTimeRange(range)}
+                  className={`px-3 py-1 text-xs rounded ${
+                    timeRange === range
+                      ? "bg-blue-600 text-white"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  }`}
+                >
+                  {range}
+                </button>
+              ))}
+              <button
+                type="button"
+                disabled
+                title="Custom range coming soon"
+                className="px-3 py-1 text-xs rounded bg-gray-50 text-gray-400 cursor-not-allowed"
+              >
+                Custom
+              </button>
+            </div>
           )}
 
           {selectedSegment && (

--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
@@ -272,14 +272,16 @@ describe("KPIAnalytics", () => {
   });
 
   describe("Trends view", () => {
-    it("switches to trends view and shows a time range selector defaulting to All", async () => {
+    it("switches to trends view and shows time range buttons defaulting to All", async () => {
       analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
       render(<KPIAnalytics />);
       await waitFor(() => {
         expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
       });
       switchViewMode("trends");
-      expect(screen.getByDisplayValue("All")).toBeInTheDocument();
+      const allButton = screen.getByRole("button", { name: "All" });
+      expect(allButton).toBeInTheDocument();
+      expect(allButton).toHaveClass("bg-blue-600");
     });
 
     it("shows no trend data message for All since it has no period series", async () => {
@@ -301,9 +303,7 @@ describe("KPIAnalytics", () => {
         expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
       });
       switchViewMode("trends");
-      fireEvent.change(screen.getByDisplayValue("All"), {
-        target: { value: "7D" },
-      });
+      fireEvent.click(screen.getByRole("button", { name: "7D" }));
       expect(
         screen.queryByText("No trend data available for 7D"),
       ).not.toBeInTheDocument();
@@ -316,23 +316,21 @@ describe("KPIAnalytics", () => {
         expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
       });
       switchViewMode("trends");
-      fireEvent.change(screen.getByDisplayValue("All"), {
-        target: { value: "1Y" },
-      });
+      fireEvent.click(screen.getByRole("button", { name: "1Y" }));
       expect(
         screen.queryByText("No trend data available for 1Y"),
       ).not.toBeInTheDocument();
     });
 
-    it("does not fetch trend data for Custom (option is disabled)", async () => {
+    it("keeps the Custom button disabled", async () => {
       analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
       render(<KPIAnalytics />);
       await waitFor(() => {
         expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
       });
       switchViewMode("trends");
-      const customOption = screen.getByText("Custom (coming soon)");
-      expect(customOption).toBeDisabled();
+      const customButton = screen.getByRole("button", { name: "Custom" });
+      expect(customButton).toBeDisabled();
     });
   });
 });


### PR DESCRIPTION
## Summary
Converts the 7D/30D/1Y/All/Custom time-range selector under KPI
Analytics → Trends from a dropdown to a button row, matching the
style already used on the Requests and Beneficiaries Analytics tabs.

## Changes
- 'KPIAnalytics.jsx': replaced the '<select>' with a row of buttons active range is highlighted blue, others gray; Custom stays visibly disabled (backend still finalizing date-range granularity for Custom)
- Updated 'KPIAnalytics.test.jsx' Trends tests to click buttons
  instead of changing a select value

## Note on "All"
-the "All" bucket only returns a single aggregate 'total_requests' number, not a per-period series like 7D/30D/1Y have.
So Trends → All correctly shows an empty state ("No trend data available for All"), this is a data limitation, not a bug.

## Testing
- Manually verified 7D, 30D, 1Y, and All all render correctly with the new button UI in local dev
- All 26 tests in KPIAnalytics.test.jsx passing