### PR TITLE
Remove categories filter and extend search field to full width on Organizations page

### DIFF
--- a/src/pages/RequestDetails/VoluntaryOrganizations.jsx
+++ b/src/pages/RequestDetails/VoluntaryOrganizations.jsx
@@ -15,9 +15,7 @@ const VoluntaryOrganizations = () => {
     direction: "descending",
   });
   const [searchTerm, setSearchTerm] = useState("");
-  const [categoryFilter, setCategoryFilter] = useState({});
   const [rowsPerPage, setRowsPerPage] = useState(5);
-  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 
@@ -160,7 +158,7 @@ const VoluntaryOrganizations = () => {
 
   const filteredData = useMemo(() => {
     return filteredOrganizations(sortedData);
-  }, [sortedData, categoryFilter, searchTerm]);
+  }, [sortedData, searchTerm]);
 
   const totalPages = (filteredData) => {
     if (!filteredData || filteredData.length == 0) return 1;
@@ -185,124 +183,18 @@ const VoluntaryOrganizations = () => {
     setCurrentPage(1);
   };
 
-  const toggleCategoryDropdown = () => {
-    setIsCategoryDropdownOpen(!isCategoryDropdownOpen);
-  };
-
-  const handleCategoryChange = (category) => {
-    setCategoryFilter((prev) => {
-      const newFilter = { ...prev };
-      if (category === "All") {
-        return Object.keys(newFilter).length ===
-          Object.keys(allCategories).length
-          ? {}
-          : allCategories;
-      } else {
-        if (newFilter[category]) {
-          delete newFilter[category];
-        } else {
-          newFilter[category] = true;
-        }
-        if (
-          Object.keys(newFilter).length ===
-          Object.keys(allCategories).length - 1
-        ) {
-          newFilter["All"] = true;
-        } else {
-          delete newFilter["All"];
-        }
-        return newFilter;
-      }
-    });
-  };
-
-  const allCategories = {
-    All: true,
-    Community: true,
-    Banking: true,
-    Books: true,
-    Clothes: true,
-    "College Admissions": true,
-    Cooking: true,
-    Education: true,
-    Employment: true,
-    Finance: true,
-    Food: true,
-    Gardening: true,
-    Homelessness: true,
-    Housing: true,
-    Jobs: true,
-    Investing: true,
-    Matrimonial: true,
-    Medical: true,
-    Rental: true,
-    School: true,
-    Shopping: true,
-    Sports: true,
-    Stocks: true,
-    Travel: true,
-    Tourism: true,
-  };
-
-  useEffect(() => {
-    if (Object.keys(categoryFilter).length === 0) {
-      setCategoryFilter(allCategories);
-    }
-  }, []);
-
-  const handleFilterBlur = (e) => {
-    if (!e.currentTarget.contains(e.relatedTarget))
-      setIsCategoryDropdownOpen(false);
-  };
-
   return (
     <div className="p-5">
       <h1 className="text-2xl font-bold mb-5">Organizations</h1>
 
-      <div className="mb-4 flex gap-2">
+      <div className="mb-4">
         <input
           type="text"
           placeholder="Search..."
           value={searchTerm}
           onChange={handleSearchChange}
-          className="p-2 border rounded flex-grow"
+          className="p-2 border rounded w-full"
         />
-        <div className="relative" onBlur={handleFilterBlur} tabIndex={-1}>
-          <button
-            className="bg-gray-200 text-black py-2 px-4 rounded hover:bg-gray-300"
-            onClick={toggleCategoryDropdown}
-            tabIndex={0}
-          >
-            {t("FILTER_BY")}
-          </button>
-          {isCategoryDropdownOpen && (
-            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10">
-              <label className="block">
-                <input
-                  type="checkbox"
-                  checked={
-                    Object.keys(categoryFilter).length ===
-                    Object.keys(allCategories).length
-                  }
-                  onChange={() => handleCategoryChange("All")}
-                />
-                All Categories
-              </label>
-              {Object.keys(allCategories)
-                .filter((cat) => cat !== "All")
-                .map((category) => (
-                  <label key={category} className="block">
-                    <input
-                      type="checkbox"
-                      checked={categoryFilter[category] || false}
-                      onChange={() => handleCategoryChange(category)}
-                    />
-                    {category}
-                  </label>
-                ))}
-            </div>
-          )}
-        </div>
       </div>
 
       {isLoading ? (

--- a/src/pages/RequestDetails/VoluntaryOrganizations.test.jsx
+++ b/src/pages/RequestDetails/VoluntaryOrganizations.test.jsx
@@ -234,21 +234,7 @@ describe("VoluntaryOrganizations", () => {
     expect(screen.queryByText("Community Care")).not.toBeInTheDocument();
   });
 
-  // 11. Category filter dropdown toggles
-  it("opens and closes category filter dropdown", async () => {
-    getOrganizations.mockResolvedValue([]);
-    renderWithProviders(<VoluntaryOrganizations />, {
-      preloadedState: MOCK_STATE,
-    });
-    await waitFor(() =>
-      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument(),
-    );
-    const filterBtn = screen.getByText("FILTER_BY");
-    fireEvent.click(filterBtn);
-    expect(screen.getByText("All Categories")).toBeInTheDocument();
-  });
-
-  // 12. Handles response wrapped in .body
+  // 11. Handles response wrapped in .body
   it("handles API response wrapped in body field", async () => {
     getOrganizations.mockResolvedValue({ body: mockOrgs });
     renderWithProviders(<VoluntaryOrganizations />, {


### PR DESCRIPTION
## What
Removes the "Filter by" categories dropdown from the Organizations page (Request Details → Organizations) and extends the Search field to span the full width of the container.
## Changes
- Removed the categories filter UI (the "Filter by" button and its checkbox dropdown)
- Removed the now-unused category state and handlers: `categoryFilter`,  `isCategoryDropdownOpen`, `toggleCategoryDropdown`, `handleCategoryChange`,  `allCategories`, the category-seeding `useEffect`, and `handleFilterBlur`
- Changed the search row from `flex gap-2` to a full-width container and the input class from `flex-grow` to `w-full`
- Removed the obsolete "opens and closes category filter dropdown" test. Search filtering behavior is unchanged.
## Testing
- `npm test` — VoluntaryOrganizations suite passes (13/13)
- `npm run build` — builds successfully
- Verified locally (`npm run dev`): search bar now full-width, filter removed,  search still filters the list

Closes #1301 