### PR TITLE
feat: enable Custom date-range trend chart in KPI Analytics

### DIFF
--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.jsx
@@ -61,6 +61,11 @@ export const renderTooltip =
 const KPIAnalytics = () => {
   const [viewMode, setViewMode] = useState("snapshot"); // snapshot | table | trends
   const [timeRange, setTimeRange] = useState("All"); // 7D | 30D | 1Y | All | Custom
+  const [customStartDate, setCustomStartDate] = useState("");
+  const [customEndDate, setCustomEndDate] = useState("");
+  const [customData, setCustomData] = useState(null);
+  const [customLoading, setCustomLoading] = useState(false);
+  const [customError, setCustomError] = useState(null);
   const [selectedSegment, setSelectedSegment] = useState(null);
   const [breakdownView, setBreakdownView] = useState("category"); // category or region
   const [kpiData, setKpiData] = useState(null);
@@ -81,6 +86,28 @@ const KPIAnalytics = () => {
     };
     fetchData();
   }, []);
+
+  // Fetches Custom-range trend data on demand (Apply button), since
+  // the Custom response is a flat object (not nested under a range
+  // key like 7D/30D/1Y/All), so it's kept in its own state.
+  const fetchCustomTrend = async () => {
+    if (!customStartDate || !customEndDate) return;
+    try {
+      setCustomLoading(true);
+      setCustomError(null);
+      const data = await getKpiAnalytics({
+        time_range: "Custom",
+        start_date: customStartDate,
+        end_date: customEndDate,
+      });
+      setCustomData(data);
+    } catch (err) {
+      setCustomError("Failed to load custom range data. Please try again.");
+    } finally {
+      setCustomLoading(false);
+    }
+  };
+
   const SLA_TARGET = kpiData?.sla?.target_hours ?? 240;
   const SLA_WARNING = kpiData?.sla?.warning_hours ?? 200;
 
@@ -112,14 +139,18 @@ const KPIAnalytics = () => {
   const totalRequests = snapshotData?.total_requests ?? 0;
 
   // Trends view reads the selected range's total_requests time series.
-  // NOTE: Custom is intentionally excluded for now - backend is still
-  // finalizing the date-range granularity for Custom.
+  // Custom uses its own separately-fetched, flat-shaped response
+  // (see fetchCustomTrend above) instead of kpiData.body[timeRange].
   const trendData = useMemo(() => {
-    if (timeRange === "Custom") return [];
+    if (timeRange === "Custom") {
+      const series = customData?.body?.total_requests;
+      if (!Array.isArray(series)) return [];
+      return [...series].sort((a, b) => (a.period > b.period ? 1 : -1));
+    }
     const series = kpiData?.body?.[timeRange]?.total_requests;
     if (!Array.isArray(series)) return [];
     return [...series].sort((a, b) => (a.period > b.period ? 1 : -1));
-  }, [kpiData, timeRange]);
+  }, [kpiData, timeRange, customData]);
 
   // Handle segment click
   const handleSegmentClick = (data) => {
@@ -227,12 +258,49 @@ const KPIAnalytics = () => {
               ))}
               <button
                 type="button"
-                disabled
-                title="Custom range coming soon"
-                className="px-3 py-1 text-xs rounded bg-gray-50 text-gray-400 cursor-not-allowed"
+                onClick={() => setTimeRange("Custom")}
+                className={`px-3 py-1 text-xs rounded ${
+                  timeRange === "Custom"
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
               >
                 Custom
               </button>
+            </div>
+          )}
+
+          {viewMode === "trends" && timeRange === "Custom" && (
+            <div className="flex gap-2 items-center flex-wrap mt-2 w-full">
+              <label className="text-xs text-gray-600">
+                From
+                <input
+                  type="date"
+                  value={customStartDate}
+                  onChange={(e) => setCustomStartDate(e.target.value)}
+                  className="ml-1 px-2 py-0.5 text-xs border border-gray-300 rounded"
+                />
+              </label>
+              <label className="text-xs text-gray-600">
+                To
+                <input
+                  type="date"
+                  value={customEndDate}
+                  onChange={(e) => setCustomEndDate(e.target.value)}
+                  className="ml-1 px-2 py-0.5 text-xs border border-gray-300 rounded"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={fetchCustomTrend}
+                disabled={!customStartDate || !customEndDate || customLoading}
+                className="px-3 py-1 text-xs rounded bg-blue-600 text-white disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {customLoading ? "Loading..." : "Apply"}
+              </button>
+              {customError && (
+                <span className="text-xs text-red-600">{customError}</span>
+              )}
             </div>
           )}
 

--- a/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
+++ b/src/pages/Dashboard/components/Analytics/KPIAnalytics.test.jsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+} from "@testing-library/react";
 import KPIAnalytics, { renderTooltip } from "./KPIAnalytics";
 import * as analyticsServices from "../../../../services/analyticsServices";
 
@@ -333,15 +339,112 @@ describe("KPIAnalytics", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("keeps the Custom button disabled", async () => {
+    it("shows date pickers and an Apply button when Custom is selected", async () => {
       analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
       render(<KPIAnalytics />);
       await waitFor(() => {
         expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
       });
       switchViewMode("trends");
-      const customButton = screen.getByRole("button", { name: "Custom" });
-      expect(customButton).toBeDisabled();
+      fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+
+      expect(screen.getByText("From")).toBeInTheDocument();
+      expect(screen.getByText("To")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    });
+
+    it("disables Apply until both dates are chosen", async () => {
+      analyticsServices.getKpiAnalytics.mockResolvedValue(mockData);
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+
+      const applyButton = screen.getByRole("button", { name: "Apply" });
+      expect(applyButton).toBeDisabled();
+
+      const [fromInput, toInput] = screen.getAllByDisplayValue("");
+      fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+      expect(applyButton).toBeDisabled();
+
+      fireEvent.change(toInput, { target: { value: "2026-01-15" } });
+      expect(applyButton).not.toBeDisabled();
+    });
+
+    it("fetches and renders the custom range chart when Apply is clicked", async () => {
+      const customResponse = {
+        body: {
+          request_status_distribution: [],
+          total_requests: [
+            { period: "2026-01-05", total_requests: 1 },
+            { period: "2026-01-08", total_requests: 5 },
+          ],
+          average_resolution_time_by_category: [],
+        },
+      };
+      analyticsServices.getKpiAnalytics
+        .mockResolvedValueOnce(mockData)
+        .mockResolvedValueOnce(customResponse);
+
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+
+      const [fromInput, toInput] = screen.getAllByDisplayValue("");
+      fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+      fireEvent.change(toInput, { target: { value: "2026-01-15" } });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+      });
+
+      await waitFor(() => {
+        expect(analyticsServices.getKpiAnalytics).toHaveBeenCalledWith({
+          time_range: "Custom",
+          start_date: "2026-01-01",
+          end_date: "2026-01-15",
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("No trend data available for Custom"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows an error message when the custom range fetch fails", async () => {
+      analyticsServices.getKpiAnalytics
+        .mockResolvedValueOnce(mockData)
+        .mockRejectedValueOnce(new Error("Network Error"));
+
+      render(<KPIAnalytics />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Snapshot")).toBeInTheDocument();
+      });
+      switchViewMode("trends");
+      fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+
+      const [fromInput, toInput] = screen.getAllByDisplayValue("");
+      fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+      fireEvent.change(toInput, { target: { value: "2026-01-15" } });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Failed to load custom range data. Please try again.",
+          ),
+        ).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
Backend confirmed Custom accepts { time_range: 'Custom', start_date, end_date } and returns a flat (unwrapped) response shape.

- Enabled the previously-disabled Custom button
- Added From/To date pickers and an Apply button, shown only when Custom is selected
- Custom fetches on demand (Apply click) via a separate customData state, since its response shape differs from the other ranges (flat object vs nested under a range key)
- trendData now branches: reads from customData for Custom, from kpiData.body[timeRange] for everything else
- Added loading/error states specific to the Custom fetch
- Replaced the stale 'Custom button disabled' test with 4 new tests: date pickers render, Apply is gated on both dates being chosen, successful fetch renders the chart, and fetch failure shows an error message
- All 29 KPIAnalytics tests passing
- Manually verified in local dev: picking a date range and clicking Apply renders a real line chart against the live API