### PR TITLE
fix(i18n): Title Case for 'Join the Community' CTA (#1690)

### DIFF
--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -291,7 +291,7 @@
   "JOIN_THE_COMMUNITY": "Join The Community",
   "JOIN_TODAY": "Experience the joy of assisting others – join Saayam For All today. Together, we can make a difference.",
   "JOIN_US": "Join us in our mission to make a difference. Whether you're looking to lend a helping hand or seeking assistance, Saayam For All is here for you. Together, let's create a more compassionate and equitable world for all.",
-  "Join the community": "Join the community",
+  "Join the community": "Join the Community",
   "LANDING_IMAGE_ALT_1": "Landing Image Alt 1",
   "LANDING_IMAGE_ALT_2": "Landing Image Alt 2",
   "LANGUAGE": "LANGUAGE",


### PR DESCRIPTION
Fixes #1690. The volunteer-section CTA is rendered in sentence case ("Join the community"), inconsistent with the platform's other multi-word CTAs (Contact Us, Get In Touch, Learn More). Changed the English i18n value only; the natural key and all 12 language translations are unchanged, so no translation regressions. Note: this key is shared with the About Us → Our Mission "Join the community" button, which now also reads Title Case (consistent with the issue's intent).

Tested: how-we-operate snapshot passes; translation is mocked in tests,
<img width="1461" height="794" alt="Screenshot 2026-07-20 at 11 47 34 PM" src="https://github.com/user-attachments/assets/ef433c54-1900-486d-b1e1-c696aae8749a" />
 so no value assertions are affected.