### PR TITLE
feat: convert KPI Trends time-range selector to buttons; separate Sna…

### DIFF
--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
@@ -84,8 +84,11 @@ const KPIAnalytics = () => {
   const SLA_TARGET = kpiData?.sla?.target_hours ?? 240;
   const SLA_WARNING = kpiData?.sla?.warning_hours ?? 200;
 
-  // Snapshot and Table view always read from the "All" bucket
-  const snapshotData = kpiData?.body?.All;
+  // Snapshot and Table view read from the dedicated "Snapshot" bucket
+  // (previously reused "All", but backend now separates them - per
+  // request from 7/19: "All" is now per-month trend data like "1Y",
+  // and "Snapshot" is the standalone aggregate).
+  const snapshotData = kpiData?.body?.Snapshot;
 
   const resolutionData = useMemo(() => {
     if (!snapshotData?.average_resolution_time_by_category) return [];

--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
@@ -9,7 +9,7 @@ jest.mock("../../../../services/analyticsServices", () => ({
 
 const mockData = {
   body: {
-    All: {
+    Snapshot: {
       request_status_distribution: [
         { status: "CREATED", count: 200 },
         { status: "MATCHING_VOLUNTEER", count: 100 },
@@ -42,6 +42,14 @@ const mockData = {
       total_requests: [
         { period: "2026-01", total_requests: 21 },
         { period: "2026-07", total_requests: 40 },
+      ],
+      average_resolution_time_by_category: [],
+    },
+    All: {
+      request_status_distribution: [],
+      total_requests: [
+        { period: "2025-12", total_requests: 48 },
+        { period: "2026-07", total_requests: 61 },
       ],
       average_resolution_time_by_category: [],
     },
@@ -106,7 +114,10 @@ describe("KPIAnalytics", () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue({
       body: {
         ...mockData.body,
-        All: { ...mockData.body.All, average_resolution_time_by_category: [] },
+        Snapshot: {
+          ...mockData.body.Snapshot,
+          average_resolution_time_by_category: [],
+        },
       },
     });
     render(<KPIAnalytics />);
@@ -206,8 +217,8 @@ describe("KPIAnalytics", () => {
     analyticsServices.getKpiAnalytics.mockResolvedValue({
       body: {
         ...mockData.body,
-        All: {
-          ...mockData.body.All,
+        Snapshot: {
+          ...mockData.body.Snapshot,
           total_requests: 0,
           request_status_distribution: [],
         },
@@ -284,7 +295,7 @@ describe("KPIAnalytics", () => {
       expect(allButton).toHaveClass("bg-blue-600");
     });
 
-    it("shows no trend data message for All since it has no period series", async () => {
+    it("renders the chart (not the empty state) when All has period data", async () => {
       analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
       render(<KPIAnalytics />);
       await waitFor(() => {
@@ -292,8 +303,8 @@ describe("KPIAnalytics", () => {
       });
       switchViewMode("trends");
       expect(
-        screen.getByText("No trend data available for All"),
-      ).toBeInTheDocument();
+        screen.queryByText("No trend data available for All"),
+      ).not.toBeInTheDocument();
     });
 
     it("renders the chart (not the empty state) when 7D has period data", async () => {


### PR DESCRIPTION
## Summary
Two changes to KPI Analytics:

1. Converted the Trends time-range selector from a dropdown to a
   button row (7D | 30D | 1Y | All | Custom), matching the styling
   used on the Requests and Beneficiaries tabs.
2. Backend now separates the aggregate "Snapshot" data from the "All"
   time range (which is now per-month trend data, like "1Y"). Updated
   Snapshot/Table view to read from body.Snapshot instead of body.All.

## Changes
- 'KPIAnalytics.jsx':
  - Time-range selector is now a button row instead of a '<select>'
  - 'snapshotData' reads from 'kpiData.body.Snapshot'
  - No change needed for Trends data flow - it already read generically
    from 'kpiData.body[timeRange].total_requests', so "All" now
    renders a real line chart automatically now that it has
    per-period data
- Updated mock data and 2 tests in `KPIAnalytics.test.jsx` for the new
  response shape

## Testing
- All 26 tests passing
- Manually verified in local dev against the live (updated) API:
  Snapshot shows correct total (454), Table view correct, Trends
  7D/30D/1Y/All all render with real data and working tooltips