### PR TITLE
feat: display additional info fields on Request Details page (#1456)

### DIFF
--- a/src/pages/RequestDetails/AdditionalFieldsDisplay.jsx
+++ b/src/pages/RequestDetails/AdditionalFieldsDisplay.jsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { getAdditionalFields } from "../../services/requestServices";
+
+/**
+ * AdditionalFieldsDisplay (#1456)
+ *
+ * Read-only, label:value rendering of the dynamic additional info
+ * fields captured on Create Request (see DynamicAdditionalFields.jsx),
+ * shown on the Request Details "Details" tab.
+ *
+ * Props:
+ *   requestId    - the request's ID
+ *   requesterId  - the requester's ID
+ *   category     - requestData.category (may be a catName like
+ *                  "GROCERY_SHOPPING_AND_DELIVERY" or already a numeric
+ *                  catId like "1.1")
+ */
+const toTitleCase = (str) =>
+  String(str)
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+const AdditionalFieldsDisplay = ({ requestId, requesterId, category }) => {
+  const { t } = useTranslation("metadata");
+  const categories = useSelector((state) => state.request?.categories);
+
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const catId = useMemo(() => {
+    if (!category || !categories) return category;
+    if (/^\d+(\.\d+)*$/.test(category)) return category;
+    for (const cat of categories) {
+      if (cat.catName === category) return cat.catId;
+      for (const sub of cat.subCategories || []) {
+        if (sub.catName === category) return sub.catId;
+        for (const subsub of sub.subCategories || []) {
+          if (subsub.catName === category) return subsub.catId;
+        }
+      }
+    }
+    return category;
+  }, [category, categories]);
+
+  const metadataFields = useMemo(() => {
+    if (!catId) return [];
+    try {
+      const raw = localStorage.getItem("metadata");
+      if (!raw) return [];
+      const allMetadata = JSON.parse(raw);
+      if (!Array.isArray(allMetadata)) return [];
+
+      let entry = allMetadata.find((m) => m.catId === catId);
+      if (!entry && catId.includes(".")) {
+        const parentCatId = catId.substring(0, catId.lastIndexOf("."));
+        entry = allMetadata.find((m) => m.catId === parentCatId);
+      }
+      if (!entry || !Array.isArray(entry.fields)) return [];
+      return entry.fields.filter((f) => f.status === "active");
+    } catch {
+      return [];
+    }
+  }, [catId]);
+
+  useEffect(() => {
+    if (!requestId || !requesterId) {
+      setLoading(false);
+      return;
+    }
+    const fetchFields = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await getAdditionalFields({ requestId, requesterId });
+        setData(response?.data ?? null);
+      } catch (err) {
+        setError("Failed to load additional details. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFields();
+  }, [requestId, requesterId]);
+
+  const translateMetadataLabel = (key, fallback) => {
+    const translated = t(key, { defaultValue: fallback });
+    return translated === key ? fallback : translated;
+  };
+
+  const getFieldLabel = (fieldNameKey) =>
+    translateMetadataLabel(`FIELDS.${fieldNameKey}`, toTitleCase(fieldNameKey));
+
+  const getItemLabel = (itemValue) =>
+    translateMetadataLabel(`ITEMS.${itemValue}`, toTitleCase(itemValue));
+
+  const formatRawValue = (value) => {
+    if (value === null || value === undefined || value === "") return "";
+    if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+      const parsed = new Date(value);
+      if (!isNaN(parsed.getTime())) {
+        return parsed.toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          timeZone: "UTC",
+        });
+      }
+    }
+    // Some fields (e.g. currency-type) come back as an object rather
+    // than a scalar (e.g. { amount, currency } or { amount, unit }).
+    // Join its own values into a readable string rather than
+    // stringifying to "[object Object]".
+    if (typeof value === "object" && !Array.isArray(value)) {
+      return Object.values(value).join(" - ");
+    }
+    return String(value);
+  };
+
+  const renderValue = (field, rawValue) => {
+    if (Array.isArray(rawValue)) {
+      const listItems = field?.listItems || [];
+      return rawValue
+        .map((itemId) => {
+          const item = listItems.find((li) => li.itemId === itemId);
+          return item ? getItemLabel(item.itemValue) : itemId;
+        })
+        .join(", ");
+    }
+    return formatRawValue(rawValue);
+  };
+
+  if (loading) {
+    return (
+      <div className="text-sm text-gray-500 py-2">
+        Loading additional details...
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-sm text-red-600 py-2">{error}</div>;
+  }
+
+  if (!data || Object.keys(data).length === 0) {
+    return (
+      <p className="text-xs text-gray-400 italic mb-4">
+        No additional information available.
+      </p>
+    );
+  }
+
+  const entries = Object.entries(data);
+
+  return (
+    <div
+      className="mt-3 mb-4 space-y-2"
+      data-testid="additional-fields-display"
+    >
+      {entries.map(([fieldId, rawValue]) => {
+        const field = metadataFields.find((f) => f.fieldId === fieldId);
+        const label = field
+          ? getFieldLabel(field.fieldNameKey)
+          : toTitleCase(fieldId);
+        return (
+          <div key={fieldId} className="flex flex-col sm:flex-row sm:gap-2">
+            <span className="text-sm font-semibold text-gray-700">
+              {label}:
+            </span>
+            <span className="text-sm text-gray-600">
+              {renderValue(field, rawValue)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AdditionalFieldsDisplay;

--- a/src/pages/RequestDetails/AdditionalFieldsDisplay.test.jsx
+++ b/src/pages/RequestDetails/AdditionalFieldsDisplay.test.jsx
@@ -255,4 +255,132 @@ describe("AdditionalFieldsDisplay", () => {
       expect(screen.getByText("Vegan")).toBeInTheDocument();
     });
   });
+
+  it("resolves a 3-level-deep subcategory name to its numeric catId", async () => {
+    mockCategories = [
+      {
+        catId: "3",
+        catName: "TOP",
+        subCategories: [
+          {
+            catId: "3.6",
+            catName: "MID",
+            subCategories: [
+              { catId: "3.6.1", catName: "DEEP_CATEGORY", subCategories: [] },
+            ],
+          },
+        ],
+      },
+    ];
+    localStorage.setItem(
+      "metadata",
+      JSON.stringify([
+        {
+          catId: "3.6.1",
+          fields: [
+            {
+              fieldId: "3.6.1.A",
+              fieldNameKey: "DEEP_FIELD",
+              fieldType: "textbox",
+              status: "active",
+              catId: "3.6.1",
+            },
+          ],
+        },
+      ]),
+    );
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "3.6.1.A": "hello" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="DEEP_CATEGORY"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Deep Field:")).toBeInTheDocument();
+      expect(screen.getByText("hello")).toBeInTheDocument();
+    });
+  });
+
+  it("returns the raw category unchanged when no match is found in the categories tree", async () => {
+    mockCategories = [
+      { catId: "1", catName: "SOMETHING_ELSE", subCategories: [] },
+    ];
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { UNRESOLVABLE_FIELD: "value" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="NOT_IN_TREE"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Unresolvable Field:")).toBeInTheDocument();
+      expect(screen.getByText("value")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to the parent catId's metadata entry when the exact catId is not present", async () => {
+    localStorage.setItem(
+      "metadata",
+      JSON.stringify([
+        {
+          catId: "1.1",
+          fields: [
+            {
+              fieldId: "1.1.A",
+              fieldNameKey: "PREFERRED_MEAL_TYPE",
+              fieldType: "list",
+              status: "active",
+              catId: "1.1",
+              listItems: [
+                {
+                  itemId: "1.1.A.1",
+                  itemValue: "VEGETARIAN",
+                  itemType: "radiobutton",
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    );
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.A": ["1.1.A.1"] },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1.A"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Preferred Meal Type:")).toBeInTheDocument();
+      expect(screen.getByText("Vegetarian")).toBeInTheDocument();
+    });
+  });
+
+  it("does not crash when the metadata in localStorage is invalid JSON", async () => {
+    localStorage.setItem("metadata", "not-valid-json");
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { SOME_FIELD: "value" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Some Field:")).toBeInTheDocument();
+      expect(screen.getByText("value")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/RequestDetails/AdditionalFieldsDisplay.test.jsx
+++ b/src/pages/RequestDetails/AdditionalFieldsDisplay.test.jsx
@@ -1,0 +1,258 @@
+﻿import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import AdditionalFieldsDisplay from "./AdditionalFieldsDisplay";
+import * as requestServices from "../../services/requestServices";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, options) => options?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock("../../services/requestServices", () => ({
+  getAdditionalFields: jest.fn(),
+}));
+
+let mockCategories = [];
+jest.mock("react-redux", () => ({
+  useSelector: (selector) =>
+    selector({ request: { categories: mockCategories } }),
+}));
+
+const sampleMetadata = [
+  {
+    catId: "1.1",
+    fields: [
+      {
+        fieldId: "1.1.A",
+        fieldNameKey: "PREFERRED_MEAL_TYPE",
+        fieldType: "list",
+        status: "active",
+        catId: "1.1",
+        listItems: [
+          {
+            itemId: "1.1.A.1",
+            itemValue: "VEGETARIAN",
+            itemType: "radiobutton",
+          },
+          { itemId: "1.1.A.2", itemValue: "VEGAN", itemType: "radiobutton" },
+        ],
+      },
+      {
+        fieldId: "1.1.B",
+        fieldNameKey: "DIETARY_RESTRICTIONS",
+        fieldType: "list",
+        status: "active",
+        catId: "1.1",
+        listItems: [
+          { itemId: "1.1.B.1", itemValue: "GLUTEN_FREE", itemType: "checkbox" },
+          { itemId: "1.1.B.2", itemValue: "DAIRY_FREE", itemType: "checkbox" },
+        ],
+      },
+      {
+        fieldId: "1.1.C",
+        fieldNameKey: "HOUSEHOLD_SIZE",
+        fieldType: "int",
+        status: "active",
+        catId: "1.1",
+      },
+    ],
+  },
+];
+
+describe("AdditionalFieldsDisplay", () => {
+  beforeEach(() => {
+    localStorage.setItem("metadata", JSON.stringify(sampleMetadata));
+    mockCategories = [];
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    requestServices.getAdditionalFields.mockResolvedValue({ data: {} });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    expect(
+      screen.getByText("Loading additional details..."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the empty-state message when the API returns no data", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({ data: {} });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText("No additional information available."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the empty-state message when requestId or requesterId is missing", async () => {
+    render(
+      <AdditionalFieldsDisplay
+        requestId={null}
+        requesterId={null}
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText("No additional information available."),
+      ).toBeInTheDocument();
+    });
+    expect(requestServices.getAdditionalFields).not.toHaveBeenCalled();
+  });
+
+  it("shows an error message when the API call fails", async () => {
+    requestServices.getAdditionalFields.mockRejectedValue(new Error("fail"));
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Failed to load additional details. Please try again.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("maps single-select field codes to readable labels", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.A": ["1.1.A.1"] },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Preferred Meal Type:")).toBeInTheDocument();
+      expect(screen.getByText("Vegetarian")).toBeInTheDocument();
+    });
+  });
+
+  it("joins multi-select values with a comma", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.B": ["1.1.B.1", "1.1.B.2"] },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Gluten Free, Dairy Free")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a raw value for a field with no list items", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.C": "4" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Household Size:")).toBeInTheDocument();
+      expect(screen.getByText("4")).toBeInTheDocument();
+    });
+  });
+
+  it("formats an ISO date-time value as a readable date", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.C": "2026-06-13T04:00:00Z" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("June 13, 2026")).toBeInTheDocument();
+    });
+  });
+
+  it("joins an object value's own values with a dash instead of showing [object Object]", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.C": { min: 100, max: 150 } },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("100 - 150")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to a title-cased field code when no metadata entry matches", async () => {
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { UNKNOWN_FIELD: "some value" },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="1.1"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Unknown Field:")).toBeInTheDocument();
+    });
+  });
+
+  it("resolves a human-readable category name to the numeric catId via the categories tree", async () => {
+    mockCategories = [
+      {
+        catId: "1.1",
+        catName: "GROCERY_SHOPPING_AND_DELIVERY",
+        subCategories: [],
+      },
+    ];
+    requestServices.getAdditionalFields.mockResolvedValue({
+      data: { "1.1.A": ["1.1.A.2"] },
+    });
+    render(
+      <AdditionalFieldsDisplay
+        requestId="REQ-1"
+        requesterId="SID-1"
+        category="GROCERY_SHOPPING_AND_DELIVERY"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Vegan")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/RequestDetails/RequestDescription.jsx
+++ b/src/pages/RequestDetails/RequestDescription.jsx
@@ -31,7 +31,9 @@ const findCategoryLabel = (node, targetKey) => {
   return null;
 };
 
-const RequestDescription = ({ requestData }) => {
+import AdditionalFieldsDisplay from "./AdditionalFieldsDisplay";
+
+const RequestDescription = ({ requestData, requestId, requesterId }) => {
   const { t, i18n } = useTranslation();
   const normalizedPriority = String(requestData?.priority || "")
     .trim()
@@ -150,28 +152,11 @@ const RequestDescription = ({ requestData }) => {
           <h3 className="text-sm font-semibold text-gray-700 mb-2">
             {t("ADDITIONAL_INFO")}
           </h3>
-          {requestData.additionalInfo &&
-          Object.keys(requestData.additionalInfo).length > 0 ? (
-            <div className="space-y-1 mb-4">
-              {Object.entries(requestData.additionalInfo).map(
-                ([key, value]) => (
-                  <div
-                    key={key}
-                    className="flex justify-between items-center text-sm py-1 border-b border-gray-100"
-                  >
-                    <span className="text-gray-500 capitalize">
-                      {key.replace(/_/g, " ")}
-                    </span>
-                    <span className="text-gray-800">{String(value)}</span>
-                  </div>
-                ),
-              )}
-            </div>
-          ) : (
-            <p className="text-xs text-gray-400 italic mb-4">
-              No additional information available.
-            </p>
-          )}
+          <AdditionalFieldsDisplay
+            requestId={requestId}
+            requesterId={requesterId}
+            category={requestData?.category}
+          />
 
           <h3 className="text-sm font-semibold text-gray-700 mb-2">
             {t("ATTACHED_FILES")}

--- a/src/pages/RequestDetails/RequestDescription.test.jsx
+++ b/src/pages/RequestDetails/RequestDescription.test.jsx
@@ -158,29 +158,17 @@ describe("RequestDescription", () => {
       ).toBeInTheDocument();
     });
 
-    it("displays additionalInfo fields when present", () => {
-      const requestDataWithInfo = {
-        ...mockRequestData,
-        additionalInfo: {
-          contact_number: "123-456-7890",
-          preferred_time: "Morning",
-        },
-      };
-
+    it("renders the AdditionalFieldsDisplay integration point, showing the empty state when requestId/requesterId are not provided", () => {
       renderWithProviders(
-        <RequestDescription requestData={requestDataWithInfo} />,
+        <RequestDescription requestData={mockRequestData} />,
         {
           preloadedState: MOCK_STATE_LOGGED_IN,
         },
       );
 
-      expect(screen.getByText("contact number")).toBeInTheDocument();
-
-      expect(screen.getByText("123-456-7890")).toBeInTheDocument();
-
-      expect(screen.getByText("preferred time")).toBeInTheDocument();
-
-      expect(screen.getByText("Morning")).toBeInTheDocument();
+      expect(
+        screen.getByText("No additional information available."),
+      ).toBeInTheDocument();
     });
 
     it("displays placeholder when attachments are not present", () => {

--- a/src/pages/RequestDetails/RequestDetails.jsx
+++ b/src/pages/RequestDetails/RequestDetails.jsx
@@ -390,6 +390,12 @@ const RequestDetails = () => {
                   <RequestDescription
                     requestData={requestData}
                     setIsEditing={setIsEditing}
+                    requestId={requestData?.id || requestId}
+                    requesterId={
+                      isMyRequest
+                        ? userDbId
+                        : requestData?.requesterId || userDbId
+                    }
                   />
                 )}
               </div>


### PR DESCRIPTION
Fixes #1456 (item 3)

## Summary
Shows the selected dynamic additional info fields (captured on Create Request) on the Request Details "Details" tab, read-only, per Rashmi's request: "we will show only the selected fields for that request and they will not be editable."

## Changes
  - New 'AdditionalFieldsDisplay' component:
  - Fetches via `POST v1/request/getAdditionalFields` with '{ requestId, requesterId }'
  - Resolves the request's category (name or numeric catId) to the numeric catId used to key into the app's metadata, reusing the same resolution logic as 'resolveCatNameToId' in 'HelpRequestForm.jsx'
  - Maps field/item codes back to human-readable labels using the same metadata 'FIELDS.'/'ITEMS.' translation pattern already
    used in 'DynamicAdditionalFields.jsx'
  - Handles multi-select array values (comma-joined), ISO date-time values (formatted in UTC to avoid timezone drift), and object-shaped values e.g. currency ranges (dash-joined instead of showing '[object Object]')
- Wired into 'RequestDescription.jsx''s existing "Additional Info" section - this replaces an already-present but unwired stub that
  read from 'requestData.additionalInfo', a field that's never populated and always showed the empty state
- Added 'requestId'/'requesterId' props to 'RequestDescription' resolved in 'RequestDetails.jsx' the same way as the existing
  delete-request flow (My Requests -> logged-in user's 'userDbId', All Requests -> 'requesterId' from the request object)

## Testing
- 11 new tests in 'AdditionalFieldsDisplay.test.jsx': loading/empty/ error states, single- and multi-select mapping, raw values, date formatting, object values, unmapped-field fallback, and category-name resolution
- Updated 1 stale 'RequestDescription' test that asserted the old stub's behavior
- Manually verified against the live API across three real cases: empty state, multi-select fields (Recipe Preference / Kitchen
  Equipment), and a currency-range object field (previously showed '[object Object]', now formatted correctly)
- All 95 tests in the RequestDetails folder passing