### PR TITLE
Add language dropdown to Create Help Request page (left of mic icon),…

### DIFF
--- a/src/pages/HelpRequest/HelpRequestForm.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.jsx
@@ -10,6 +10,7 @@ import "react-toastify/dist/ReactToastify.css"; // Don't forget to import the CS
 import { Tabs, Tab } from "../../common/components/Tabs/Tabs";
 import { loadCategories } from "../../redux/features/help_request/requestActions";
 import { FiPaperclip } from "react-icons/fi";
+import { changeUiLanguage } from "../../common/i18n/utils";
 import { mapHelpRequestPayload } from "../../utils/mapHelpRequestPayload";
 import {
   useAddRequestMutation,
@@ -222,6 +223,10 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
     lead_volunteer: "Ethan Marshall",
     is_calamity: false,
     preferred_language: (() => {
+      const saved = JSON.parse(localStorage.getItem("userPreferences") || "{}");
+      return saved.languagePreference1 || "";
+    })(),
+    request_language: (() => {
       const saved = JSON.parse(localStorage.getItem("userPreferences") || "{}");
       return saved.languagePreference1 || "";
     })(),
@@ -1748,7 +1753,7 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
 
                 {/* Description + Attach npmfiles icon */}
                 <div className="mt-3" data-testid="parentDivSeven">
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <label
                       htmlFor="description"
                       className="text-gray-700 font-medium mb-2 flex items-center gap-2"
@@ -1757,9 +1762,27 @@ const HelpRequestForm = ({ isEdit = false, onClose, editRequestData }) => {
                       <span className="text-red-500 m-1">*</span>(
                       {t("MAX_CHARACTERS", { count: 500 })})
                     </label>
-
-                    {/* Right side: Voice Recording Component and File Attachment */}
-                    <div className="flex items-center gap-3">
+                    {/* Right side: Language Dropdown, Voice Recording Component and File Attachment */}
+                    <div className="flex items-center gap-3 flex-wrap">
+                      {/* Language Dropdown - indicates the language of this request's text */}
+                      <select
+                        id="request_language"
+                        value={formData.request_language}
+                        onChange={(e) => {
+                          handleChange(e);
+                          changeUiLanguage({
+                            languagePreference1: e.target.value,
+                          });
+                        }}
+                        className="border border-gray-300 text-gray-700 rounded-lg p-2 text-sm bg-white min-w-0 max-w-[140px] flex-shrink"
+                        aria-label="Request language"
+                      >
+                        {languages.map((language) => (
+                          <option key={language.value} value={language.value}>
+                            {language.label}
+                          </option>
+                        ))}
+                      </select>
                       {/* Voice Recording Component */}
                       <VoiceRecordingComponent
                         onTranscriptionUpdate={(text) => {

--- a/src/pages/HelpRequest/HelpRequestForm.test.jsx
+++ b/src/pages/HelpRequest/HelpRequestForm.test.jsx
@@ -12,7 +12,7 @@ import HelpRequestForm from "./HelpRequestForm";
 import authReducer from "#redux/features/authentication/authSlice";
 import requestReducer from "../../redux/features/help_request/requestSlice";
 import { NotificationProvider } from "../../context/NotificationContext";
-
+import { changeUiLanguage } from "../../common/i18n/utils";
 /**
  * Stable t mock — the same jest.fn instance is returned on every useTranslation()
  * call. This prevents the infinite render loop that occurs when t is listed as a
@@ -94,6 +94,10 @@ jest.mock("../../services/audioServices", () => ({
 jest.mock("../../common/components/VoiceRecordingComponent", () => () => (
   <div data-testid="voice-recorder" />
 ));
+
+jest.mock("../../common/i18n/utils", () => ({
+  changeUiLanguage: jest.fn(),
+}));
 
 jest.mock("../../common/components/Loading/Loading.jsx", () => () => (
   <span data-testid="loading-spinner" />
@@ -3034,5 +3038,53 @@ describe("HelpRequestForm — Other person location field (#1622)", () => {
     );
     expect(callArgs.formData.otherPersonLocation).toBeUndefined();
     expect(callArgs.formData.otherPersonLocationCoordinates).toBeUndefined();
+  });
+});
+
+describe("HelpRequestForm — language dropdown (Create Request)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    changeUiLanguage.mockClear();
+  });
+
+  it("defaults to the user's saved first language preference", () => {
+    localStorage.setItem(
+      "userPreferences",
+      JSON.stringify({ languagePreference1: "Hindi" }),
+    );
+    renderForm();
+    const languageSelect = document.getElementById("request_language");
+    expect(languageSelect.value).toBe("Hindi");
+  });
+
+  it("falls back to the first language in the list when no preference is saved", () => {
+    renderForm();
+    const languageSelect = document.getElementById("request_language");
+    // Native <select> has no blank/placeholder option, so with an empty
+    // formData.request_language it falls back to displaying the first
+    // option in the list (Arabic, per languagesData.js) rather than blank.
+    expect(languageSelect.value).toBe("Arabic");
+  });
+
+  it("updates the selected value and calls changeUiLanguage when the user picks a different language", () => {
+    localStorage.setItem(
+      "userPreferences",
+      JSON.stringify({ languagePreference1: "Hindi" }),
+    );
+    renderForm();
+    const languageSelect = document.getElementById("request_language");
+    fireEvent.change(languageSelect, { target: { value: "Spanish" } });
+    expect(languageSelect.value).toBe("Spanish");
+    expect(changeUiLanguage).toHaveBeenCalledWith({
+      languagePreference1: "Spanish",
+    });
+  });
+
+  it("renders the language dropdown next to the voice recorder in the Description section", () => {
+    renderForm();
+    const languageSelect = document.getElementById("request_language");
+    const voiceRecorder = screen.getByTestId("voice-recorder");
+    expect(languageSelect).toBeInTheDocument();
+    expect(voiceRecorder).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
What was built:

1. Language dropdown added to the left of the microphone icon in the Description section
2. Defaults to the user's First Language Preference from the Preferences page
3. Fully changeable before typing, and syncs the site's UI language live when changed
4. Responsive layout — stacks cleanly on smaller screens instead of overflowing