### PR TITLE
fix: prevent random text when no speech is detected during voice recording #1708

### DIFF
--- a/src/common/components/VoiceRecordingComponent.jsx
+++ b/src/common/components/VoiceRecordingComponent.jsx
@@ -12,6 +12,34 @@ import { Howl } from "howler";
 import { uploadAudioAndTranscribe } from "../../services/audioServices";
 
 const DEFAULT_MAX_RECORDING_SECONDS = 60;
+const SILENCE_RMS_THRESHOLD = 0.01;
+
+/**
+ * Analyze audio blob to detect if it contains mostly silence.
+ * Uses Web Audio API to decode the audio and compute RMS energy.
+ * @param {Blob} audioBlob - recorded audio blob
+ * @returns {Promise<boolean>} - true if the audio is silent (no speech detected)
+ */
+const isSilentAudio = async (audioBlob) => {
+  try {
+    const audioContext = new (window.AudioContext ||
+      window.webkitAudioContext)();
+    const arrayBuffer = await audioBlob.arrayBuffer();
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    const channelData = audioBuffer.getChannelData(0);
+
+    let sumSquares = 0;
+    for (let i = 0; i < channelData.length; i++) {
+      sumSquares += channelData[i] * channelData[i];
+    }
+    const rms = Math.sqrt(sumSquares / channelData.length);
+
+    audioContext.close();
+    return rms < SILENCE_RMS_THRESHOLD;
+  } catch {
+    return false;
+  }
+};
 
 const VoiceRecordingComponent = ({
   onTranscriptionUpdate,
@@ -174,6 +202,16 @@ const VoiceRecordingComponent = ({
         setIsProcessing(true);
 
         try {
+          const silent = await isSilentAudio(nextBlob);
+          if (silent) {
+            setError(
+              "No speech detected. Please try again and speak into your microphone while recording.",
+            );
+            setTranscriptionError(true);
+            setIsProcessing(false);
+            return;
+          }
+
           const localAudioUrl = URL.createObjectURL(nextBlob);
           setAudioUrl(localAudioUrl);
           audioUrlRef.current = localAudioUrl;

--- a/src/common/components/VoiceRecordingComponent.test.jsx
+++ b/src/common/components/VoiceRecordingComponent.test.jsx
@@ -1,0 +1,233 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+// Mock howler — not needed for silence-detection tests
+jest.mock("howler", () => ({
+  Howl: jest.fn().mockImplementation(() => ({
+    play: jest.fn(),
+    pause: jest.fn(),
+    stop: jest.fn(),
+    unload: jest.fn(),
+  })),
+}));
+
+// Mock audioServices
+const mockUploadAudioAndTranscribe = jest.fn();
+jest.mock("../../services/audioServices", () => ({
+  uploadAudioAndTranscribe: (...args) => mockUploadAudioAndTranscribe(...args),
+}));
+
+// ── Helpers to build fake AudioContext / AudioBuffer ────────────────────────
+
+/**
+ * Build a minimal mock for window.AudioContext that returns channel data
+ * with the given RMS energy level.
+ *
+ * @param {number} rms - desired RMS value of the fake audio (0 = total silence)
+ */
+function mockAudioContext(rms) {
+  const sampleCount = 1000;
+  // Each sample value s must satisfy: sqrt(N * s^2 / N) = rms  →  s = rms
+  const amplitude = rms;
+  const channelData = new Float32Array(sampleCount).fill(amplitude);
+
+  const fakeAudioBuffer = { getChannelData: () => channelData };
+
+  const fakeCtx = {
+    decodeAudioData: jest.fn().mockResolvedValue(fakeAudioBuffer),
+    close: jest.fn(),
+  };
+
+  window.AudioContext = jest.fn(() => fakeCtx);
+  window.webkitAudioContext = jest.fn(() => fakeCtx);
+  return fakeCtx;
+}
+
+// ── Mock MediaRecorder & getUserMedia ──────────────────────────────────────
+
+let capturedOnDataAvailable;
+let capturedOnStop;
+let mockMediaRecorderInstance;
+
+function setupMediaMocks() {
+  mockMediaRecorderInstance = {
+    start: jest.fn(),
+    stop: jest.fn().mockImplementation(() => {
+      if (capturedOnStop) capturedOnStop();
+    }),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    state: "recording",
+    ondataavailable: null,
+    onstop: null,
+  };
+
+  // Capture callbacks when they are assigned
+  Object.defineProperty(mockMediaRecorderInstance, "ondataavailable", {
+    set(fn) {
+      capturedOnDataAvailable = fn;
+    },
+    get() {
+      return capturedOnDataAvailable;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(mockMediaRecorderInstance, "onstop", {
+    set(fn) {
+      capturedOnStop = fn;
+    },
+    get() {
+      return capturedOnStop;
+    },
+    configurable: true,
+  });
+
+  window.MediaRecorder = jest.fn(() => mockMediaRecorderInstance);
+  window.MediaRecorder.isTypeSupported = jest.fn(() => true);
+
+  const mockStream = { getTracks: () => [{ stop: jest.fn() }] };
+  navigator.mediaDevices = {
+    getUserMedia: jest.fn().mockResolvedValue(mockStream),
+  };
+}
+
+// ── Import component AFTER mocks are set up ────────────────────────────────
+
+let VoiceRecordingComponent;
+beforeAll(async () => {
+  const mod = await import("./VoiceRecordingComponent");
+  VoiceRecordingComponent = mod.default;
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("VoiceRecordingComponent — silence detection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMediaMocks();
+    // Provide Blob.prototype.arrayBuffer for jsdom
+    if (!Blob.prototype.arrayBuffer) {
+      Blob.prototype.arrayBuffer = function () {
+        return new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.readAsArrayBuffer(this);
+        });
+      };
+    }
+    // Mock URL.createObjectURL / revokeObjectURL for jsdom
+    if (!URL.createObjectURL) {
+      URL.createObjectURL = jest.fn(() => "blob:mock-url");
+    }
+    if (!URL.revokeObjectURL) {
+      URL.revokeObjectURL = jest.fn();
+    }
+  });
+
+  it("shows no-speech error and does NOT call transcription API when audio is silent", async () => {
+    // RMS = 0 → completely silent
+    mockAudioContext(0);
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    // Click start recording
+    const startBtn = screen.getByRole("button", { name: /start recording/i });
+    await act(async () => {
+      fireEvent.click(startBtn);
+    });
+
+    // Simulate a data chunk arriving (silent audio)
+    const silentBlob = new Blob([new ArrayBuffer(100)], {
+      type: "audio/webm",
+    });
+    await act(async () => {
+      capturedOnDataAvailable({ data: silentBlob });
+    });
+
+    // Stop recording — triggers onstop handler
+    const stopBtn = screen.getByRole("button", { name: /stop recording/i });
+    await act(async () => {
+      fireEvent.click(stopBtn);
+    });
+
+    // Wait for the silence detection to complete
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /no speech detected/i,
+      );
+    });
+
+    // Transcription API should NOT have been called
+    expect(mockUploadAudioAndTranscribe).not.toHaveBeenCalled();
+    // Description should NOT be updated
+    expect(onTranscriptionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("calls transcription API normally when audio contains speech", async () => {
+    // RMS = 0.1 → well above threshold (0.01)
+    mockAudioContext(0.1);
+
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "Hello world",
+      detectedLanguage: "en",
+      requestId: "req-123",
+    });
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    // Start recording
+    const startBtn = screen.getByRole("button", { name: /start recording/i });
+    await act(async () => {
+      fireEvent.click(startBtn);
+    });
+
+    // Simulate a data chunk
+    const speechBlob = new Blob([new ArrayBuffer(100)], {
+      type: "audio/webm",
+    });
+    await act(async () => {
+      capturedOnDataAvailable({ data: speechBlob });
+    });
+
+    // Stop recording
+    const stopBtn = screen.getByRole("button", { name: /stop recording/i });
+    await act(async () => {
+      fireEvent.click(stopBtn);
+    });
+
+    // Wait for transcription to complete
+    await waitFor(() => {
+      expect(mockUploadAudioAndTranscribe).toHaveBeenCalled();
+    });
+
+    // Description should be updated with transcription text
+    expect(onTranscriptionUpdate).toHaveBeenCalledWith("Hello world");
+  });
+});

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -818,5 +818,6 @@
   "STEP_NUMBER_3": "3",
   "STEP_NUMBER_4": "4",
   "STEP_NUMBER_5": "5",
-  "DELETE_ACTION": "Delete"
+  "DELETE_ACTION": "Delete",
+  "VOICE_NO_SPEECH_DETECTED": "No speech detected. Please try again and speak into your microphone while recording."
 }

--- a/src/services/audioServices.js
+++ b/src/services/audioServices.js
@@ -556,8 +556,6 @@ export const generateHelloAudio = async () => {
  * @returns {Promise<Object>} - Returns transcription text and requestId
  */
 export const uploadAudioAndTranscribe = async (audioBlob) => {
-  const base64Audio = await blobToBase64(audioBlob);
-  const response = await speechDetectV2(base64Audio);
   try {
     // Convert WEBM/Opus audio blob to base64 string (no format conversion needed)
     const base64Audio = await blobToBase64(audioBlob);


### PR DESCRIPTION



### Problem
When a user starts voice recording but does not speak, the speech-to-text API returns hallucinated/random text (e.g., "I'm going to go ahead and put this in the middle.") that gets populated into the description field.

### Root Cause
The recorded audio was sent directly to the transcription API without validating whether it contained actual speech. Speech-to-text models can hallucinate output when given silent or near-silent input. Additionally, [uploadAudioAndTranscribe](cci:1://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/services/audioServices.js:552:0-595:2) in [audioServices.js](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/services/audioServices.js:0:0-0:0) had duplicate unguarded API calls outside its `try` block.

### Solution
<img width="583" height="564" alt="Screenshot 2026-08-02 at 2 39 40 PM" src="https://github.com/user-attachments/assets/05f229a8-af51-47bd-9574-dffaa5c0ed95" />


- Introduced client-side silence detection using the Web Audio API. After recording stops, the audio blob is decoded and its RMS energy is computed. If below the silence threshold, transcription is skipped entirely.
- Users see a clear error notification asking them to try again while speaking.
<img width="547" height="611" alt="Screenshot 2026-08-02 at 2 41 23 PM" src="https://github.com/user-attachments/assets/9917a65e-aa27-49ae-a82c-c91d80315d3b" />



https://github.com/user-attachments/assets/81ee77e9-932e-4d65-a5dc-dc844c00ed9b





- Fixed the duplicate API call bug in [audioServices.js](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/services/audioServices.js:0:0-0:0).

### Files Changed
| File | Change |
|------|--------|
| [src/common/components/VoiceRecordingComponent.jsx](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/common/components/VoiceRecordingComponent.jsx:0:0-0:0) | Added [isSilentAudio()](cci:1://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/common/components/VoiceRecordingComponent.jsx:16:0-41:2) + silence check before transcription |
| [src/common/components/VoiceRecordingComponent.test.jsx](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/common/components/VoiceRecordingComponent.test.jsx:0:0-0:0) | New test file with silence detection tests |
| [src/services/audioServices.js](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/services/audioServices.js:0:0-0:0) | Removed duplicate unguarded API calls |
| [src/common/i18n/locales/en/common.json](cci:7://file:///Users/monesh/Desktop/Projects/SaayamForAll/webapp/src/common/i18n/locales/en/common.json:0:0-0:0) | Added `VOICE_NO_SPEECH_DETECTED` key |

### Testing
- All 75 existing `HelpRequestForm` tests pass
- 2 new tests pass (silent audio → error shown, speech audio → transcription proceeds)