### PR TITLE
feat: add Join Our Community CTA to Donate page

### DIFF
--- a/src/pages/Donate/Donate.jsx
+++ b/src/pages/Donate/Donate.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { JoinCTA } from "../About Us/OurMission/JoinCTA";
 import BenevityLogo from "../../assets/donate_buttons/Benevity_logo.svg";
 import CharityNavLogo from "../../assets/donate_buttons/CharityNav_Logo_Stack.png";
 import PayPalLogo from "../../assets/donate_buttons/PayPal.svg";
@@ -234,6 +235,7 @@ const Donate = () => {
           ))}
         </div>
       </div>
+      <JoinCTA />
     </div>
   );
 };

--- a/src/pages/Donate/__snapshots__/donate.test.js.snap
+++ b/src/pages/Donate/__snapshots__/donate.test.js.snap
@@ -157,6 +157,27 @@ exports[`Donate renders correctly 1`] = `
             </div>
           </div>
         </div>
+        <section
+          class="flex flex-col items-center justify-center py-16 bg-white text-center"
+        >
+          <h2
+            class="text-[24px] font-bold mb-1"
+          >
+            mockTranslate(Looking to join us?)
+          </h2>
+          <p
+            class="text-gray-600 text-sm leading-snug max-w-md mb-4"
+          >
+            mockTranslate(Chat with our community and get in touch with different charity)
+             
+            mockTranslate(organizations!)
+          </p>
+          <button
+            class="bg-[#00B2FF] text-white text-xs font-semibold px-5 py-2 rounded-full hover:bg-[#009ee0] transition"
+          >
+            mockTranslate(Join our community)
+          </button>
+        </section>
       </div>
     </div>
   </body>,
@@ -313,6 +334,27 @@ exports[`Donate renders correctly 1`] = `
           </div>
         </div>
       </div>
+      <section
+        class="flex flex-col items-center justify-center py-16 bg-white text-center"
+      >
+        <h2
+          class="text-[24px] font-bold mb-1"
+        >
+          mockTranslate(Looking to join us?)
+        </h2>
+        <p
+          class="text-gray-600 text-sm leading-snug max-w-md mb-4"
+        >
+          mockTranslate(Chat with our community and get in touch with different charity)
+           
+          mockTranslate(organizations!)
+        </p>
+        <button
+          class="bg-[#00B2FF] text-white text-xs font-semibold px-5 py-2 rounded-full hover:bg-[#009ee0] transition"
+        >
+          mockTranslate(Join our community)
+        </button>
+      </section>
     </div>
   </div>,
   "debug": [Function],


### PR DESCRIPTION
This PR adds the existing "Join Our Community" CTA below the FAQ section on the Donate page.
## Changes
- Reused the existing `JoinCTA` component
- Added the CTA below the Donate page FAQ section
- Preserved navigation to the login page
- Avoided duplicating existing CTA markup

## Testing

- Verified the Donate page renders correctly
- Verified the CTA redirects users to the login page
- Verified the production build succeeds

Related to #1707