### PR TITLE
Add steward view to volunteer review page

### DIFF
--- a/src/pages/Dashboard/views/StewardDashboard.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import Table from "../../../common/components/DataTable/Table";
 import LoadingIndicator from "../../../common/components/Loading/Loading";
-import { getMockVolunteersData } from "../../../services/volunteerServices";
+import { getVolunteersData } from "../../../services/volunteerServices";
 
 const StewardDashboard = (props) => {
   const [activeTab, setActiveTab] = useState("allRequests");
@@ -13,7 +13,7 @@ const StewardDashboard = (props) => {
       const fetchVolunteers = async () => {
         setIsVolunteerLoading(true);
         try {
-          const data = await getMockVolunteersData();
+          const data = await getVolunteersData();
           setVolunteerData(data);
         } catch (error) {
           console.error("Error fetching volunteers:", error);
@@ -38,6 +38,7 @@ const StewardDashboard = (props) => {
   };
 
   const volunteerRows = volunteerData.map((v) => ({
+    ...v,
     "User Id": v.userId,
     "Updated Time": v.updatedAt ? new Date(v.updatedAt).toLocaleString() : "",
     "Volunteering Request": "Review",
@@ -83,7 +84,7 @@ const StewardDashboard = (props) => {
           }`}
           onClick={() => setActiveTab("volunteers")}
         >
-          Volunteers
+          Needs Attention
         </button>
       </div>
 
@@ -138,7 +139,10 @@ const StewardDashboard = (props) => {
               requestSort={requestSort}
               onRowsPerPageChange={onRowsPerPageChange}
               getLinkPath={getVolunteerLinkPath}
-              getLinkState={(volunteer) => volunteer}
+              getLinkState={(volunteer) => ({
+                ...volunteer,
+                isStewardReview: true,
+              })}
             />
           )}
         </div>

--- a/src/pages/Dashboard/views/StewardDashboard.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Table from "../../../common/components/DataTable/Table";
 import LoadingIndicator from "../../../common/components/Loading/Loading";
 import { getVolunteersData } from "../../../services/volunteerServices";
@@ -9,40 +9,49 @@ const StewardDashboard = (props) => {
   const [isVolunteerLoading, setIsVolunteerLoading] = useState(false);
 
   useEffect(() => {
-    if (activeTab === "volunteers") {
-      const fetchVolunteers = async () => {
-        setIsVolunteerLoading(true);
-        try {
-          const data = await getVolunteersData();
-          setVolunteerData(data);
-        } catch (error) {
-          console.error("Error fetching volunteers:", error);
-        } finally {
-          setIsVolunteerLoading(false);
-        }
-      };
-      fetchVolunteers();
+    if (activeTab !== "volunteers") {
+      return;
     }
+
+    const fetchVolunteers = async () => {
+      setIsVolunteerLoading(true);
+
+      try {
+        const data = await getVolunteersData();
+        setVolunteerData(data || []);
+      } catch (error) {
+        console.error("Error fetching volunteers:", error);
+        setVolunteerData([]);
+      } finally {
+        setIsVolunteerLoading(false);
+      }
+    };
+
+    fetchVolunteers();
   }, [activeTab]);
 
   const volunteerHeaders = ["User Id", "Updated Time", "Volunteering Request"];
 
   const getVolunteerLinkPath = (volunteer, header) => {
     if (header === "User Id") {
-      return `/profile`;
+      return "/profile";
     }
+
     if (header === "Volunteering Request") {
-      return `/promote-to-volunteer?step=5`;
+      return "/promote-to-volunteer?step=5";
     }
+
     return null;
   };
 
-  const volunteerRows = volunteerData.map((v) => ({
-    ...v,
-    "User Id": v.userId,
-    "Updated Time": v.updatedAt ? new Date(v.updatedAt).toLocaleString() : "",
+  const volunteerRows = volunteerData.map((volunteer) => ({
+    ...volunteer,
+    "User Id": volunteer.userId,
+    "Updated Time": volunteer.updatedAt
+      ? new Date(volunteer.updatedAt).toLocaleString()
+      : "",
     "Volunteering Request": "Review",
-    volunteerRequestId: v.volunteerRequestId,
+    volunteerRequestId: volunteer.volunteerRequestId,
   }));
 
   const {
@@ -65,26 +74,29 @@ const StewardDashboard = (props) => {
 
   return (
     <div>
-      <div className="flex mb-5">
+      <div className="mb-5 flex">
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
+          type="button"
+          className={`flex-1 cursor-pointer border-b-2 py-3 text-center font-bold ${
             activeTab === "allRequests"
-              ? "bg-white text-blue-500 border-blue-500"
-              : "bg-gray-300 border-transparent hover:bg-gray-200"
+              ? "border-blue-500 bg-white text-blue-500"
+              : "border-transparent bg-gray-300 hover:bg-gray-200"
           }`}
           onClick={() => setActiveTab("allRequests")}
         >
           All Requests
         </button>
+
         <button
-          className={`flex-1 py-3 text-center cursor-pointer border-b-2 font-bold ${
+          type="button"
+          className={`flex-1 cursor-pointer border-b-2 py-3 text-center font-bold ${
             activeTab === "volunteers"
-              ? "bg-white text-blue-500 border-blue-500"
-              : "bg-gray-300 border-transparent hover:bg-gray-200"
+              ? "border-blue-500 bg-white text-blue-500"
+              : "border-transparent bg-gray-300 hover:bg-gray-200"
           }`}
           onClick={() => setActiveTab("volunteers")}
         >
-          Needs Attention
+          Volunteers
         </button>
       </div>
 
@@ -92,7 +104,7 @@ const StewardDashboard = (props) => {
         <>
           {searchFilters}
 
-          <div className="requests-section overflow-hidden table-height-fix">
+          <div className="requests-section table-height-fix overflow-hidden">
             {isLoading ? (
               <div className="flex justify-center py-10">
                 <LoadingIndicator size="50px" position="beside" />
@@ -121,7 +133,7 @@ const StewardDashboard = (props) => {
       )}
 
       {activeTab === "volunteers" && (
-        <div className="requests-section overflow-hidden table-height-fix">
+        <div className="requests-section table-height-fix overflow-hidden">
           {isVolunteerLoading ? (
             <div className="flex justify-center py-10">
               <LoadingIndicator size="50px" position="beside" />

--- a/src/pages/Dashboard/views/StewardDashboard.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.jsx
@@ -1,12 +1,31 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
+
 import Table from "../../../common/components/DataTable/Table";
 import LoadingIndicator from "../../../common/components/Loading/Loading";
-import { getVolunteersData } from "../../../services/volunteerServices";
+import { getMockVolunteersData } from "../../../services/volunteerServices";
 
 const StewardDashboard = (props) => {
   const [activeTab, setActiveTab] = useState("allRequests");
   const [volunteerData, setVolunteerData] = useState([]);
   const [isVolunteerLoading, setIsVolunteerLoading] = useState(false);
+
+  const {
+    headers,
+    filteredData,
+    isLoading,
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    rowsPerPage,
+    sortConfig,
+    requestSort,
+    onRowsPerPageChange,
+    getLinkPath,
+    getLinkState,
+    searchFilters,
+    serverPaginated,
+    serverTotalRows,
+  } = props;
 
   useEffect(() => {
     if (activeTab !== "volunteers") {
@@ -17,8 +36,10 @@ const StewardDashboard = (props) => {
       setIsVolunteerLoading(true);
 
       try {
-        const data = await getVolunteersData();
-        setVolunteerData(data || []);
+        // Keep the mock API for Issue #1656.
+        const data = await getMockVolunteersData();
+
+        setVolunteerData(Array.isArray(data) ? data : []);
       } catch (error) {
         console.error("Error fetching volunteers:", error);
         setVolunteerData([]);
@@ -46,31 +67,34 @@ const StewardDashboard = (props) => {
 
   const volunteerRows = volunteerData.map((volunteer) => ({
     ...volunteer,
+
     "User Id": volunteer.userId,
+
     "Updated Time": volunteer.updatedAt
       ? new Date(volunteer.updatedAt).toLocaleString()
       : "",
+
     "Volunteering Request": "Review",
+
     volunteerRequestId: volunteer.volunteerRequestId,
+
+    // This comes from the mock volunteer service.
+    phoneNumber:
+      volunteer.phoneNumber || volunteer.phone || volunteer.mobileNumber || "",
   }));
 
-  const {
-    headers,
-    filteredData,
-    isLoading,
-    currentPage,
-    setCurrentPage,
-    totalPages,
-    rowsPerPage,
-    sortConfig,
-    requestSort,
-    onRowsPerPageChange,
-    getLinkPath,
-    getLinkState,
-    searchFilters,
-    serverPaginated,
-    serverTotalRows,
-  } = props;
+  const getVolunteerLinkState = (volunteer) => ({
+    userId: volunteer.userId,
+    updatedAt: volunteer.updatedAt,
+    volunteerRequestId: volunteer.volunteerRequestId,
+    phoneNumber: volunteer.phoneNumber,
+    isStewardReview: true,
+  });
+
+  const volunteerTotalPages = Math.max(
+    1,
+    Math.ceil(volunteerRows.length / rowsPerPage),
+  );
 
   return (
     <div>
@@ -144,17 +168,15 @@ const StewardDashboard = (props) => {
               rows={volunteerRows}
               currentPage={currentPage}
               setCurrentPage={setCurrentPage}
-              totalPages={Math.ceil(volunteerRows.length / rowsPerPage)}
+              totalPages={volunteerTotalPages}
               totalRows={volunteerRows.length}
               itemsPerPage={rowsPerPage}
               sortConfig={sortConfig}
               requestSort={requestSort}
               onRowsPerPageChange={onRowsPerPageChange}
               getLinkPath={getVolunteerLinkPath}
-              getLinkState={(volunteer) => ({
-                ...volunteer,
-                isStewardReview: true,
-              })}
+              getLinkState={getVolunteerLinkState}
+              serverPaginated={false}
             />
           )}
         </div>

--- a/src/pages/Dashboard/views/StewardDashboard.test.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.test.jsx
@@ -1,12 +1,12 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+﻿import { fireEvent, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import StewardDashboard from "./StewardDashboard";
 import { renderWithProviders } from "#utils/test-utils.jsx";
-import { getVolunteersData } from "../../../services/volunteerServices";
+import { getMockVolunteersData } from "../../../services/volunteerServices";
 
 jest.mock("../../../services/volunteerServices", () => ({
-  getVolunteersData: jest.fn(),
+  getMockVolunteersData: jest.fn(),
 }));
 
 jest.mock("../../../common/components/Loading/Loading", () => {
@@ -87,18 +87,18 @@ describe("StewardDashboard Component", () => {
     expect(screen.getByText("Volunteers")).toBeInTheDocument();
     expect(screen.getByText("Search Filters")).toBeInTheDocument();
 
-    expect(getVolunteersData).not.toHaveBeenCalled();
+    expect(getMockVolunteersData).not.toHaveBeenCalled();
   });
 
   it("switches to Volunteers tab when clicked", async () => {
-    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
+    getMockVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
     fireEvent.click(screen.getByText("Volunteers"));
 
     await waitFor(() => {
-      expect(getVolunteersData).toHaveBeenCalledTimes(1);
+      expect(getMockVolunteersData).toHaveBeenCalledTimes(1);
     });
 
     expect(await screen.findByText("SID-00-000-000-001")).toBeInTheDocument();
@@ -108,7 +108,10 @@ describe("StewardDashboard Component", () => {
   });
 
   it("displays volunteer data correctly", async () => {
-    getVolunteersData.mockResolvedValue([mockVolunteerOne, mockVolunteerTwo]);
+    getMockVolunteersData.mockResolvedValue([
+      mockVolunteerOne,
+      mockVolunteerTwo,
+    ]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
@@ -124,7 +127,7 @@ describe("StewardDashboard Component", () => {
   it("handles API error gracefully", async () => {
     const apiError = new Error("API Error");
 
-    getVolunteersData.mockRejectedValue(apiError);
+    getMockVolunteersData.mockRejectedValue(apiError);
 
     const consoleSpy = jest
       .spyOn(console, "error")
@@ -151,13 +154,13 @@ describe("StewardDashboard Component", () => {
 
     expect(screen.queryByText("SID-00-000-000-001")).not.toBeInTheDocument();
 
-    expect(getVolunteersData).not.toHaveBeenCalled();
+    expect(getMockVolunteersData).not.toHaveBeenCalled();
   });
 
   it("renders loading indicator while volunteers data is fetching", async () => {
     let resolveVolunteers;
 
-    getVolunteersData.mockImplementation(
+    getMockVolunteersData.mockImplementation(
       () =>
         new Promise((resolve) => {
           resolveVolunteers = resolve;
@@ -188,7 +191,7 @@ describe("StewardDashboard Component", () => {
   });
 
   it("formats updated time correctly", async () => {
-    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
+    getMockVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
@@ -204,7 +207,7 @@ describe("StewardDashboard Component", () => {
   });
 
   it("returns correct link paths for volunteer table", async () => {
-    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
+    getMockVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 

--- a/src/pages/Dashboard/views/StewardDashboard.test.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.test.jsx
@@ -1,31 +1,78 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
 import StewardDashboard from "./StewardDashboard";
 import { renderWithProviders } from "#utils/test-utils.jsx";
+import { getVolunteersData } from "../../../services/volunteerServices";
 
 jest.mock("../../../services/volunteerServices", () => ({
-  getMockVolunteersData: jest.fn(),
+  getVolunteersData: jest.fn(),
 }));
-jest.mock("../../../common/components/Loading/Loading", () => () => (
-  <div data-testid="loading-indicator" />
-));
+
+jest.mock("../../../common/components/Loading/Loading", () => {
+  const MockLoadingIndicator = () => <div data-testid="loading-indicator" />;
+
+  MockLoadingIndicator.displayName = "MockLoadingIndicator";
+
+  return MockLoadingIndicator;
+});
 
 const mockProps = {
   headers: ["Request ID", "Status", "Date"],
   filteredData: [
-    { "Request ID": "REQ-001", Status: "Pending", Date: "2024-01-01" },
+    {
+      "Request ID": "REQ-001",
+      Status: "Pending",
+      Date: "2024-01-01",
+    },
   ],
   isLoading: false,
   currentPage: 1,
   setCurrentPage: jest.fn(),
   totalPages: jest.fn(() => 1),
   rowsPerPage: 10,
-  sortConfig: { key: null, direction: null },
+  sortConfig: {
+    key: null,
+    direction: null,
+  },
   requestSort: jest.fn(),
   onRowsPerPageChange: jest.fn(),
   getLinkPath: jest.fn(),
   getLinkState: jest.fn(),
   searchFilters: <div>Search Filters</div>,
+  serverPaginated: false,
+  serverTotalRows: 0,
+};
+
+const mockVolunteerOne = {
+  userId: "SID-00-000-000-001",
+  updatedAt: "2024-01-01T10:00:00Z",
+  volunteerRequestId: "req_123",
+};
+
+const mockVolunteerTwo = {
+  userId: "SID-00-000-000-002",
+  updatedAt: "2024-01-02T11:00:00Z",
+  volunteerRequestId: "req_456",
+};
+
+/**
+ * React Router Link may be rendered as:
+ * - a real <a href="..."> element, or
+ * - a mocked <mock-link to="..."> element.
+ *
+ * This helper supports both cases.
+ */
+const expectCorrectLinkDestination = (textElement, expectedPath) => {
+  const linkElement = textElement.closest("a, mock-link");
+
+  expect(linkElement).not.toBeNull();
+
+  if (linkElement.tagName.toLowerCase() === "a") {
+    expect(linkElement).toHaveAttribute("href", expectedPath);
+  } else {
+    expect(linkElement).toHaveAttribute("to", expectedPath);
+  }
 };
 
 describe("StewardDashboard Component", () => {
@@ -39,70 +86,45 @@ describe("StewardDashboard Component", () => {
     expect(screen.getByText("All Requests")).toBeInTheDocument();
     expect(screen.getByText("Volunteers")).toBeInTheDocument();
     expect(screen.getByText("Search Filters")).toBeInTheDocument();
+
+    expect(getVolunteersData).not.toHaveBeenCalled();
   });
 
   it("switches to Volunteers tab when clicked", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
-    getMockVolunteersData.mockResolvedValue([
-      {
-        userId: "SID-00-000-000-001",
-        updatedAt: "2024-01-01T10:00:00Z",
-        volunteerRequestId: "req_123",
-      },
-    ]);
+    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
-    fireEvent.click(volunteersTab);
+    fireEvent.click(screen.getByText("Volunteers"));
 
     await waitFor(() => {
-      expect(getMockVolunteersData).toHaveBeenCalled();
+      expect(getVolunteersData).toHaveBeenCalledTimes(1);
     });
 
-    expect(screen.getByText("SID-00-000-000-001")).toBeInTheDocument();
+    expect(await screen.findByText("SID-00-000-000-001")).toBeInTheDocument();
+
     expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.queryByText("Search Filters")).not.toBeInTheDocument();
   });
 
   it("displays volunteer data correctly", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
-    getMockVolunteersData.mockResolvedValue([
-      {
-        userId: "SID-00-000-000-001",
-        updatedAt: "2024-01-01T10:00:00Z",
-        volunteerRequestId: "req_123",
-      },
-      {
-        userId: "SID-00-000-000-002",
-        updatedAt: "2024-01-02T11:00:00Z",
-        volunteerRequestId: "req_456",
-      },
-    ]);
+    getVolunteersData.mockResolvedValue([mockVolunteerOne, mockVolunteerTwo]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
-    fireEvent.click(volunteersTab);
+    fireEvent.click(screen.getByText("Volunteers"));
 
-    await waitFor(() => {
-      expect(screen.getByText("SID-00-000-000-001")).toBeInTheDocument();
-      expect(screen.getByText("SID-00-000-000-002")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("SID-00-000-000-001")).toBeInTheDocument();
 
-    // Check that both Review links are present
-    const reviewLinks = screen.getAllByText("Review");
-    expect(reviewLinks).toHaveLength(2);
+    expect(screen.getByText("SID-00-000-000-002")).toBeInTheDocument();
+
+    expect(screen.getAllByText("Review")).toHaveLength(2);
   });
 
   it("handles API error gracefully", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
-    getMockVolunteersData.mockRejectedValue(new Error("API Error"));
+    const apiError = new Error("API Error");
+
+    getVolunteersData.mockRejectedValue(apiError);
 
     const consoleSpy = jest
       .spyOn(console, "error")
@@ -110,15 +132,16 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
-    fireEvent.click(volunteersTab);
+    fireEvent.click(screen.getByText("Volunteers"));
 
     await waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(
         "Error fetching volunteers:",
-        expect.any(Error),
+        apiError,
       );
     });
+
+    expect(screen.queryByText("SID-00-000-000-001")).not.toBeInTheDocument();
 
     consoleSpy.mockRestore();
   });
@@ -126,16 +149,15 @@ describe("StewardDashboard Component", () => {
   it("shows loading state initially", () => {
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    // Initially, volunteers tab should not show table until clicked
     expect(screen.queryByText("SID-00-000-000-001")).not.toBeInTheDocument();
+
+    expect(getVolunteersData).not.toHaveBeenCalled();
   });
 
   it("renders loading indicator while volunteers data is fetching", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
     let resolveVolunteers;
-    getMockVolunteersData.mockImplementation(
+
+    getVolunteersData.mockImplementation(
       () =>
         new Promise((resolve) => {
           resolveVolunteers = resolve;
@@ -143,76 +165,57 @@ describe("StewardDashboard Component", () => {
     );
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
+
     fireEvent.click(screen.getByText("Volunteers"));
 
-    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-    expect(screen.queryByTestId("mock-table")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+    });
 
-    resolveVolunteers([
-      {
-        userId: "SID-00-000-000-001",
-        updatedAt: "2024-01-01T10:00:00Z",
-        volunteerRequestId: "req_123",
-      },
-    ]);
+    resolveVolunteers([mockVolunteerOne]);
 
     await waitFor(() => {
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
-      expect(screen.getByText("SID-00-000-000-001")).toBeInTheDocument();
     });
+
+    expect(await screen.findByText("SID-00-000-000-001")).toBeInTheDocument();
   });
 
   it("renders loading indicator when isLoading is true on All Requests", () => {
     renderWithProviders(<StewardDashboard {...mockProps} isLoading={true} />);
+
     expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("formats updated time correctly", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
-    getMockVolunteersData.mockResolvedValue([
-      {
-        userId: "SID-00-000-000-001",
-        updatedAt: "2024-01-01T10:00:00Z",
-        volunteerRequestId: "req_123",
-      },
-    ]);
+    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
-    fireEvent.click(volunteersTab);
+    fireEvent.click(screen.getByText("Volunteers"));
 
-    await waitFor(() => {
-      // Should display formatted date
-      expect(screen.getByText(/1\/1\/2024/)).toBeInTheDocument();
-    });
+    await screen.findByText("SID-00-000-000-001");
+
+    const expectedFormattedDate = new Date(
+      mockVolunteerOne.updatedAt,
+    ).toLocaleString();
+
+    expect(screen.getByText(expectedFormattedDate)).toBeInTheDocument();
   });
 
   it("returns correct link paths for volunteer table", async () => {
-    const {
-      getMockVolunteersData,
-    } = require("../../../services/volunteerServices");
-    getMockVolunteersData.mockResolvedValue([
-      {
-        userId: "SID-00-000-000-001",
-        updatedAt: "2024-01-01T10:00:00Z",
-        volunteerRequestId: "req_123",
-      },
-    ]);
+    getVolunteersData.mockResolvedValue([mockVolunteerOne]);
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
-    fireEvent.click(volunteersTab);
+    fireEvent.click(screen.getByText("Volunteers"));
 
-    await waitFor(() => {
-      expect(screen.getByText("SID-00-000-000-001")).toBeInTheDocument();
-    });
+    const userId = await screen.findByText("SID-00-000-000-001");
 
-    // The component should have the correct link paths configured
-    // We can't easily test the actual links without more complex setup,
-    // but we can verify the data is rendered
+    const review = screen.getByText("Review");
+
+    expectCorrectLinkDestination(userId, "/profile");
+
+    expectCorrectLinkDestination(review, "/promote-to-volunteer?step=5");
   });
 });

--- a/src/pages/Profile/ApplicantProfile.jsx
+++ b/src/pages/Profile/ApplicantProfile.jsx
@@ -1,0 +1,80 @@
+import { Link, useLocation } from "react-router-dom";
+const ApplicantProfile = () => {
+  const location = useLocation();
+  const applicant = location.state?.applicant;
+
+  if (!applicant) {
+    return (
+      <div className="mx-auto my-10 max-w-xl px-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-6 text-center">
+          <p className="text-gray-600">Applicant information is unavailable.</p>
+
+          <Link
+            to="/dashboard?view=steward"
+            className="mt-5 inline-block rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Back to Steward Dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto my-10 max-w-2xl px-4">
+      <div className="rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="mb-6 text-center text-2xl font-bold">
+          {applicant.name || "Applicant Profile"}
+        </h1>
+
+        <div className="space-y-4">
+          <div>
+            <span className="font-semibold">Name: </span>
+            <span>{applicant.name || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Email: </span>
+            <span>{applicant.email || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Phone: </span>
+            <span>{applicant.phone || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Location: </span>
+            <span>{applicant.location || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Interested Cause: </span>
+            <span>{applicant.cause || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Rating: </span>
+            <span>{applicant.rating || "Not available"}</span>
+          </div>
+
+          <div>
+            <span className="font-semibold">Date Added: </span>
+            <span>{applicant.dateAdded || "Not available"}</span>
+          </div>
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link
+            to="/dashboard?view=steward"
+            className="inline-block rounded bg-blue-500 px-5 py-2 text-white hover:bg-blue-700"
+          >
+            Back to Steward Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicantProfile;

--- a/src/pages/Profile/ApplicantProfile.test.jsx
+++ b/src/pages/Profile/ApplicantProfile.test.jsx
@@ -1,0 +1,63 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import ApplicantProfile from "./ApplicantProfile";
+
+const mockUseLocation = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => mockUseLocation(),
+  Link: ({ to, children }) => <a href={to}>{children}</a>,
+}));
+
+describe("ApplicantProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("displays selected applicant information", () => {
+    mockUseLocation.mockReturnValue({
+      state: {
+        applicant: {
+          name: "Jane Cooper",
+          email: "jane@microsoft.com",
+          phone: "(225) 555-0118",
+          location: "Boston, USA",
+          cause: "Cooking",
+          rating: "★★★★★",
+          dateAdded: "2023-10-01",
+        },
+      },
+    });
+
+    render(<ApplicantProfile />);
+
+    expect(
+      screen.getByRole("heading", { name: "Jane Cooper" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("jane@microsoft.com")).toBeInTheDocument();
+    expect(screen.getByText("(225) 555-0118")).toBeInTheDocument();
+    expect(screen.getByText("Boston, USA")).toBeInTheDocument();
+    expect(screen.getByText("Cooking")).toBeInTheDocument();
+    expect(screen.getByText("★★★★★")).toBeInTheDocument();
+    expect(screen.getByText("2023-10-01")).toBeInTheDocument();
+  });
+
+  test("shows unavailable message when applicant data is missing", () => {
+    mockUseLocation.mockReturnValue({
+      state: null,
+    });
+
+    render(<ApplicantProfile />);
+
+    expect(
+      screen.getByText("Applicant information is unavailable."),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: "Back to Steward Dashboard",
+      }),
+    ).toHaveAttribute("href", "/dashboard?view=steward");
+  });
+});

--- a/src/pages/Volunteer/PromoteToVolunteer.jsx
+++ b/src/pages/Volunteer/PromoteToVolunteer.jsx
@@ -4,7 +4,7 @@ import StepperControl from "./StepperControl";
 import Availability from "./steps/Availability";
 import Review from "./steps/Review";
 import Skills from "./steps/Skills";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import TermsConditions from "./steps/TermsConditions";
 import VolunteerCourse from "./steps/VolunteerCourse";
 import {
@@ -50,9 +50,16 @@ const removeSessionStorageItem = (key) => {
 
 const PromoteToVolunteer = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
+
+  const applicant = location.state;
+  const isStewardReview = applicant?.isStewardReview === true;
   const stepParam = parseInt(searchParams.get("step")) || 1;
   const [currentStep, setCurrentStep] = useState(() => {
+    if (isStewardReview) {
+      return 5;
+    }
     const cachedStep = getSessionStorageItem("volunteer_wizard_step");
     return cachedStep ? parseInt(cachedStep, 10) : stepParam;
   });
@@ -100,9 +107,7 @@ const PromoteToVolunteer = () => {
         console.error("Failed to parse volunteer_form_data:", e);
       }
     }
-    return [
-      { id: 1, dayOfWeek: "Everyday", startTime: null, endTime: null },
-    ];
+    return [{ id: 1, dayOfWeek: "Everyday", startTime: null, endTime: null }];
   });
   const [tobeNotified, setNotification] = useState(() => {
     const cachedData = getSessionStorageItem("volunteer_form_data");
@@ -155,7 +160,14 @@ const PromoteToVolunteer = () => {
       };
       setSessionStorageItem("volunteer_form_data", JSON.stringify(formData));
     }
-  }, [isAcknowledged, isUploaded, selectedSkills, availabilitySlots, tobeNotified, currentStep]);
+  }, [
+    isAcknowledged,
+    isUploaded,
+    selectedSkills,
+    availabilitySlots,
+    tobeNotified,
+    currentStep,
+  ]);
 
   useEffect(() => {
     const fetchUserId = async () => {
@@ -229,13 +241,16 @@ const PromoteToVolunteer = () => {
             setNotification={setNotification}
           />
         );
+
       case 5:
-        return <Review />;
+        return (
+          <Review isStewardReview={isStewardReview} applicant={applicant} />
+        );
+
       default:
         return null;
     }
   };
-
   const isAvailabilityValid = useMemo(() => {
     if (!availabilitySlots || availabilitySlots.length === 0) return false;
     return availabilitySlots.some((slot) => {
@@ -327,7 +342,7 @@ const PromoteToVolunteer = () => {
         default:
           isValidStep = false;
       }
- 
+
       if (isValidStep) {
         setErrorMessage("");
         newStep++;
@@ -336,9 +351,7 @@ const PromoteToVolunteer = () => {
           removeSessionStorageItem("volunteer_form_data");
         }
       } else {
-        setErrorMessage(
-          t("COMPLETE_REQUIRED_FIELDS"),
-        );
+        setErrorMessage(t("COMPLETE_REQUIRED_FIELDS"));
       }
     } else if (direction === "prev") {
       newStep--;

--- a/src/pages/Volunteer/promote-to-volunteer.test.js
+++ b/src/pages/Volunteer/promote-to-volunteer.test.js
@@ -1,3 +1,4 @@
+import { MemoryRouter } from "react-router-dom";
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import PromoteToVolunteer from "./PromoteToVolunteer";
@@ -17,6 +18,7 @@ jest.mock("react-router-dom", () => ({
     return [params, jest.fn()];
   },
   useNavigate: () => jest.fn(),
+  useLocation: () => ({ state: null }),
 }));
 
 jest.mock("../../services/volunteerServices", () => ({
@@ -200,9 +202,7 @@ describe("PromoteToVolunteer Component", () => {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
 
-    expect(
-      screen.getByTestId("next-button"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeInTheDocument();
     expect(
       screen.getByText(/mockTranslate\(common:BACK\)/),
     ).toBeInTheDocument();
@@ -1035,9 +1035,7 @@ describe("PromoteToVolunteer Component", () => {
     });
 
     // Check StepperControl is present
-    expect(
-      screen.getByTestId("next-button"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeInTheDocument();
     expect(
       screen.getByText(/mockTranslate\(common:BACK\)/),
     ).toBeInTheDocument();
@@ -1549,68 +1547,80 @@ describe("PromoteToVolunteer Component", () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
- 
+
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
- 
+
     let nextButton = screen.getByTestId("next-button");
- 
+
     // Navigate through steps
     fireEvent.click(nextButton);
- 
+
     await waitFor(() => {
       expect(
         screen.getByText("mockTranslate(IDENTIFICATION)"),
       ).toBeInTheDocument();
     });
- 
+
     // Continue to other steps...
     nextButton = screen.getByTestId("next-button");
- 
+
     // Button should still be present on step 2
     expect(nextButton).toBeInTheDocument();
   });
- 
+
   it("covers VolunteerCourse custom file input interactions and size/type validation", async () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
- 
+
     // Step 1: Acknowledge terms
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
     let nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 2: Identification
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
- 
+
     const fileInput = document.querySelector('input[type="file"]');
     expect(fileInput).toBeInTheDocument();
- 
+
     // 1. Click choose file button to trigger proxy click
     const chooseButton = screen.getByText("mockTranslate(CHOOSE_FILE)");
-    const clickSpy = jest.spyOn(fileInput, "click").mockImplementation(() => {});
+    const clickSpy = jest
+      .spyOn(fileInput, "click")
+      .mockImplementation(() => {});
     fireEvent.click(chooseButton);
     expect(clickSpy).toHaveBeenCalled();
     clickSpy.mockRestore();
- 
+
     // 2. Select file that is too large (> 5MB)
-    const largeFile = new File(["a".repeat(6 * 1024 * 1024)], "large.png", { type: "image/png" });
+    const largeFile = new File(["a".repeat(6 * 1024 * 1024)], "large.png", {
+      type: "image/png",
+    });
     fireEvent.change(fileInput, { target: { files: [largeFile] } });
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(FILE_SIZE_ERROR)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(FILE_SIZE_ERROR)"),
+      ).toBeInTheDocument();
     });
- 
+
     // 3. Select invalid file type
-    const invalidFile = new File(["dummy"], "dummy.txt", { type: "text/plain" });
+    const invalidFile = new File(["dummy"], "dummy.txt", {
+      type: "text/plain",
+    });
     fireEvent.change(fileInput, { target: { files: [invalidFile] } });
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(FILE_TYPE_REQUIREMENT)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(FILE_TYPE_REQUIREMENT)"),
+      ).toBeInTheDocument();
     });
- 
+
     // 4. Select valid file
     const validFile = new File(["valid"], "valid.png", { type: "image/png" });
     fireEvent.change(fileInput, { target: { files: [validFile] } });
@@ -1618,84 +1628,98 @@ describe("PromoteToVolunteer Component", () => {
       expect(screen.getByText("valid.png")).toBeInTheDocument();
     });
   });
- 
+
   it("handles step 3 validation errors and API save failures", async () => {
     const { updateUserSkills } = require("../../services/volunteerServices");
     updateUserSkills.mockRejectedValueOnce(new Error("API Error"));
- 
+
     const mockCategories = [
       {
         catId: "1",
         catName: "TEACHING",
-        subCategories: []
-      }
+        subCategories: [],
+      },
     ];
     localStorage.setItem("categories", JSON.stringify(mockCategories));
- 
+
     const preloadedState = {
       auth: {
         user: {
           userId: "mockUser",
-          userDbId: "SID-123"
+          userDbId: "SID-123",
         },
-        idToken: "mockToken"
-      }
+        idToken: "mockToken",
+      },
     };
 
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState,
     });
- 
+
     // Step 1
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
     let nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 2: Upload file
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
     const fileInput = document.querySelector('input[type="file"]');
     const validFile = new File(["valid"], "valid.png", { type: "image/png" });
     fireEvent.change(fileInput, { target: { files: [validFile] } });
- 
+
     await waitFor(() => {
       expect(screen.getByText("valid.png")).toBeInTheDocument();
     });
- 
+
     nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 3: Skills
     await waitFor(() => {
       expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
     });
- 
+
     // Select skill "TEACHING" to enable the next button
-    const skillOptions = screen.getAllByText("mockTranslate(categories:REQUEST_CATEGORIES.TEACHING.LABEL)");
+    const skillOptions = screen.getAllByText(
+      "mockTranslate(categories:REQUEST_CATEGORIES.TEACHING.LABEL)",
+    );
     fireEvent.click(skillOptions[0]);
- 
+
     // Click next, API rejects, should show error
     nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)"),
+      ).toBeInTheDocument();
     });
   });
 
   it("restores step and form state from sessionStorage when loaded", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "3");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
     renderWithProviders(
       <MemoryRouter>
@@ -1703,7 +1727,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
@@ -1712,15 +1736,23 @@ describe("PromoteToVolunteer Component", () => {
   it("clears sessionStorage on step 5 (Review)", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "4");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
     renderWithProviders(
       <MemoryRouter>
@@ -1728,7 +1760,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(AVAILABILITY)")).toBeInTheDocument();
@@ -1753,7 +1785,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
     expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
   });
@@ -1761,14 +1793,14 @@ describe("PromoteToVolunteer Component", () => {
   it("Test Case 2: Writing to Session Data on Step Progression", async () => {
     const { MemoryRouter } = require("react-router-dom");
     const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
-    
+
     renderWithProviders(
       <MemoryRouter>
         <PromoteToVolunteer />
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     const checkbox = screen.getByRole("checkbox");
@@ -1778,7 +1810,9 @@ describe("PromoteToVolunteer Component", () => {
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
 
     expect(setItemSpy).toHaveBeenCalledWith("volunteer_wizard_step", "2");
@@ -1786,18 +1820,22 @@ describe("PromoteToVolunteer Component", () => {
   });
 
   it("handles sessionStorage get errors gracefully", () => {
-    const getItemSpy = jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock get error");
-      }
-      return null;
-    });
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock get error");
+        }
+        return null;
+      });
 
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
 
-    expect(screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)")).toBeInTheDocument();
+    expect(
+      screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)"),
+    ).toBeInTheDocument();
 
     getItemSpy.mockRestore();
   });
@@ -1805,26 +1843,38 @@ describe("PromoteToVolunteer Component", () => {
   it("handles sessionStorage set and remove errors gracefully", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "4");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
-    const setItemSpy = jest.spyOn(Storage.prototype, "setItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock set error");
-      }
-    });
-    const removeItemSpy = jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock remove error");
-      }
-    });
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock set error");
+        }
+      });
+    const removeItemSpy = jest
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock remove error");
+        }
+      });
 
     renderWithProviders(
       <MemoryRouter>
@@ -1832,7 +1882,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(AVAILABILITY)")).toBeInTheDocument();
@@ -1853,7 +1903,9 @@ describe("PromoteToVolunteer Component", () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
-    expect(screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)")).toBeInTheDocument();
+    expect(
+      screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)"),
+    ).toBeInTheDocument();
   });
 
   it("handles out of bounds steps and default branches gracefully", async () => {
@@ -1865,14 +1917,16 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     const nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -12,6 +12,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
     applicant?.fullName ||
     applicant?.name ||
     combinedName ||
+    applicant?.userId ||
     applicant?.["User Id"] ||
     "Applicant";
 
@@ -22,14 +23,31 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
     applicant?.phone ||
     "";
 
+  // WhatsApp requires the country code and digits only.
   const whatsappNumber = String(applicantPhone).replace(/\D/g, "");
+
+  const hasValidWhatsAppNumber = whatsappNumber.length >= 8;
+
+  const handleSendMessage = () => {
+    if (!hasValidWhatsAppNumber) {
+      return;
+    }
+
+    const message = encodeURIComponent(
+      `Hello ${applicantName}, we are contacting you regarding your Saayam For All volunteer application.`,
+    );
+
+    const whatsappUrl = `https://wa.me/${whatsappNumber}` + `?text=${message}`;
+
+    window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+  };
 
   return (
     <div className="container md:mt-6">
       <div className="flex flex-col items-center">
         <div className="text-yellow-500">
           <svg
-            className="w-24 h-24"
+            className="h-24 w-24"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -43,20 +61,21 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
           {t("IN_REVIEW")}
         </div>
 
-        <div className="mt-4 text-center text-gray-600 max-w-md px-4">
+        <div className="mt-4 max-w-md px-4 text-center text-gray-600">
           <p>{t("REVIEW_STATUS_MESSAGE")}</p>
+
           <p className="mt-2">{t("REVIEW_APPROVAL_MESSAGE")}</p>
         </div>
 
         {isStewardReview && applicant && (
           <div className="mt-8 w-full max-w-md px-4">
-            <div className="rounded-lg border border-gray-200 p-5">
+            <div className="rounded-lg border border-gray-200 p-5 shadow-sm">
               <div className="text-center">
                 <span className="text-gray-600">Applicant: </span>
 
                 <Link
-                  to="/applicant-profile"
-                  state={{ applicant }}
+                  to="/profile"
+                  state={applicant}
                   className="font-semibold text-blue-600 underline hover:text-blue-800"
                 >
                   {applicantName}
@@ -71,29 +90,37 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                   Promote
                 </button>
 
-                <button className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mx-auto mt-12">
+                <button
+                  type="button"
+                  className="rounded bg-red-600 px-5 py-2 text-white hover:bg-red-700"
+                >
                   Reject
                 </button>
 
-                {whatsappNumber ? (
-                  <a
-                    href={`https://wa.me/${whatsappNumber}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="rounded bg-green-500 px-5 py-2 text-center text-white hover:bg-green-600"
-                  >
-                    Send Message
-                  </a>
-                ) : (
-                  <button
-                    type="button"
-                    disabled
-                    className="cursor-not-allowed rounded bg-gray-300 px-5 py-2 text-gray-600"
-                  >
-                    Send Message
-                  </button>
-                )}
+                <button
+                  type="button"
+                  onClick={handleSendMessage}
+                  disabled={!hasValidWhatsAppNumber}
+                  title={
+                    hasValidWhatsAppNumber
+                      ? "Send WhatsApp message"
+                      : "Applicant phone number is unavailable"
+                  }
+                  className={`rounded px-5 py-2 text-center ${
+                    hasValidWhatsAppNumber
+                      ? "cursor-pointer bg-green-500 text-white hover:bg-green-600"
+                      : "cursor-not-allowed bg-gray-300 text-gray-600"
+                  }`}
+                >
+                  Send Message
+                </button>
               </div>
+
+              {!hasValidWhatsAppNumber && (
+                <p className="mt-3 text-center text-sm text-red-500">
+                  Phone number is unavailable for this applicant.
+                </p>
+              )}
             </div>
           </div>
         )}

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -74,7 +74,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                 <span className="text-gray-600">Applicant: </span>
 
                 <Link
-                  to="/profile"
+                  to="/applicantprofile"
                   state={applicant}
                   className="font-semibold text-blue-600 underline hover:text-blue-800"
                 >

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -28,26 +28,12 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
 
   const hasValidWhatsAppNumber = whatsappNumber.length >= 8;
 
-  const handleSendMessage = () => {
-    if (!hasValidWhatsAppNumber) {
-      return;
-    }
-
-    const message = encodeURIComponent(
-      `Hello ${applicantName}, we are contacting you regarding your Saayam For All volunteer application.`,
-    );
-
-    const whatsappUrl = `https://wa.me/${whatsappNumber}` + `?text=${message}`;
-
-    window.open(whatsappUrl, "_blank", "noopener,noreferrer");
-  };
-
   return (
     <div className="container md:mt-6">
       <div className="flex flex-col items-center">
         <div className="text-yellow-500">
           <svg
-            className="h-24 w-24"
+            className="w-24 h-24"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -61,7 +47,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
           {t("IN_REVIEW")}
         </div>
 
-        <div className="mt-4 max-w-md px-4 text-center text-gray-600">
+        <div className="mt-4 text-center text-gray-600 max-w-md px-4">
           <p>{t("REVIEW_STATUS_MESSAGE")}</p>
 
           <p className="mt-2">{t("REVIEW_APPROVAL_MESSAGE")}</p>
@@ -74,8 +60,8 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                 <span className="text-gray-600">Applicant: </span>
 
                 <Link
-                  to="/applicantprofile"
-                  state={applicant}
+                  to="/applicant-profile"
+                  state={{ applicant }}
                   className="font-semibold text-blue-600 underline hover:text-blue-800"
                 >
                   {applicantName}
@@ -97,23 +83,25 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                   Reject
                 </button>
 
-                <button
-                  type="button"
-                  onClick={handleSendMessage}
-                  disabled={!hasValidWhatsAppNumber}
-                  title={
-                    hasValidWhatsAppNumber
-                      ? "Send WhatsApp message"
-                      : "Applicant phone number is unavailable"
-                  }
-                  className={`rounded px-5 py-2 text-center ${
-                    hasValidWhatsAppNumber
-                      ? "cursor-pointer bg-green-500 text-white hover:bg-green-600"
-                      : "cursor-not-allowed bg-gray-300 text-gray-600"
-                  }`}
-                >
-                  Send Message
-                </button>
+                {hasValidWhatsAppNumber ? (
+                  <a
+                    href={`https://wa.me/${whatsappNumber}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded bg-green-500 px-5 py-2 text-center text-white hover:bg-green-600"
+                  >
+                    Send Message
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    disabled
+                    title="Applicant phone number is unavailable"
+                    className="cursor-not-allowed rounded bg-gray-300 px-5 py-2 text-gray-600"
+                  >
+                    Send Message
+                  </button>
+                )}
               </div>
 
               {!hasValidWhatsAppNumber && (

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 const Review = ({ isStewardReview = false, applicant = null }) => {
   const { t } = useTranslation();
-  console.log("Applicant data in Review:", applicant);
+
   const combinedName = [applicant?.firstName, applicant?.lastName]
     .filter(Boolean)
     .join(" ");
@@ -14,8 +14,6 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
     combinedName ||
     applicant?.["User Id"] ||
     "Applicant";
-
-  const applicantUserId = applicant?.userId || applicant?.["User Id"] || "";
 
   const applicantPhone =
     applicant?.whatsappNumber ||
@@ -31,7 +29,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
       <div className="flex flex-col items-center">
         <div className="text-yellow-500">
           <svg
-            className="w-24 h-24"
+            className="h-24 w-24"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -40,18 +38,16 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
             <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z" />
           </svg>
         </div>
+
         <div className="mt-3 text-xl font-semibold uppercase text-yellow-600">
           {t("IN_REVIEW")}
         </div>
-        <div className="mt-4 text-center text-gray-600 max-w-md px-4">
+
+        <div className="mt-4 max-w-md px-4 text-center text-gray-600">
           <p>{t("REVIEW_STATUS_MESSAGE")}</p>
           <p className="mt-2">{t("REVIEW_APPROVAL_MESSAGE")}</p>
         </div>
-        {isStewardReview && (
-          <pre className="m-4 max-w-full overflow-auto border p-4 text-left text-xs">
-            {JSON.stringify(applicant, null, 2)}
-          </pre>
-        )}
+
         {isStewardReview && applicant && (
           <div className="mt-8 w-full max-w-md px-4">
             <div className="rounded-lg border border-gray-200 p-5">
@@ -59,11 +55,8 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                 <span className="text-gray-600">Applicant: </span>
 
                 <Link
-                  to="/profile"
-                  state={{
-                    ...applicant,
-                    userId: applicantUserId,
-                  }}
+                  to="/applicant-profile"
+                  state={{ applicant }}
                   className="font-semibold text-blue-600 underline hover:text-blue-800"
                 >
                   {applicantName}
@@ -107,8 +100,12 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
             </div>
           </div>
         )}
+
         <Link to="/dashboard">
-          <button className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mx-auto mt-12">
+          <button
+            type="button"
+            className="mx-auto mt-12 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-700"
+          >
             {t("CLOSE")}
           </button>
         </Link>

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -29,7 +29,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
       <div className="flex flex-col items-center">
         <div className="text-yellow-500">
           <svg
-            className="h-24 w-24"
+            className="w-24 h-24"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -43,7 +43,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
           {t("IN_REVIEW")}
         </div>
 
-        <div className="mt-4 max-w-md px-4 text-center text-gray-600">
+        <div className="mt-4 text-center text-gray-600 max-w-md px-4">
           <p>{t("REVIEW_STATUS_MESSAGE")}</p>
           <p className="mt-2">{t("REVIEW_APPROVAL_MESSAGE")}</p>
         </div>
@@ -71,10 +71,7 @@ const Review = ({ isStewardReview = false, applicant = null }) => {
                   Promote
                 </button>
 
-                <button
-                  type="button"
-                  className="rounded bg-red-600 px-5 py-2 text-white hover:bg-red-700"
-                >
+                <button className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mx-auto mt-12">
                   Reject
                 </button>
 

--- a/src/pages/Volunteer/steps/Review.jsx
+++ b/src/pages/Volunteer/steps/Review.jsx
@@ -1,8 +1,30 @@
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-const Review = () => {
+const Review = ({ isStewardReview = false, applicant = null }) => {
   const { t } = useTranslation();
+  console.log("Applicant data in Review:", applicant);
+  const combinedName = [applicant?.firstName, applicant?.lastName]
+    .filter(Boolean)
+    .join(" ");
+
+  const applicantName =
+    applicant?.fullName ||
+    applicant?.name ||
+    combinedName ||
+    applicant?.["User Id"] ||
+    "Applicant";
+
+  const applicantUserId = applicant?.userId || applicant?.["User Id"] || "";
+
+  const applicantPhone =
+    applicant?.whatsappNumber ||
+    applicant?.phoneNumber ||
+    applicant?.mobileNumber ||
+    applicant?.phone ||
+    "";
+
+  const whatsappNumber = String(applicantPhone).replace(/\D/g, "");
 
   return (
     <div className="container md:mt-6">
@@ -25,6 +47,66 @@ const Review = () => {
           <p>{t("REVIEW_STATUS_MESSAGE")}</p>
           <p className="mt-2">{t("REVIEW_APPROVAL_MESSAGE")}</p>
         </div>
+        {isStewardReview && (
+          <pre className="m-4 max-w-full overflow-auto border p-4 text-left text-xs">
+            {JSON.stringify(applicant, null, 2)}
+          </pre>
+        )}
+        {isStewardReview && applicant && (
+          <div className="mt-8 w-full max-w-md px-4">
+            <div className="rounded-lg border border-gray-200 p-5">
+              <div className="text-center">
+                <span className="text-gray-600">Applicant: </span>
+
+                <Link
+                  to="/profile"
+                  state={{
+                    ...applicant,
+                    userId: applicantUserId,
+                  }}
+                  className="font-semibold text-blue-600 underline hover:text-blue-800"
+                >
+                  {applicantName}
+                </Link>
+              </div>
+
+              <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  className="rounded bg-green-600 px-5 py-2 text-white hover:bg-green-700"
+                >
+                  Promote
+                </button>
+
+                <button
+                  type="button"
+                  className="rounded bg-red-600 px-5 py-2 text-white hover:bg-red-700"
+                >
+                  Reject
+                </button>
+
+                {whatsappNumber ? (
+                  <a
+                    href={`https://wa.me/${whatsappNumber}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded bg-green-500 px-5 py-2 text-center text-white hover:bg-green-600"
+                  >
+                    Send Message
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    disabled
+                    className="cursor-not-allowed rounded bg-gray-300 px-5 py-2 text-gray-600"
+                  >
+                    Send Message
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
         <Link to="/dashboard">
           <button className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mx-auto mt-12">
             {t("CLOSE")}

--- a/src/pages/Volunteer/steps/Review.steward.test.jsx
+++ b/src/pages/Volunteer/steps/Review.steward.test.jsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import Review from "./Review";
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ to, children }) => <a href={to}>{children}</a>,
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+describe("Review steward perspective", () => {
+  test("does not display steward controls in normal volunteer flow", () => {
+    render(<Review />);
+
+    expect(screen.queryByText("Applicant:")).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Promote" }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Reject" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("Send Message")).not.toBeInTheDocument();
+  });
+
+  test("displays applicant information and steward controls", () => {
+    const applicant = {
+      name: "Jane Cooper",
+      phone: "+1 (225) 555-0118",
+    };
+
+    render(<Review isStewardReview={true} applicant={applicant} />);
+
+    expect(screen.getByRole("link", { name: "Jane Cooper" })).toHaveAttribute(
+      "href",
+      "/applicant-profile",
+    );
+
+    expect(screen.getByRole("button", { name: "Promote" })).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: "Send Message" })).toHaveAttribute(
+      "href",
+      "https://wa.me/12255550118",
+    );
+  });
+
+  test("disables Send Message when phone number is unavailable", () => {
+    render(
+      <Review isStewardReview={true} applicant={{ name: "Jane Cooper" }} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Send Message" })).toBeDisabled();
+  });
+
+  test("uses first and last name when full name is unavailable", () => {
+    render(
+      <Review
+        isStewardReview={true}
+        applicant={{
+          firstName: "Jane",
+          lastName: "Cooper",
+          phone: "+12255550118",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Jane Cooper" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Volunteer/steps/__snapshots__/review.test.js.snap
+++ b/src/pages/Volunteer/steps/__snapshots__/review.test.js.snap
@@ -45,7 +45,8 @@ exports[`Review renders correctly 1`] = `
         to="/dashboard"
       >
         <button
-          class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mx-auto mt-12"
+          class="mx-auto mt-12 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-700"
+          type="button"
         >
           mockTranslate(CLOSE)
         </button>

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -16,6 +16,7 @@ import LandingPage from "../pages/LandingPage/LandingPage";
 import NewsOurStories from "../pages/NewsOurStories/NewsOurStories";
 import Notifications from "../pages/Notifications/Notifications";
 import Profile from "../pages/Profile/Profile";
+import ApplicantProfile from "../pages/Profile/ApplicantProfile";
 import OrganizationDetails from "../pages/RequestDetails/OrganizationDetails";
 import RequestDetails from "../pages/RequestDetails/RequestDetails";
 import VoluntaryOrganizations from "../pages/RequestDetails/VoluntaryOrganizations";
@@ -134,6 +135,11 @@ const routes = [
       {
         path: "profile",
         element: <Profile />,
+        handle: { leaveAdSpace: true },
+      },
+      {
+        path: "applicant-profile",
+        element: <ApplicantProfile />,
         handle: { leaveAdSpace: true },
       },
       {

--- a/src/services/volunteerServices.js
+++ b/src/services/volunteerServices.js
@@ -4,179 +4,106 @@ import { ACCEPTED_IMAGE_TYPES, fileToBase64 } from "../utils/fileToBase64";
 
 const MAX_PROFILE_IMAGE_SIZE = 5_000_000;
 
-// Temporary phone numbers used only with the mock volunteer endpoint.
-// Replace these with approved mock/test numbers when they are available.
-const MOCK_PHONE_NUMBERS = ["15551234567", "15557654321", "15559876543"];
-
-const extractVolunteerArray = (data) => {
-  if (Array.isArray(data?.body)) {
-    return data.body;
-  }
-
-  if (Array.isArray(data)) {
-    return data;
-  }
-
-  return [];
-};
-
 export const getVolunteerOrgsList = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_ORGS_LIST);
-
   return response.data;
 };
-
 export const getVolunteerSkills = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_SKILLS);
-
   return response.data;
 };
 
 /**
- * Fetch user skills by userId.
- *
- * @param {string} userId User database ID.
- * @returns {Promise<Object>} User skills response.
+ * Fetch user skills by userId
+ * @param {string} userId - The user's database ID (e.g., "SID-00-000-002-10000")
+ * @returns {Promise<Object>} - Returns { userId: string, skills: string[] }
  */
 export const fetchUserSkills = async (userId) => {
-  const response = await api.post(endpoints.PROFILE_SKILLS, {
-    userId,
-  });
-
+  const response = await api.post(endpoints.PROFILE_SKILLS, { userId });
   return response.data;
 };
 
 /**
- * Update all skills for a user.
- *
- * @param {string} userId User database ID.
- * @param {string[]} skills Skill IDs.
- * @returns {Promise<Object>} API response.
+ * Update user skills (replaces entire skills list)
+ * @param {string} userId - The user's database ID
+ * @param {string[]} skills - Array of skill IDs (e.g., ["0.0.0.0.0", "4.2"])
+ * @returns {Promise<Object>} - API response
  */
 export const updateUserSkills = async (userId, skills) => {
-  const response = await api.put(endpoints.PROFILE_SKILLS, {
-    userId,
-    skills,
-  });
-
+  const response = await api.put(endpoints.PROFILE_SKILLS, { userId, skills });
   return response.data;
 };
 
 /**
- * Delete user skills by sending the remaining skill list.
- *
- * @param {string} userId User database ID.
- * @param {string[]} skills Remaining skills.
- * @returns {Promise<Object>} API response.
+ * Delete user skills by sending empty list or updated list
+ * Internally uses update logic - skills not in list will be removed
+ * @param {string} userId - The user's database ID
+ * @param {string[]} skills - Remaining skills after deletion
+ * @returns {Promise<Object>} - API response
  */
 export const deleteUserSkills = async (userId, skills) => {
   const response = await api.delete(endpoints.PROFILE_SKILLS, {
-    data: {
-      userId,
-      skills,
-    },
+    data: { userId, skills },
   });
-
   return response.data;
 };
-
 export const createVolunteer = async (volunteerData) => {
   const response = await api.post(endpoints.CREATE_VOLUNTEER, volunteerData);
-
   return response.data;
 };
-
 export const updateVolunteer = async (volunteerData) => {
   const response = await api.put(endpoints.UPDATE_VOLUNTEER, volunteerData);
-
   return response.data;
 };
 
 export const getUserId = async (email) => {
   try {
-    const response = await api.post(endpoints.GET_USER_ID, {
-      email,
-    });
-
+    const response = await api.post(endpoints.GET_USER_ID, { email });
     return response.data;
   } catch (error) {
     const message =
       error?.response?.data?.message ||
       error?.message ||
       "Unknown error while fetching user ID";
-
     throw new Error(message);
   }
 };
 
-/**
- * Real volunteers API.
- *
- * Do not use this function for the Issue 1656 Steward tab.
- * The Steward tab must continue using getMockVolunteersData.
- */
 export const getVolunteersData = async () => {
-  const response = await api.get(endpoints.GET_VOLUNTEERS_DATA);
-
-  return extractVolunteerArray(response.data);
+  const { data } = await api.get(endpoints.GET_VOLUNTEERS_DATA);
+  return Array.isArray(data?.body)
+    ? data.body
+    : Array.isArray(data)
+      ? data
+      : [];
 };
 
-/**
- * Mock volunteers API used by the Steward Volunteers tab.
- *
- * The backend does not currently provide real volunteer data
- * for Issue 1656. Keep this mock endpoint call.
- *
- * Temporary phone numbers are added when the mock response
- * does not contain a phone number. This enables the steward
- * Send Message button for local testing.
- */
 export const getMockVolunteersData = async () => {
-  const response = await api.get(endpoints.MOCK_GET_VOLUNTEERS);
-
-  const volunteers = extractVolunteerArray(response.data);
-
-  return volunteers.map((volunteer, index) => ({
-    ...volunteer,
-
-    phoneNumber:
-      volunteer.phoneNumber ||
-      volunteer.phone ||
-      volunteer.mobileNumber ||
-      MOCK_PHONE_NUMBERS[index % MOCK_PHONE_NUMBERS.length],
-  }));
+  const { data } = await api.get(endpoints.MOCK_GET_VOLUNTEERS);
+  return Array.isArray(data?.body)
+    ? data.body
+    : Array.isArray(data)
+      ? data
+      : [];
 };
 
 /**
- * Upload profile image to S3 through the backend.
- *
- * @param {string} userId User database ID.
- * @param {File} file Profile image.
+ * Upload profile image to S3 via backend (Base64 in JSON).
+ * @param {string} userId - userDBId from Redux
+ * @param {File} file - Image file (jpeg/png only)
  * @returns {Promise<void>}
  */
 export const uploadProfileImage = async (userId, file) => {
-  if (!userId) {
-    throw new Error("User ID is required");
-  }
-
-  if (!file || !(file instanceof File)) {
-    throw new Error("Invalid file");
-  }
-
-  const normalizedFileType = (file.type || "").toLowerCase();
-
-  if (!ACCEPTED_IMAGE_TYPES.includes(normalizedFileType)) {
+  if (!userId) throw new Error("User ID is required");
+  if (!file || !(file instanceof File)) throw new Error("Invalid file");
+  if (!ACCEPTED_IMAGE_TYPES.includes((file.type || "").toLowerCase())) {
     throw new Error("Only JPG and PNG formats are accepted.");
   }
-
   if (file.size > MAX_PROFILE_IMAGE_SIZE) {
     throw new Error("File size must be 5 MB or less.");
   }
-
   const base64 = await fileToBase64(file);
-
   const contentType = file.type === "image/png" ? "image/png" : "image/jpeg";
-
   await api.post(endpoints.UPLOAD_PROFILE_IMAGE, {
     userId,
     contentType,
@@ -186,39 +113,27 @@ export const uploadProfileImage = async (userId, file) => {
 
 /**
  * Delete profile image.
- *
- * @param {string} userId User database ID.
+ * @param {string} userId - userDBId from Redux
  * @returns {Promise<void>}
  */
 export const deleteProfileImage = async (userId) => {
-  if (!userId) {
-    throw new Error("User ID is required");
-  }
-
+  if (!userId) throw new Error("User ID is required");
   await api.delete(endpoints.DELETE_PROFILE_IMAGE, {
-    data: {
-      userId,
-    },
+    data: { userId },
   });
 };
 
 /**
- * Fetch profile image as a Blob.
- *
- * @param {string} userId User database ID.
- * @returns {Promise<Blob|null>} Image Blob or null.
+ * Fetch profile image as Blob; caller should create object URL and revoke on cleanup.
+ * @param {string} userId - userDBId from Redux
+ * @returns {Promise<Blob|null>} - Blob or null if 404/no image
  */
 export const fetchProfileImage = async (userId) => {
-  if (!userId) {
-    throw new Error("User ID is required");
-  }
-
+  if (!userId) throw new Error("User ID is required");
   try {
     const response = await api.post(
       endpoints.VIEW_PROFILE_IMAGE,
-      {
-        userId,
-      },
+      { userId },
       {
         responseType: "blob",
         headers: {
@@ -226,31 +141,26 @@ export const fetchProfileImage = async (userId) => {
         },
       },
     );
-
     return response.data instanceof Blob ? response.data : null;
   } catch (error) {
-    if (error?.response?.status === 404) {
-      return null;
-    }
-
+    if (error?.response?.status === 404) return null;
     throw error;
   }
 };
 
 /**
- * Sign off a user from the database.
- *
- * @param {string} userId User database ID.
- * @param {string} reason Optional reason.
- * @returns {Promise<Object>} API response.
+ * Sign off (delete) user from the database
+ * @param {string} userId - The user's database ID (e.g., "SID-00-000-002-558")
+ * @param {string} reason - Optional reason for leaving
+ * @returns {Promise<Object>} - Returns { success: boolean, statusCode: number, message: string, data: { userId: string } }
  */
 export const signOffUser = async (userId, reason = "") => {
   const response = await api.request({
     method: "DELETE",
     url: endpoints.SIGN_OFF_USER,
     data: {
-      userId,
-      reason,
+      userId: userId,
+      reason: reason,
     },
     headers: {
       "Content-Type": "application/json",

--- a/src/services/volunteerServices.js
+++ b/src/services/volunteerServices.js
@@ -4,106 +4,179 @@ import { ACCEPTED_IMAGE_TYPES, fileToBase64 } from "../utils/fileToBase64";
 
 const MAX_PROFILE_IMAGE_SIZE = 5_000_000;
 
+// Temporary phone numbers used only with the mock volunteer endpoint.
+// Replace these with approved mock/test numbers when they are available.
+const MOCK_PHONE_NUMBERS = ["15551234567", "15557654321", "15559876543"];
+
+const extractVolunteerArray = (data) => {
+  if (Array.isArray(data?.body)) {
+    return data.body;
+  }
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  return [];
+};
+
 export const getVolunteerOrgsList = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_ORGS_LIST);
+
   return response.data;
 };
+
 export const getVolunteerSkills = async () => {
   const response = await api.get(endpoints.GET_VOLUNTEER_SKILLS);
+
   return response.data;
 };
 
 /**
- * Fetch user skills by userId
- * @param {string} userId - The user's database ID (e.g., "SID-00-000-002-10000")
- * @returns {Promise<Object>} - Returns { userId: string, skills: string[] }
+ * Fetch user skills by userId.
+ *
+ * @param {string} userId User database ID.
+ * @returns {Promise<Object>} User skills response.
  */
 export const fetchUserSkills = async (userId) => {
-  const response = await api.post(endpoints.PROFILE_SKILLS, { userId });
+  const response = await api.post(endpoints.PROFILE_SKILLS, {
+    userId,
+  });
+
   return response.data;
 };
 
 /**
- * Update user skills (replaces entire skills list)
- * @param {string} userId - The user's database ID
- * @param {string[]} skills - Array of skill IDs (e.g., ["0.0.0.0.0", "4.2"])
- * @returns {Promise<Object>} - API response
+ * Update all skills for a user.
+ *
+ * @param {string} userId User database ID.
+ * @param {string[]} skills Skill IDs.
+ * @returns {Promise<Object>} API response.
  */
 export const updateUserSkills = async (userId, skills) => {
-  const response = await api.put(endpoints.PROFILE_SKILLS, { userId, skills });
+  const response = await api.put(endpoints.PROFILE_SKILLS, {
+    userId,
+    skills,
+  });
+
   return response.data;
 };
 
 /**
- * Delete user skills by sending empty list or updated list
- * Internally uses update logic - skills not in list will be removed
- * @param {string} userId - The user's database ID
- * @param {string[]} skills - Remaining skills after deletion
- * @returns {Promise<Object>} - API response
+ * Delete user skills by sending the remaining skill list.
+ *
+ * @param {string} userId User database ID.
+ * @param {string[]} skills Remaining skills.
+ * @returns {Promise<Object>} API response.
  */
 export const deleteUserSkills = async (userId, skills) => {
   const response = await api.delete(endpoints.PROFILE_SKILLS, {
-    data: { userId, skills },
+    data: {
+      userId,
+      skills,
+    },
   });
+
   return response.data;
 };
+
 export const createVolunteer = async (volunteerData) => {
   const response = await api.post(endpoints.CREATE_VOLUNTEER, volunteerData);
+
   return response.data;
 };
+
 export const updateVolunteer = async (volunteerData) => {
   const response = await api.put(endpoints.UPDATE_VOLUNTEER, volunteerData);
+
   return response.data;
 };
 
 export const getUserId = async (email) => {
   try {
-    const response = await api.post(endpoints.GET_USER_ID, { email });
+    const response = await api.post(endpoints.GET_USER_ID, {
+      email,
+    });
+
     return response.data;
   } catch (error) {
     const message =
       error?.response?.data?.message ||
       error?.message ||
       "Unknown error while fetching user ID";
+
     throw new Error(message);
   }
 };
 
+/**
+ * Real volunteers API.
+ *
+ * Do not use this function for the Issue 1656 Steward tab.
+ * The Steward tab must continue using getMockVolunteersData.
+ */
 export const getVolunteersData = async () => {
-  const { data } = await api.get(endpoints.GET_VOLUNTEERS_DATA);
-  return Array.isArray(data?.body)
-    ? data.body
-    : Array.isArray(data)
-      ? data
-      : [];
-};
+  const response = await api.get(endpoints.GET_VOLUNTEERS_DATA);
 
-export const getMockVolunteersData = async () => {
-  const { data } = await api.get(endpoints.MOCK_GET_VOLUNTEERS);
-  return Array.isArray(data?.body)
-    ? data.body
-    : Array.isArray(data)
-      ? data
-      : [];
+  return extractVolunteerArray(response.data);
 };
 
 /**
- * Upload profile image to S3 via backend (Base64 in JSON).
- * @param {string} userId - userDBId from Redux
- * @param {File} file - Image file (jpeg/png only)
+ * Mock volunteers API used by the Steward Volunteers tab.
+ *
+ * The backend does not currently provide real volunteer data
+ * for Issue 1656. Keep this mock endpoint call.
+ *
+ * Temporary phone numbers are added when the mock response
+ * does not contain a phone number. This enables the steward
+ * Send Message button for local testing.
+ */
+export const getMockVolunteersData = async () => {
+  const response = await api.get(endpoints.MOCK_GET_VOLUNTEERS);
+
+  const volunteers = extractVolunteerArray(response.data);
+
+  return volunteers.map((volunteer, index) => ({
+    ...volunteer,
+
+    phoneNumber:
+      volunteer.phoneNumber ||
+      volunteer.phone ||
+      volunteer.mobileNumber ||
+      MOCK_PHONE_NUMBERS[index % MOCK_PHONE_NUMBERS.length],
+  }));
+};
+
+/**
+ * Upload profile image to S3 through the backend.
+ *
+ * @param {string} userId User database ID.
+ * @param {File} file Profile image.
  * @returns {Promise<void>}
  */
 export const uploadProfileImage = async (userId, file) => {
-  if (!userId) throw new Error("User ID is required");
-  if (!file || !(file instanceof File)) throw new Error("Invalid file");
-  if (!ACCEPTED_IMAGE_TYPES.includes((file.type || "").toLowerCase())) {
+  if (!userId) {
+    throw new Error("User ID is required");
+  }
+
+  if (!file || !(file instanceof File)) {
+    throw new Error("Invalid file");
+  }
+
+  const normalizedFileType = (file.type || "").toLowerCase();
+
+  if (!ACCEPTED_IMAGE_TYPES.includes(normalizedFileType)) {
     throw new Error("Only JPG and PNG formats are accepted.");
   }
+
   if (file.size > MAX_PROFILE_IMAGE_SIZE) {
     throw new Error("File size must be 5 MB or less.");
   }
+
   const base64 = await fileToBase64(file);
+
   const contentType = file.type === "image/png" ? "image/png" : "image/jpeg";
+
   await api.post(endpoints.UPLOAD_PROFILE_IMAGE, {
     userId,
     contentType,
@@ -113,27 +186,39 @@ export const uploadProfileImage = async (userId, file) => {
 
 /**
  * Delete profile image.
- * @param {string} userId - userDBId from Redux
+ *
+ * @param {string} userId User database ID.
  * @returns {Promise<void>}
  */
 export const deleteProfileImage = async (userId) => {
-  if (!userId) throw new Error("User ID is required");
+  if (!userId) {
+    throw new Error("User ID is required");
+  }
+
   await api.delete(endpoints.DELETE_PROFILE_IMAGE, {
-    data: { userId },
+    data: {
+      userId,
+    },
   });
 };
 
 /**
- * Fetch profile image as Blob; caller should create object URL and revoke on cleanup.
- * @param {string} userId - userDBId from Redux
- * @returns {Promise<Blob|null>} - Blob or null if 404/no image
+ * Fetch profile image as a Blob.
+ *
+ * @param {string} userId User database ID.
+ * @returns {Promise<Blob|null>} Image Blob or null.
  */
 export const fetchProfileImage = async (userId) => {
-  if (!userId) throw new Error("User ID is required");
+  if (!userId) {
+    throw new Error("User ID is required");
+  }
+
   try {
     const response = await api.post(
       endpoints.VIEW_PROFILE_IMAGE,
-      { userId },
+      {
+        userId,
+      },
       {
         responseType: "blob",
         headers: {
@@ -141,26 +226,31 @@ export const fetchProfileImage = async (userId) => {
         },
       },
     );
+
     return response.data instanceof Blob ? response.data : null;
   } catch (error) {
-    if (error?.response?.status === 404) return null;
+    if (error?.response?.status === 404) {
+      return null;
+    }
+
     throw error;
   }
 };
 
 /**
- * Sign off (delete) user from the database
- * @param {string} userId - The user's database ID (e.g., "SID-00-000-002-558")
- * @param {string} reason - Optional reason for leaving
- * @returns {Promise<Object>} - Returns { success: boolean, statusCode: number, message: string, data: { userId: string } }
+ * Sign off a user from the database.
+ *
+ * @param {string} userId User database ID.
+ * @param {string} reason Optional reason.
+ * @returns {Promise<Object>} API response.
  */
 export const signOffUser = async (userId, reason = "") => {
   const response = await api.request({
     method: "DELETE",
     url: endpoints.SIGN_OFF_USER,
     data: {
-      userId: userId,
-      reason: reason,
+      userId,
+      reason,
     },
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
Closes #1656

Changes:
- Shows steward-only review controls when Step 5 is opened from the Steward Dashboard
- Keeps the normal volunteer Step 5 UI unchanged
- Displays the applicant name
- Adds Promote, Reject, and WhatsApp Send Message controls
- Passes the selected applicant through router state

Current limitation:
- Applicant profile navigation is still being verified
- Promote and Reject currently require confirmation of the backend API and payload

Testing:
- Confirmed steward controls appear from Steward Dashboard → Volunteers → Review
- Confirmed normal volunteer Step 5 does not show steward controls