### PR TITLE
Clear login credentials on logout

### DIFF
--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -41,6 +41,11 @@ const LoginPage = () => {
   });
 
   useEffect(() => {
+    setEmailValue("");
+    setPasswordValue("");
+  }, []);
+
+  useEffect(() => {
     if (user) {
       navigate("/dashboard");
     }
@@ -159,10 +164,12 @@ const LoginPage = () => {
           <label htmlFor="email">{t("common:EMAIL")}</label>
           <input
             id="email"
+            name="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
             placeholder={t("common:EMAIL")}
             type="text"
+            autoComplete="off"
             className="px-4 py-2 border border-gray-300 rounded-xl"
             required={true}
           />
@@ -181,9 +188,11 @@ const LoginPage = () => {
           >
             <input
               id="password"
+              name="password"
               placeholder={t("common:PASSWORD")}
               value={passwordValue}
               type={passwordVisible ? "text" : "password"}
+              autoComplete="off"
               onChange={(e) => setPasswordValue(e.target.value)}
               onFocus={() => setPasswordFocus(true)}
               onBlur={() => setPasswordFocus(false)}

--- a/src/pages/Auth/Login.test.jsx
+++ b/src/pages/Auth/Login.test.jsx
@@ -59,6 +59,18 @@ describe("LoginPage", () => {
     expect(screen.getByLabelText(/PASSWORD/i)).toBeInTheDocument();
   });
 
+  it("disables browser auto-fill for the login fields", () => {
+    renderLogin();
+    expect(screen.getByLabelText(/EMAIL/i)).toHaveAttribute(
+      "autocomplete",
+      "off",
+    );
+    expect(screen.getByLabelText(/PASSWORD/i)).toHaveAttribute(
+      "autocomplete",
+      "off",
+    );
+  });
+
   it("shows success banner when accountCreated is true in location state", () => {
     mockLocationState = { accountCreated: true };
     renderLogin();

--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -210,6 +210,7 @@ export const logout = () => async (dispatch) => {
   try {
     returnDefaultLanguage();
     await signOut();
+    localStorage.removeItem("expireTime");
     localStorage.removeItem("userDbId");
     dispatch(logoutSuccess());
   } catch (error) {


### PR DESCRIPTION
## Summary
#1544 
- Improved the login flow so saved credentials do not remain visible after logout.
- Cleared the login form state when the page loads and disabled browser autofill on the email and password fields.
- Removed the logout-related expiry token from local storage during sign-out to reduce stale authentication state.
- Added a regression test to verify that the login email and password fields have browser autofill disabled.