### PR TITLE
fix: cancel pending debounced fetch on suggestion select (#1622)

### DIFF
--- a/src/pages/HelpRequest/location/usePlacesSearchBox.jsx
+++ b/src/pages/HelpRequest/location/usePlacesSearchBox.jsx
@@ -33,10 +33,11 @@ const usePlacesSearchBox = (setLocation, setCoordinates) => {
   }, []);
 
   const handleSelectSuggestion = (suggestion) => {
-    console.log("Suggestion coordinates:", {
-      latitude: parseFloat(suggestion.lat),
-      longitude: parseFloat(suggestion.lon),
-    });
+    // Cancel any pending debounced fetch so a stale response can't
+    // reopen the suggestions dropdown after the user has already made
+    // a selection.
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+
     setLocation(suggestion.display_name);
     if (setCoordinates) {
       setCoordinates({

--- a/src/pages/HelpRequest/location/usePlacesSearchBox.test.jsx
+++ b/src/pages/HelpRequest/location/usePlacesSearchBox.test.jsx
@@ -85,6 +85,39 @@ describe("usePlacesSearchBox", () => {
     expect(result.current.suggestions).toEqual([]);
   });
 
+  it("does not reopen suggestions from a stale pending fetch after a suggestion is selected", async () => {
+    const mockSuggestions = [{ display_name: "Kansas City, Missouri, USA" }];
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue(mockSuggestions),
+    });
+    const setLocation = jest.fn();
+    const { result } = renderHook(() => usePlacesSearchBox(setLocation));
+
+    // Start typing - this schedules a debounced fetch 500ms out
+    await act(async () => {
+      result.current.handleSearchChange("Kansas");
+    });
+
+    // User selects a suggestion immediately, before the debounce fires
+    act(() => {
+      result.current.handleSelectSuggestion({
+        display_name: "Kansas City, Missouri, USA",
+        lat: "39.0997",
+        lon: "-94.5786",
+      });
+    });
+
+    // Wait past the original debounce window - if the pending timer
+    // wasn't cancelled, its fetch would resolve here and reopen the
+    // suggestions list with stale results
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700));
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([]);
+  });
+
   it("handles fetch error gracefully", async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
 


### PR DESCRIPTION
Fixes the issue reported on #1622: the Other-person location
suggestions dropdown stayed open even after selecting a suggestion
and moving to other fields.

## Root cause
'handleSelectSuggestion' correctly cleared 'suggestions, but never cancelled any in-flight debounce timer. If a user clicked a suggestion right as the previously scheduled fetch was about to resolve, that stale fetch response would call 'setSuggestions(data)' after the click and silently reopen the dropdown.

## Fix
Cancel the pending debounce timer inside 'handleSelectSuggestion', matching what already happens at the start of 'handleSearchChange'. Also removed a leftover debug 'console.log'.

## Testing
- Added a regression test in 'usePlacesSearchBox.test.jsx' simulating the exact race condition (select a suggestion, then let the
  original debounced fetch resolve, confirm suggestions stay empty)
- All 7 'usePlacesSearchBox' tests and all 75 'HelpRequestForm' tests passing
- Manually reproduced the original bug and confirmed it no longer occurs, following the repro steps from the issue