### PR TITLE
Shorten matching volunteer status translations

### DIFF
--- a/src/common/i18n/locales/ar/common.json
+++ b/src/common/i18n/locales/ar/common.json
@@ -360,7 +360,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "مانافا سيفا مادهافا سيفا (نص بديل)",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "اقتباس مانافا سيفا مادهافا سيفا",
   "MATCHING_PROCESS": "عملية المطابقة : ",
-  "MATCHING_VOLUNTEER": "جاري مطابقة المتطوع",
+  "MATCHING_VOLUNTEER": "البحث عن متطوع",
   "MAX_CHARACTERS": "الحد الأقصى {{count}} حرفاً",
   "MAY_ALL_LIVE_HAPPILY": "نتمنى أن يعيش الجميع بسعادة",
   "MEDICAL_EMERGENCY": "حالة طبية طارئة",

--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -361,7 +361,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "মানব সেবায়ে মাধব সেবা Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "মানব সেবায়ে মাধব সেবা উদ্ধৃতি",
   "MATCHING_PROCESS": "ম্যাচিং প্রক্রিয়া : ",
-  "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক মিলানো হচ্ছে",
+  "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক খোঁজ",
   "MAX_CHARACTERS": "সর্বোচ্চ {{count}} অক্ষর",
   "MAY_ALL_LIVE_HAPPILY": "সকলে সুখে বাস করুক",
   "MEDICAL_EMERGENCY": "চিকিৎসা জরুরি অবস্থা",

--- a/src/common/i18n/locales/bn/enums.json
+++ b/src/common/i18n/locales/bn/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "তৈরি হয়েছে",
-    "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক খোঁজা হচ্ছে",
+    "MATCHING_VOLUNTEER": "স্বেচ্ছাসেবক খোঁজ",
     "MANAGED": "পরিচালিত",
     "RESOLVED": "সমাধান হয়েছে",
     "CANCELLED": "বাতিল করা হয়েছে",

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -360,7 +360,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Zitat",
   "MATCHING_PROCESS": "Vermittlungsprozess:",
-  "MATCHING_VOLUNTEER": "Freiwilliger wird zugeordnet",
+  "MATCHING_VOLUNTEER": "Freiwilligensuche",
   "MAX_CHARACTERS": "Maximal {{count}} Zeichen",
   "MAY_ALL_LIVE_HAPPILY": "Mögen alle glücklich leben",
   "MEDICAL_EMERGENCY": "Medizinischer Notfall",

--- a/src/common/i18n/locales/de/enums.json
+++ b/src/common/i18n/locales/de/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "Erstellt",
-    "MATCHING_VOLUNTEER": "Freiwilliger wird gesucht",
+    "MATCHING_VOLUNTEER": "Freiwilligensuche",
     "MANAGED": "Verwaltet",
     "RESOLVED": "Gelöst",
     "CANCELLED": "Abgebrochen",

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -360,7 +360,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Quote",
   "MATCHING_PROCESS": "Proceso de emparejamiento: ",
-  "MATCHING_VOLUNTEER": "Asignando voluntario",
+  "MATCHING_VOLUNTEER": "Búsqueda de voluntario",
   "MAX_CHARACTERS": "Máximo {{count}} caracteres",
   "MAY_ALL_LIVE_HAPPILY": "May All Live Happily",
   "MEDICAL_EMERGENCY": "Emergencia médica",

--- a/src/common/i18n/locales/es/enums.json
+++ b/src/common/i18n/locales/es/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "Creado",
-    "MATCHING_VOLUNTEER": "Buscando voluntario",
+    "MATCHING_VOLUNTEER": "Búsqueda de voluntario",
     "MANAGED": "Gestionado",
     "RESOLVED": "Resuelto",
     "CANCELLED": "Cancelado",

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -361,7 +361,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Citation",
   "MATCHING_PROCESS": "Processus de mise en correspondance : ",
-  "MATCHING_VOLUNTEER": "Mise en relation avec un bénévole",
+  "MATCHING_VOLUNTEER": "Recherche de bénévole",
   "MAX_CHARACTERS": "Max {{count}} caractères",
   "MAY_ALL_LIVE_HAPPILY": "Que tous vivent heureux",
   "MEDICAL_EMERGENCY": "Urgence médicale",

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -361,7 +361,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Quote",
   "MATCHING_PROCESS": "मिलान प्रक्रिया : ",
-  "MATCHING_VOLUNTEER": "स्वयंसेवक मिलान हो रहा है",
+  "MATCHING_VOLUNTEER": "स्वयंसेवक खोज",
   "MAX_CHARACTERS": "अधिकतम {{count}} वर्ण",
   "MAY_ALL_LIVE_HAPPILY": "May All Live Happily",
   "MEDICAL_EMERGENCY": "चिकित्सा आपातकाल",

--- a/src/common/i18n/locales/hi/enums.json
+++ b/src/common/i18n/locales/hi/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "बनाया गया",
-    "MATCHING_VOLUNTEER": "स्वयंसेवक खोज रहे हैं",
+    "MATCHING_VOLUNTEER": "स्वयंसेवक खोज",
     "MANAGED": "प्रबंधित",
     "RESOLVED": "हल किया गया",
     "CANCELLED": "रद्द किया गया",

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -366,7 +366,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Imagem Alt de Manava Sevaye Madhava Seva",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Citação de Manava Sevaye Madhava Seva",
   "MATCHING_PROCESS": "Processo de Combinação:",
-  "MATCHING_VOLUNTEER": "A associar voluntário",
+  "MATCHING_VOLUNTEER": "Busca de voluntário",
   "MAX_CHARACTERS": "Máximo de {{count}} caracteres",
   "MAY_ALL_LIVE_HAPPILY": "Que Todos Vivam Felizes",
   "MEDICAL_EMERGENCY": "Emergência médica",

--- a/src/common/i18n/locales/pt/enums.json
+++ b/src/common/i18n/locales/pt/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "Criado",
-    "MATCHING_VOLUNTEER": "Procurando voluntário",
+    "MATCHING_VOLUNTEER": "Busca de voluntário",
     "MANAGED": "Gerenciado",
     "RESOLVED": "Resolvido",
     "CANCELLED": "Cancelado",

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -361,7 +361,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Quote",
   "MATCHING_PROCESS": "Процесс подбора: ",
-  "MATCHING_VOLUNTEER": "Подбирается волонтёр",
+  "MATCHING_VOLUNTEER": "Поиск волонтёра",
   "MAX_CHARACTERS": "Максимум {{count}} символов",
   "MAY_ALL_LIVE_HAPPILY": "May All Live Happily",
   "MEDICAL_EMERGENCY": "Медицинская чрезвычайная ситуация",

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -359,7 +359,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "ఇద్దరు వ్యక్తులు ల్యాప్‌టాప్‌లో ఒకరికి ఒకరు సహాయం చేసుకుంటున్నారు",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "మానవ సేవయే మాధవ సేవ",
   "MATCHING_PROCESS": "సరిపోలిక ప్రక్రియ : ",
-  "MATCHING_VOLUNTEER": "వాలంటీర్‌ను సరిపోలుస్తున్నారు",
+  "MATCHING_VOLUNTEER": "వాలంటీర్ శోధన",
   "MAX_CHARACTERS": "గరిష్టంగా {{count}} అక్షరాలు",
   "MAY_ALL_LIVE_HAPPILY": "అందరూ సంతోషంగా జీవించండి.",
   "MEDICAL_EMERGENCY": "వైద్య అత్యవసర పరిస్థితి",

--- a/src/common/i18n/locales/te/enums.json
+++ b/src/common/i18n/locales/te/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "సృష్టించబడింది",
-    "MATCHING_VOLUNTEER": "స్వచ్ఛంద సేవకుడిని వెతుకుతోంది",
+    "MATCHING_VOLUNTEER": "వాలంటీర్ శోధన",
     "MANAGED": "నిర్వహించబడింది",
     "RESOLVED": "పరిష్కరించబడింది",
     "CANCELLED": "రద్దు చేయబడింది",

--- a/src/common/i18n/locales/ur/common.json
+++ b/src/common/i18n/locales/ur/common.json
@@ -430,7 +430,7 @@
   "CREATION_DATE": "تخلیق کی تاریخ",
   "UPDATED_DATE": "تازہ کاری کی تاریخ",
   "CREATED": "بنایا گیا",
-  "MATCHING_VOLUNTEER": "رضاکار ملایا جا رہا ہے",
+  "MATCHING_VOLUNTEER": "رضاکار کی تلاش",
   "IN_PROGRESS": "جاری ہے",
   "RESOLVED": "حل ہو گیا",
   "CANCELLED": "منسوخ کر دیا گیا",

--- a/src/common/i18n/locales/ur/enums.json
+++ b/src/common/i18n/locales/ur/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "تخلیق کیا گیا",
-    "MATCHING_VOLUNTEER": "رضاکار تلاش کر رہے ہیں",
+    "MATCHING_VOLUNTEER": "رضاکار کی تلاش",
     "MANAGED": "منظم کیا گیا",
     "RESOLVED": "حل کیا گیا",
     "CANCELLED": "منسوخ کیا گیا",

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -363,7 +363,7 @@
   "MANAVA_SEVAYE_MADHAVA_SEVA_ALT": "Manava Sevaye Madhava Seva Alt",
   "MANAVA_SEVAYE_MADHAVA_SEVA_QUOTE": "Manava Sevaye Madhava Seva Quote",
   "MATCHING_PROCESS": "匹配过程：",
-  "MATCHING_VOLUNTEER": "正在匹配志愿者",
+  "MATCHING_VOLUNTEER": "志愿者匹配",
   "MAX_CHARACTERS": "最多{{count}}个字符",
   "MAY_ALL_LIVE_HAPPILY": "May All Live Happily",
   "MEDICAL_EMERGENCY": "医疗急救",

--- a/src/common/i18n/locales/zh/enums.json
+++ b/src/common/i18n/locales/zh/enums.json
@@ -11,7 +11,7 @@
   },
   "requestStatus": {
     "CREATED": "已创建",
-    "MATCHING_VOLUNTEER": "匹配志愿者中",
+    "MATCHING_VOLUNTEER": "志愿者匹配",
     "MANAGED": "已管理",
     "RESOLVED": "已解决",
     "CANCELLED": "已取消",


### PR DESCRIPTION
### Summary

* Shortened the `MATCHING_VOLUNTEER` status text in all supported non-English languages.
* Replaced sentence-style translations with concise status labels.
* Kept the English translation unchanged.
* Made no changes to components, APIs, or application logic.

### Testing

* Validated all modified locale JSON files.
* Ran `npm run build` successfully.
* Confirmed that only the intended translation files were modified.

Related to #1590.
