### PR TITLE
Clear Auth0 and LinkedIn sessions on logout for LinkedIn users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { loginFailure } from "./redux/features/authentication/authSlice";
 import routes from "./routes/routes";
 import "react-datepicker/dist/react-datepicker.css";
 import "./App.css";
+import { completePendingLinkedInLogout } from "./utils/auth/linkedInLogout";
 
 const router = createBrowserRouter([
   {
@@ -22,6 +23,9 @@ const App = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    if (completePendingLinkedInLogout()) {
+      return undefined;
+    }
     const searchParams = new URLSearchParams(window.location.search);
     const hasOAuthRedirectParams =
       searchParams.has("code") ||

--- a/src/common/components/InactivityTimer/InactivityTimer.jsx
+++ b/src/common/components/InactivityTimer/InactivityTimer.jsx
@@ -16,7 +16,16 @@ const InactivityLogoutTimer = ({ children }) => {
   };
 
   const checkForInactivity = () => {
-    const expireTime = parseInt(localStorage.getItem("expireTime") || "0", 10);
+    const storedExpiry = localStorage.getItem("expireTime");
+
+    // No timestamp yet (fresh profile, or a social login that never set one):
+    // start the clock rather than treating the session as already expired.
+    if (!storedExpiry) {
+      updateExpiryTime();
+      return;
+    }
+
+    const expireTime = parseInt(storedExpiry, 10);
 
     if (expireTime < Date.now() && location.pathname !== "/") {
       dispatch(logout());

--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -32,6 +32,12 @@ import {
   updateUserProfileSuccess,
 } from "./authSlice";
 
+import {
+  clearLinkedInLogoutPending,
+  isLinkedInSession,
+  markLinkedInLogoutPending,
+} from "../../../utils/auth/linkedInLogout";
+
 export const checkAuthStatus = () => async (dispatch) => {
   dispatch(loginRequest());
   try {
@@ -218,10 +224,21 @@ export const updateUserProfile = (userData) => async (dispatch) => {
 export const logout = () => async (dispatch) => {
   try {
     returnDefaultLanguage();
-    await signOut();
+
+    // Step 1: detect the provider while the ID token still exists.
+    const linkedInUser = await isLinkedInSession();
+    if (linkedInUser) {
+      markLinkedInLogoutPending();
+    }
+
+    // Clear local state before signOut(): for federated users signOut()
+    // navigates the browser away, so code after it may not run.
     localStorage.removeItem("userDbId");
     dispatch(logoutSuccess());
+
+    await signOut();
   } catch (error) {
+    clearLinkedInLogoutPending();
     dispatch(loginFailure(error.message));
   }
 };

--- a/src/redux/features/authentication/authActions.test.js
+++ b/src/redux/features/authentication/authActions.test.js
@@ -188,8 +188,10 @@ describe("authActions", () => {
 
   describe("logout", () => {
     beforeEach(() => {
-      const { signOut } = require("aws-amplify/auth");
+      const { signOut, fetchAuthSession } = require("aws-amplify/auth");
       signOut.mockResolvedValue({});
+      fetchAuthSession.mockResolvedValue({});
+      window.sessionStorage.clear();
     });
 
     it("removes userDbId from localStorage on logout", async () => {
@@ -202,6 +204,34 @@ describe("authActions", () => {
       await logout()(dispatch);
 
       expect(dispatch).toHaveBeenCalledWith(logoutSuccess());
+    });
+
+    it("flags a pending LinkedIn logout for LinkedIn users", async () => {
+      const { fetchAuthSession } = require("aws-amplify/auth");
+      fetchAuthSession.mockResolvedValue({
+        tokens: {
+          idToken: { payload: { identities: [{ providerName: "LinkedIn" }] } },
+        },
+      });
+
+      await logout()(dispatch);
+
+      expect(window.sessionStorage.getItem("pendingLinkedInLogout")).toBe(
+        "auth0",
+      );
+    });
+
+    it("does not flag a LinkedIn logout for non-LinkedIn users", async () => {
+      const { fetchAuthSession } = require("aws-amplify/auth");
+      fetchAuthSession.mockResolvedValue({
+        tokens: {
+          idToken: { payload: { identities: [{ providerName: "Google" }] } },
+        },
+      });
+
+      await logout()(dispatch);
+
+      expect(window.sessionStorage.getItem("pendingLinkedInLogout")).toBeNull();
     });
 
     it("dispatches loginFailure when logout throws error", async () => {

--- a/src/utils/auth/linkedInLogout.js
+++ b/src/utils/auth/linkedInLogout.js
@@ -1,0 +1,196 @@
+import { fetchAuthSession } from "aws-amplify/auth";
+
+/**
+ * Provider name for LinkedIn as configured in the Cognito user pool.
+ */
+export const LINKEDIN_PROVIDER_NAME = "linkedin";
+
+/**
+ * Cognito federates to LinkedIn through an Auth0 tenant, so a LinkedIn user has
+ * FOUR sessions, not two:
+ *
+ *   Amplify tokens -> Cognito cookie -> Auth0 cookie -> LinkedIn cookie
+ *
+ * signOut() clears the first two. Testing in a clean browser profile confirmed
+ * that BOTH remaining sessions must be cleared: with the Auth0 session alive it
+ * re-issues an assertion without contacting LinkedIn, and with the LinkedIn
+ * session alive Auth0 simply re-asks LinkedIn, which answers silently.
+ *
+ * Auth0's ?federated parameter does NOT clear LinkedIn (LinkedIn publishes no
+ * OIDC end_session_endpoint), so LinkedIn has to be visited separately.
+ *
+ * Order matters: Auth0 first (it can return the browser to us), LinkedIn last
+ * (it cannot).
+ */
+export const AUTH0_DOMAIN = "dev-gdkev2n8pc4az5uh.us.auth0.com";
+export const AUTH0_CLIENT_ID = "GyMTjvWIZXBpoLJvgXoVW9G6U0beVUVD";
+
+/**
+ * Auth0 returns the browser here after clearing its session. Auth0 rejects any
+ * returnTo that is not in the application's Allowed Logout URLs, and /login is
+ * the path already registered for both localhost and the Netlify deployment,
+ * so the chain reuses it rather than depending on additional configuration.
+ */
+export const AUTH0_LOGOUT_RETURN_PATH = "/login";
+
+/** LinkedIn's own web logout. Terminal - it cannot return the user to us. */
+export const LINKEDIN_LOGOUT_URL = "https://www.linkedin.com/m/logout/";
+
+/**
+ * Tracks which stage of the logout chain we are in. Because every hop returns
+ * the browser to /login, the URL alone cannot tell us whether Auth0 still needs
+ * clearing, so the stage is held here. sessionStorage is per-tab, survives the
+ * redirect round trips, and is not wiped by the localStorage cleanup that
+ * logout performs.
+ */
+export const PENDING_LINKEDIN_LOGOUT_KEY = "pendingLinkedInLogout";
+
+/** Auth0 has yet to be cleared. */
+export const LOGOUT_STAGE_AUTH0 = "auth0";
+
+/** Auth0 is done; LinkedIn is the final hop. */
+export const LOGOUT_STAGE_LINKEDIN = "linkedin";
+
+/**
+ * True once a hop has been started during THIS page load.
+ *
+ * React StrictMode runs effects twice in development. Without this guard the
+ * second invocation reads the stage the first one just advanced to and fires
+ * the next hop immediately, which cancels the in-flight navigation. A real
+ * navigation reloads the module, so this resets naturally on the next page.
+ */
+let redirectStarted = false;
+
+/** Test-only: reset the per-page-load guard. */
+export const resetLogoutRedirectGuard = () => {
+  redirectStarted = false;
+};
+
+const normalize = (value) => String(value ?? "").toLowerCase();
+
+const safeParse = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+export const buildAuth0LogoutUrl = (origin = window.location.origin) => {
+  const returnTo = encodeURIComponent(`${origin}${AUTH0_LOGOUT_RETURN_PATH}`);
+  return `https://${AUTH0_DOMAIN}/v2/logout?client_id=${AUTH0_CLIENT_ID}&returnTo=${returnTo}`;
+};
+
+/**
+ * True when the currently signed-in user authenticated through LinkedIn.
+ * MUST be called before signOut(), because the ID token is gone afterwards.
+ */
+export const isLinkedInSession = async () => {
+  try {
+    const session = await fetchAuthSession();
+    const payload = session?.tokens?.idToken?.payload;
+
+    if (!payload) {
+      return false;
+    }
+
+    const rawIdentities = payload.identities ?? payload["cognito:identities"];
+    const identities =
+      typeof rawIdentities === "string"
+        ? safeParse(rawIdentities)
+        : rawIdentities;
+
+    if (Array.isArray(identities)) {
+      return identities.some(
+        (identity) =>
+          normalize(identity?.providerName) === LINKEDIN_PROVIDER_NAME,
+      );
+    }
+
+    // Fallback: federated Cognito usernames look like "linkedin_linkedin|abc".
+    return normalize(payload["cognito:username"]).startsWith(
+      `${LINKEDIN_PROVIDER_NAME}_`,
+    );
+  } catch (error) {
+    console.warn("Unable to resolve auth provider before logout:", error);
+    return false;
+  }
+};
+
+export const markLinkedInLogoutPending = () => {
+  try {
+    window.sessionStorage.setItem(
+      PENDING_LINKEDIN_LOGOUT_KEY,
+      LOGOUT_STAGE_AUTH0,
+    );
+  } catch {
+    // sessionStorage can be unavailable (private mode / blocked storage).
+    // Losing the flag only means the IdP sessions stay alive, which is the
+    // pre-existing behaviour, so fail quietly rather than blocking logout.
+  }
+};
+
+export const clearLinkedInLogoutPending = () => {
+  try {
+    window.sessionStorage.removeItem(PENDING_LINKEDIN_LOGOUT_KEY);
+  } catch {
+    // no-op
+  }
+};
+
+export const getLinkedInLogoutStage = () => {
+  try {
+    return window.sessionStorage.getItem(PENDING_LINKEDIN_LOGOUT_KEY);
+  } catch {
+    return null;
+  }
+};
+
+export const isLinkedInLogoutPending = () => getLinkedInLogoutStage() !== null;
+
+/**
+ * Steps 2 and 3 of the logout chain, driven by the stage flag. Each hop returns
+ * the browser to /login, where this runs again for the next stage:
+ *
+ *   stage "auth0"    -> Auth0 /v2/logout  (returns to /login)
+ *   stage "linkedin" -> LinkedIn /m/logout (terminal, cannot return)
+ *
+ * The stage is advanced BEFORE navigating so a re-render (React StrictMode runs
+ * effects twice in dev) or a back-button press cannot repeat a hop.
+ *
+ * @returns {boolean} true if a redirect was started, so callers can bail out.
+ */
+export const completePendingLinkedInLogout = () => {
+  // A hop is already navigating; do not start another and cancel it.
+  if (redirectStarted) {
+    return true;
+  }
+
+  const stage = getLinkedInLogoutStage();
+
+  if (stage === LOGOUT_STAGE_AUTH0) {
+    try {
+      window.sessionStorage.setItem(
+        PENDING_LINKEDIN_LOGOUT_KEY,
+        LOGOUT_STAGE_LINKEDIN,
+      );
+    } catch {
+      // If the stage cannot be persisted the chain would loop on Auth0, so
+      // stop here rather than redirect. The app session is already cleared.
+      return false;
+    }
+
+    redirectStarted = true;
+    window.location.assign(buildAuth0LogoutUrl());
+    return true;
+  }
+
+  if (stage === LOGOUT_STAGE_LINKEDIN) {
+    clearLinkedInLogoutPending();
+    redirectStarted = true;
+    window.location.assign(LINKEDIN_LOGOUT_URL);
+    return true;
+  }
+
+  return false;
+};

--- a/src/utils/auth/linkedInLogout.test.js
+++ b/src/utils/auth/linkedInLogout.test.js
@@ -1,0 +1,183 @@
+import {
+  AUTH0_CLIENT_ID,
+  AUTH0_DOMAIN,
+  LINKEDIN_LOGOUT_URL,
+  buildAuth0LogoutUrl,
+  LOGOUT_STAGE_LINKEDIN,
+  PENDING_LINKEDIN_LOGOUT_KEY,
+  completePendingLinkedInLogout,
+  isLinkedInLogoutPending,
+  isLinkedInSession,
+  markLinkedInLogoutPending,
+  resetLogoutRedirectGuard,
+} from "./linkedInLogout";
+
+jest.mock("aws-amplify/auth", () => ({
+  fetchAuthSession: jest.fn(),
+}));
+
+const { fetchAuthSession } = require("aws-amplify/auth");
+
+const sessionWithIdentities = (payload) => ({
+  tokens: { idToken: { payload } },
+});
+
+describe("linkedInLogout", () => {
+  let assignMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.sessionStorage.clear();
+    resetLogoutRedirectGuard();
+
+    assignMock = jest.fn();
+    delete window.location;
+    window.location = {
+      assign: assignMock,
+      href: "",
+      origin: "http://localhost",
+    };
+  });
+
+  describe("isLinkedInSession", () => {
+    it("detects a LinkedIn user from the identities claim", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({
+          identities: [{ providerName: "LinkedIn", userId: "abc" }],
+        }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(true);
+    });
+
+    it("detects a LinkedIn user when identities is a JSON string", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({
+          identities: JSON.stringify([{ providerName: "LinkedIn" }]),
+        }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(true);
+    });
+
+    it("detects a LinkedIn user from the cognito:identities claim", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({
+          "cognito:identities": [{ providerName: "linkedin" }],
+        }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(true);
+    });
+
+    it("falls back to the federated cognito:username prefix", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({ "cognito:username": "LinkedIn_abc123" }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(true);
+    });
+
+    it("returns false for Google users", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({ identities: [{ providerName: "Google" }] }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(false);
+    });
+
+    it("returns false for email/password users", async () => {
+      fetchAuthSession.mockResolvedValue(
+        sessionWithIdentities({ "cognito:username": "priyanka" }),
+      );
+
+      await expect(isLinkedInSession()).resolves.toBe(false);
+    });
+
+    it("returns false when there is no session", async () => {
+      fetchAuthSession.mockResolvedValue({});
+
+      await expect(isLinkedInSession()).resolves.toBe(false);
+    });
+
+    it("returns false instead of throwing when the session lookup fails", async () => {
+      fetchAuthSession.mockRejectedValue(new Error("no session"));
+
+      await expect(isLinkedInSession()).resolves.toBe(false);
+    });
+  });
+
+  describe("completePendingLinkedInLogout", () => {
+    it("does nothing when no logout is pending", () => {
+      expect(completePendingLinkedInLogout()).toBe(false);
+      expect(assignMock).not.toHaveBeenCalled();
+    });
+
+    it("redirects to Auth0 first when a logout is pending", () => {
+      markLinkedInLogoutPending();
+      expect(isLinkedInLogoutPending()).toBe(true);
+
+      expect(completePendingLinkedInLogout()).toBe(true);
+
+      const target = assignMock.mock.calls[0][0];
+      expect(target).toContain(AUTH0_DOMAIN);
+      expect(target).toContain(`client_id=${AUTH0_CLIENT_ID}`);
+      expect(target).toContain(
+        `returnTo=${encodeURIComponent("http://localhost/login")}`,
+      );
+    });
+
+    it("does not go straight to LinkedIn, since Auth0 must be cleared first", () => {
+      markLinkedInLogoutPending();
+
+      completePendingLinkedInLogout();
+
+      expect(assignMock).not.toHaveBeenCalledWith(LINKEDIN_LOGOUT_URL);
+    });
+
+    it("advances to the LinkedIn stage after the Auth0 hop", () => {
+      markLinkedInLogoutPending();
+      completePendingLinkedInLogout();
+
+      expect(window.sessionStorage.getItem(PENDING_LINKEDIN_LOGOUT_KEY)).toBe(
+        LOGOUT_STAGE_LINKEDIN,
+      );
+    });
+
+    it("only starts one navigation when the effect runs twice (StrictMode)", () => {
+      markLinkedInLogoutPending();
+
+      // React StrictMode invokes the effect twice within the same page load.
+      completePendingLinkedInLogout();
+      completePendingLinkedInLogout();
+
+      expect(assignMock).toHaveBeenCalledTimes(1);
+      expect(assignMock.mock.calls[0][0]).toContain(AUTH0_DOMAIN);
+    });
+
+    it("redirects to LinkedIn on the second pass and then stops", () => {
+      markLinkedInLogoutPending();
+
+      completePendingLinkedInLogout(); // Auth0
+      resetLogoutRedirectGuard(); // simulates the real page load after Auth0
+      expect(completePendingLinkedInLogout()).toBe(true); // LinkedIn
+
+      expect(assignMock).toHaveBeenLastCalledWith(LINKEDIN_LOGOUT_URL);
+      resetLogoutRedirectGuard();
+      expect(completePendingLinkedInLogout()).toBe(false);
+      expect(assignMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("buildAuth0LogoutUrl", () => {
+    it("points returnTo at the dedicated logout route on the current origin", () => {
+      const url = buildAuth0LogoutUrl("https://idptest-saayam.netlify.app");
+
+      expect(url).toContain(
+        `returnTo=${encodeURIComponent(
+          "https://idptest-saayam.netlify.app/login",
+        )}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Clear Auth0 and LinkedIn sessions on logout for LinkedIn users

Closes saayam-for-all/ba#69 (logout portion)

## Problem

Signing out of Saayam left the upstream identity provider sessions intact, so
the next "Sign in with LinkedIn" click silently re-authenticated the user with
no password prompt.

## What the ticket assumed vs. what is actually there

The ticket describes the chain as Saayam → Cognito → LinkedIn, and proposes
redirecting to `linkedin.com/m/logout` after our normal logout.

There is an **Auth0 tenant** (`dev-gdkev2n8pc4az5uh.us.auth0.com`) between
Cognito and LinkedIn that is not mentioned anywhere in the ticket. The real
chain has four sessions:

```
Amplify tokens  →  Cognito cookie  →  Auth0 cookie  →  LinkedIn cookie
```

Evidence: the Cognito federated username is `linkedin_linkedin|<sub>` — the pipe
is Auth0's user-id format — and the LinkedIn consent screen in
`Saayam_test_Case_Scenarios.pdf` shows a redirect to the Auth0 tenant.

## Test results

All runs in a fresh incognito window, verifying a password prompt on first login
to confirm a clean starting state.

| LinkedIn cleared | Auth0 cleared | Next login |
|---|---|---|
| yes | no  | silent → dashboard |
| no  | yes | silent → dashboard |
| yes | yes | **password prompt** |

Both must be cleared. With Auth0 alive it issues an assertion without contacting
LinkedIn; with LinkedIn alive, Auth0 re-asks LinkedIn and LinkedIn answers
silently.

Auth0's `?federated` parameter does **not** clear LinkedIn — LinkedIn publishes
no OIDC `end_session_endpoint`, so Auth0 cannot propagate the logout. LinkedIn
has to be visited separately.

## Approach

A staged logout driven by a `sessionStorage` flag. Each hop returns the browser
to `/login`, where the next stage runs:

```
Logout → Cognito /logout → /login → Auth0 /v2/logout → /login → linkedin.com/m/logout
```

Auth0 goes before LinkedIn because Auth0 can return the browser to us and
LinkedIn cannot.

Two failure modes this design avoids, both observed during development:

1. **Racing Amplify's own navigation.** In Amplify v6, `signOut()` navigates the
   page to Cognito's `/logout` for hosted-UI users. Calling
   `window.location.assign` immediately after `await signOut()` produces two
   competing navigations; depending on which wins, either the Cognito session
   survives or the user never reaches the IdP. Provider detection therefore
   happens *before* `signOut()`, and the external hops run on subsequent page
   loads.

2. **StrictMode double-invocation.** React StrictMode runs effects twice in
   development. Without a per-page-load guard, the second invocation reads the
   stage the first just advanced to and fires the next hop immediately,
   cancelling the in-flight navigation. This was observed in a network trace as
   the Auth0 request showing `(canceled)` at 0 bytes. A module-level guard
   ensures only one navigation starts per page load; it resets naturally because
   a real navigation reloads the module.

`returnTo` points at `/login` rather than a dedicated route because `/login` is
already registered in the Auth0 application's Allowed Logout URLs for both
localhost and the Netlify deployment. Auth0 rejects any unregistered `returnTo`.

## Also fixed: social logins were auto-logged-out after ~5 seconds

`expireTime` is only written by the email/password login path and by the
inactivity timer's own activity listeners. Social logins never set it, so
`InactivityTimer` read `0`, treated the session as expired, and dispatched
`logout()` within one 5-second tick of signing in. Any mouse movement masked it,
which is why it went unnoticed.

This is pre-existing and affects LinkedIn, Google, and Facebook equally — it can
be reproduced on `idptest` without any of the changes here. It is included in
this PR because otherwise the new logout redirect appears to fire spontaneously
seconds after login. Happy to split it out if reviewers prefer.

## Scope

- Non-LinkedIn providers and email/password logins are untouched (unit tested).
- Applies to both the navbar logout and the inactivity timeout, since both
  dispatch the same thunk.
- Config lives in `linkedInLogout.js` rather than `aws-exports.js`, which is
  marked "DO NOT EDIT".

## Testing

- `npm test` — 716 passing, 68 suites
- `npm run build` — clean
- Manual, fresh incognito per run:
  - LinkedIn login → logout → password prompt on next login ✅
  - Network trace confirms Cognito 302, Auth0 302, LinkedIn 200/303 ✅
  - Google login → logout → unchanged, no external redirect ✅
  - Facebook login → logout → unchanged ✅
  - Email/password login → logout → lands on `/login` ✅
  - No auto-logout after social login ✅

## Notes for reviewers

- Vaishnavi has an earlier LinkedIn logout commit on `feature/linkedin-signin`
  (6f912a6). It redirects only to LinkedIn and calls `window.location` directly
  after `signOut()`, so it hits both failure modes described above. That branch
  has also diverged from `idptest`.
- Known UX limitation: the user ends on LinkedIn's logged-out page rather than
  back on Saayam. LinkedIn offers no reliable post-logout return URL. An
  interstitial "Signing you out…" page would soften the transition; suggest a
  follow-up ticket rather than expanding this one.
- Separately noted, not fixed here: `handleLinkedInLogin` (and the Google and
  Facebook equivalents) throw `UserAlreadyAuthenticatedException` and only log to
  the console if a session already exists, so the button appears to do nothing.
  Worth its own issue.

## Config dependency

`https://idptest-saayam.netlify.app/login` and `http://localhost:5173/login` must
remain in the Auth0 application's Allowed Logout URLs. Removing either breaks the
chain at the Auth0 hop.
