### PR TITLE
fix: internationalize dashboard names (#1649)

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -18,7 +18,6 @@ import {
   getDefaultDashboard,
   canAccessDashboard,
   validateDashboardAccess,
-  getDashboardDisplayName,
   DASHBOARDS,
 } from "../../utils/rbac";
 
@@ -38,6 +37,14 @@ import {
   normalizePriorityValue,
 } from "../../utils/filterHelpers";
 import "./Dashboard.css";
+
+const DASHBOARD_TRANSLATION_KEYS = {
+  [DASHBOARDS.BENEFICIARY]: "BENEFICIARY_DASHBOARD",
+  [DASHBOARDS.VOLUNTEER]: "VOLUNTEER_DASHBOARD",
+  [DASHBOARDS.STEWARD]: "STEWARD_DASHBOARD",
+  [DASHBOARDS.ADMIN]: "ADMIN_DASHBOARD",
+  [DASHBOARDS.SUPER_ADMIN]: "SUPER_ADMIN_DASHBOARD",
+};
 
 const Dashboard = ({ userRole }) => {
   const { t } = useTranslation();
@@ -1125,9 +1132,9 @@ const Dashboard = ({ userRole }) => {
 
   const [showAddressMsg, setShowAddressMsg] = useState(false);
 
-  const dashboardTitle = selectedDashboard
-    ? getDashboardDisplayName(selectedDashboard)
-    : "Dashboard";
+  const dashboardTitle = t(
+    DASHBOARD_TRANSLATION_KEYS[selectedDashboard] || "DASHBOARD",
+  );
 
   const dashboardDefaultTab = {
     [DASHBOARDS.SUPER_ADMIN]: "analytics",
@@ -1486,7 +1493,7 @@ const Dashboard = ({ userRole }) => {
               >
                 {accessibleDashboards.map((dash) => (
                   <option key={dash} value={dash}>
-                    {getDashboardDisplayName(dash)}
+                    {t(DASHBOARD_TRANSLATION_KEYS[dash] || "DASHBOARD")}
                   </option>
                 ))}
               </select>

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, MOCK_STATE_LOGGED_IN } from "#utils/test-utils";
 
 jest.mock("react-router-dom", () => {
@@ -11,12 +11,40 @@ jest.mock("react-router-dom", () => {
   };
 });
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key) => key,
-    i18n: { changeLanguage: jest.fn() },
-  }),
-}));
+jest.mock("react-i18next", () => {
+  const React = require("react");
+  const listeners = new Set();
+  const translations = {
+    en: require("../../common/i18n/locales/en/common.json"),
+    es: require("../../common/i18n/locales/es/common.json"),
+  };
+  const mockI18n = {
+    language: "en",
+    changeLanguage: jest.fn((language) => {
+      mockI18n.language = language;
+      listeners.forEach((listener) => listener());
+      return Promise.resolve();
+    }),
+  };
+
+  return {
+    useTranslation: () => {
+      const [, rerender] = React.useReducer((count) => count + 1, 0);
+
+      React.useEffect(() => {
+        listeners.add(rerender);
+        return () => listeners.delete(rerender);
+      }, []);
+
+      return {
+        t: (key) =>
+          translations[mockI18n.language]?.[key] ?? translations.en[key] ?? key,
+        i18n: mockI18n,
+      };
+    },
+    mockI18n,
+  };
+});
 
 jest.mock("react-toastify", () => ({
   ToastContainer: () => null,
@@ -89,6 +117,7 @@ jest.mock("./components/Analytics/RequestsAnalytics", () => () => null);
 jest.mock("./components/Analytics/VolunteerAnalytics", () => () => null);
 
 import Dashboard from "./Dashboard";
+import { mockI18n } from "react-i18next";
 
 const adminAuthState = {
   auth: {
@@ -123,9 +152,22 @@ const volunteerAuthState = {
   },
 };
 
+const superAdminAuthState = {
+  auth: {
+    user: {
+      userId: "u1",
+      userDbId: "SID-00-000-003-016",
+      groups: ["SuperAdmins"],
+    },
+    idToken: "tok",
+  },
+};
+
 describe("Dashboard", () => {
   beforeEach(() => {
     localStorage.clear();
+    mockI18n.language = "en";
+    mockI18n.changeLanguage.mockClear();
     lastAdminDashboardProps = null;
     lastBeneficiaryDashboardProps = null;
     lastVolunteerDashboardProps = null;
@@ -138,6 +180,99 @@ describe("Dashboard", () => {
       },
     });
     expect(getByTestId("beneficiary-dashboard")).toBeInTheDocument();
+  });
+
+  it("translates the dashboard title and every selector label without changing option values", () => {
+    localStorage.setItem("environment", JSON.stringify("dev"));
+    const { getByRole } = renderWithProviders(<Dashboard />, {
+      preloadedState: superAdminAuthState,
+    });
+
+    expect(
+      getByRole("heading", { name: "Super Admin Dashboard" }),
+    ).toBeInTheDocument();
+
+    const options = Array.from(getByRole("combobox").options).map((option) => ({
+      label: option.textContent,
+      value: option.value,
+    }));
+    expect(options).toEqual([
+      { label: "Beneficiary Dashboard", value: "beneficiary" },
+      { label: "Volunteer Dashboard", value: "volunteer" },
+      { label: "Steward Dashboard", value: "steward" },
+      { label: "Admin Dashboard", value: "admin" },
+      { label: "Super Admin Dashboard", value: "superAdmin" },
+    ]);
+  });
+
+  it("updates the title and selector labels when the language changes", async () => {
+    localStorage.setItem("environment", JSON.stringify("dev"));
+    const { getByRole } = renderWithProviders(<Dashboard />, {
+      preloadedState: superAdminAuthState,
+    });
+
+    await act(async () => {
+      await mockI18n.changeLanguage("es");
+    });
+
+    expect(
+      getByRole("heading", { name: "Panel de Superadministrador" }),
+    ).toBeInTheDocument();
+    expect(
+      Array.from(getByRole("combobox").options).map(
+        (option) => option.textContent,
+      ),
+    ).toEqual([
+      "Panel de Beneficiario",
+      "Panel de Voluntario",
+      "Panel de Supervisor",
+      "Panel de Administrador",
+      "Panel de Superadministrador",
+    ]);
+  });
+
+  it("falls back to English dashboard labels for an unsupported language", async () => {
+    localStorage.setItem("environment", JSON.stringify("dev"));
+    const { getByRole } = renderWithProviders(<Dashboard />, {
+      preloadedState: superAdminAuthState,
+    });
+
+    await act(async () => {
+      await mockI18n.changeLanguage("unsupported");
+    });
+
+    expect(
+      getByRole("heading", { name: "Super Admin Dashboard" }),
+    ).toBeInTheDocument();
+    expect(
+      Array.from(getByRole("combobox").options).map(
+        (option) => option.textContent,
+      ),
+    ).toEqual([
+      "Beneficiary Dashboard",
+      "Volunteer Dashboard",
+      "Steward Dashboard",
+      "Admin Dashboard",
+      "Super Admin Dashboard",
+    ]);
+  });
+
+  it("keeps the selected dashboard identifier stable when changing dashboards", () => {
+    localStorage.setItem("environment", JSON.stringify("dev"));
+    const { getByRole, getByTestId } = renderWithProviders(<Dashboard />, {
+      preloadedState: superAdminAuthState,
+    });
+
+    fireEvent.change(getByRole("combobox"), {
+      target: { value: "volunteer" },
+    });
+
+    expect(getByRole("combobox")).toHaveValue("volunteer");
+    expect(localStorage.getItem("lastDashboardSelected")).toBe("volunteer");
+    expect(getByTestId("volunteer-dashboard")).toBeInTheDocument();
+    expect(
+      getByRole("heading", { name: "Volunteer Dashboard" }),
+    ).toBeInTheDocument();
   });
 
   it("renders steward dashboard when user has steward role", () => {


### PR DESCRIPTION
## Description

Closes #1649

Internationalizes the dashboard names displayed in the Dashboard page title and the dashboard selector, using the existing common-namespace translations.

## Root cause

The Dashboard UI rendered names through `getDashboardDisplayName()`, which returns hardcoded English labels. The empty-selection fallback was also hardcoded as `Dashboard`.

## Changes

- Added a stable mapping from dashboard identifiers to existing translation keys
- Translated the current dashboard page title
- Translated every dashboard selector option label
- Translated the generic `DASHBOARD` fallback
- Preserved selector values, query parameters, localStorage values, API values, and RBAC behavior
- Preserved `getDashboardDisplayName()` for non-UI logic such as access-denied messages
- Added focused coverage for translated labels, stable identifiers, language switching, English fallback, and dashboard selection

No locale files or dependencies were changed because the required keys already exist in all 12 active languages.

## User impact

Dashboard names now update with the selected language while internal dashboard identifiers and authorization behavior remain unchanged.

## Testing

- `npm test -- --runInBand src/pages/Dashboard/Dashboard.test.jsx` — 28/28 passed
- `npm test -- --runInBand` — 72 suites / 802 tests passed
- `npm run build` — passed
- `npm run test:coverage -- --runInBand` — passed (54.2% statements overall)
- Prettier check — passed
- `git diff --check` — passed
- `npm run lint` — repository baseline currently fails with 603 errors and 33 warnings across unrelated existing files; this PR does not broaden scope to address them