### PR TITLE
fix(ui): clip timeline dotted line and resolve card overlap (#1692)

### DIFF
--- a/src/pages/How We Operate/HowWeOperate.jsx
+++ b/src/pages/How We Operate/HowWeOperate.jsx
@@ -68,7 +68,7 @@ const HowWeOperate = () => {
             {t("Get help in 5 easy steps.")}
           </p>
 
-          <div className="relative h-full min-h-[800px]">
+          <div className="relative h-full min-h-[800px] overflow-hidden">
             {/* Animated line */}
             <div
               className="absolute left-1/2 top-32 md:top-32 lg:top-36 transform -translate-x-1/2 w-0.5 border-l-2 border-dashed border-blue-300 z-10"
@@ -187,7 +187,7 @@ const TimelineItem = ({ number, title, description, image, align }) => {
       {/* Text Content Container: takes 50% width on sm screens. Inner padding adjusts for step number. */}
       <div
         className={`w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 ${
-          isTextOnRight ? "sm:pl-0" : "sm:pr-0"
+          isTextOnRight ? "sm:pl-2" : "sm:pr-2"
         }`}
       >
         <div className="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center">

--- a/src/pages/How We Operate/__snapshots__/how-we-operate.test.js.snap
+++ b/src/pages/How We Operate/__snapshots__/how-we-operate.test.js.snap
@@ -27,7 +27,7 @@ exports[`HowWeOperate renders correctly 1`] = `
               mockTranslate(Get help in 5 easy steps.)
             </p>
             <div
-              class="relative h-full min-h-[800px]"
+              class="relative h-full min-h-[800px] overflow-hidden"
             >
               <div
                 class="absolute left-1/2 top-32 md:top-32 lg:top-36 transform -translate-x-1/2 w-0.5 border-l-2 border-dashed border-blue-300 z-10"
@@ -58,7 +58,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                   >
                     <div
                       class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -99,7 +99,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-0"
+                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-2"
                   >
                     <div
                       class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -140,7 +140,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                   >
                     <div
                       class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -181,7 +181,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-0"
+                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-2"
                   >
                     <div
                       class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -222,7 +222,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                    class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                   >
                     <div
                       class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -298,7 +298,7 @@ exports[`HowWeOperate renders correctly 1`] = `
             mockTranslate(Get help in 5 easy steps.)
           </p>
           <div
-            class="relative h-full min-h-[800px]"
+            class="relative h-full min-h-[800px] overflow-hidden"
           >
             <div
               class="absolute left-1/2 top-32 md:top-32 lg:top-36 transform -translate-x-1/2 w-0.5 border-l-2 border-dashed border-blue-300 z-10"
@@ -329,7 +329,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                 >
                   <div
                     class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -370,7 +370,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-0"
+                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-2"
                 >
                   <div
                     class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -411,7 +411,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                 >
                   <div
                     class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -452,7 +452,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-0"
+                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pl-2"
                 >
                   <div
                     class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"
@@ -493,7 +493,7 @@ exports[`HowWeOperate renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-0"
+                  class="w-full sm:w-1/2 flex items-stretch order-3 sm:order-none p-2 sm:pr-2"
                 >
                   <div
                     class="bg-blue-50 rounded-2xl p-6 sm:p-8 md:p-10 w-full flex flex-col justify-center"


### PR DESCRIPTION
## Summary
Fixes #1692. The vertical dotted step-indicator line on `/how-we-operate` overflowed the timeline section — spilling into the "Connecting help to those who need it." heading — and overlapped the right edge of the step-5 card.

## Changes
`src/pages/How We Operate/HowWeOperate.jsx`:
- Added `overflow-hidden` to the timeline container so the animated line is clipped to the section and can no longer extend into the heading below.
- Changed the text card's center-side padding (`sm:pl-0`/`sm:pr-0` → `sm:pl-2`/`sm:pr-2`) so cards no longer touch the centered dotted line (mirrors the clearance the image side already had).

Snapshot updated to reflect the className changes.

## Testing
- [x] `how-we-operate` snapshot regenerated; suite passes
- [x] Verified visually at desktop and mobile widths — line connects the step nodes without overlapping cards or the heading
- [x] Verified on the Netlify Deploy Preview
