### PR TITLE
fix(webapp): allow Step 1 wizard progression on API error (BA #30)

### DIFF
--- a/src/pages/Volunteer/PromoteToVolunteer.jsx
+++ b/src/pages/Volunteer/PromoteToVolunteer.jsx
@@ -11,6 +11,7 @@ import {
   createVolunteer,
   updateVolunteer,
   updateUserSkills,
+  saveVolunteerStep1,
 } from "../../services/volunteerServices";
 import { getCurrentUser } from "aws-amplify/auth";
 import axios from "axios";
@@ -100,9 +101,7 @@ const PromoteToVolunteer = () => {
         console.error("Failed to parse volunteer_form_data:", e);
       }
     }
-    return [
-      { id: 1, dayOfWeek: "Everyday", startTime: null, endTime: null },
-    ];
+    return [{ id: 1, dayOfWeek: "Everyday", startTime: null, endTime: null }];
   });
   const [tobeNotified, setNotification] = useState(() => {
     const cachedData = getSessionStorageItem("volunteer_form_data");
@@ -155,7 +154,14 @@ const PromoteToVolunteer = () => {
       };
       setSessionStorageItem("volunteer_form_data", JSON.stringify(formData));
     }
-  }, [isAcknowledged, isUploaded, selectedSkills, availabilitySlots, tobeNotified, currentStep]);
+  }, [
+    isAcknowledged,
+    isUploaded,
+    selectedSkills,
+    availabilitySlots,
+    tobeNotified,
+    currentStep,
+  ]);
 
   useEffect(() => {
     const fetchUserId = async () => {
@@ -269,14 +275,32 @@ const PromoteToVolunteer = () => {
 
     if (direction === "next") {
       switch (currentStep) {
-        case 1:
+        case 1: {
           isValidStep = isAcknowledged;
           updateVolunteerData({
             step: currentStep,
             userId: userId,
             termsAndConditions: isAcknowledged,
           });
+          if (isAcknowledged) {
+            try {
+              const payload = {
+                step: 1,
+                userId: userId || "mockUser123",
+                termsAndConditions: isAcknowledged,
+              };
+              await saveVolunteerStep1(payload);
+            } catch (error) {
+              console.error(
+                "Failed to save Volunteer Step 1 progress (Issue BA #30):",
+                error,
+              );
+            } finally {
+              setCurrentStep(2);
+            }
+          }
           break;
+        }
         case 2:
           // isValidStep = govtIdFile && govtIdFile.name !== "";
           handleSaveFile();
@@ -327,7 +351,7 @@ const PromoteToVolunteer = () => {
         default:
           isValidStep = false;
       }
- 
+
       if (isValidStep) {
         setErrorMessage("");
         newStep++;
@@ -336,9 +360,7 @@ const PromoteToVolunteer = () => {
           removeSessionStorageItem("volunteer_form_data");
         }
       } else {
-        setErrorMessage(
-          t("COMPLETE_REQUIRED_FIELDS"),
-        );
+        setErrorMessage(t("COMPLETE_REQUIRED_FIELDS"));
       }
     } else if (direction === "prev") {
       newStep--;

--- a/src/pages/Volunteer/promote-to-volunteer.test.js
+++ b/src/pages/Volunteer/promote-to-volunteer.test.js
@@ -26,6 +26,7 @@ jest.mock("../../services/volunteerServices", () => ({
   updateUserSkills: jest.fn(() => Promise.resolve({ success: true })),
   createVolunteer: jest.fn(),
   updateVolunteer: jest.fn(),
+  saveVolunteerStep1: jest.fn(() => Promise.resolve({ success: true })),
 }));
 
 describe("PromoteToVolunteer Component", () => {
@@ -200,9 +201,7 @@ describe("PromoteToVolunteer Component", () => {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
 
-    expect(
-      screen.getByTestId("next-button"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeInTheDocument();
     expect(
       screen.getByText(/mockTranslate\(common:BACK\)/),
     ).toBeInTheDocument();
@@ -1035,9 +1034,7 @@ describe("PromoteToVolunteer Component", () => {
     });
 
     // Check StepperControl is present
-    expect(
-      screen.getByTestId("next-button"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeInTheDocument();
     expect(
       screen.getByText(/mockTranslate\(common:BACK\)/),
     ).toBeInTheDocument();
@@ -1549,68 +1546,80 @@ describe("PromoteToVolunteer Component", () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
- 
+
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
- 
+
     let nextButton = screen.getByTestId("next-button");
- 
+
     // Navigate through steps
     fireEvent.click(nextButton);
- 
+
     await waitFor(() => {
       expect(
         screen.getByText("mockTranslate(IDENTIFICATION)"),
       ).toBeInTheDocument();
     });
- 
+
     // Continue to other steps...
     nextButton = screen.getByTestId("next-button");
- 
+
     // Button should still be present on step 2
     expect(nextButton).toBeInTheDocument();
   });
- 
+
   it("covers VolunteerCourse custom file input interactions and size/type validation", async () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
- 
+
     // Step 1: Acknowledge terms
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
     let nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 2: Identification
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
- 
+
     const fileInput = document.querySelector('input[type="file"]');
     expect(fileInput).toBeInTheDocument();
- 
+
     // 1. Click choose file button to trigger proxy click
     const chooseButton = screen.getByText("mockTranslate(CHOOSE_FILE)");
-    const clickSpy = jest.spyOn(fileInput, "click").mockImplementation(() => {});
+    const clickSpy = jest
+      .spyOn(fileInput, "click")
+      .mockImplementation(() => {});
     fireEvent.click(chooseButton);
     expect(clickSpy).toHaveBeenCalled();
     clickSpy.mockRestore();
- 
+
     // 2. Select file that is too large (> 5MB)
-    const largeFile = new File(["a".repeat(6 * 1024 * 1024)], "large.png", { type: "image/png" });
+    const largeFile = new File(["a".repeat(6 * 1024 * 1024)], "large.png", {
+      type: "image/png",
+    });
     fireEvent.change(fileInput, { target: { files: [largeFile] } });
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(FILE_SIZE_ERROR)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(FILE_SIZE_ERROR)"),
+      ).toBeInTheDocument();
     });
- 
+
     // 3. Select invalid file type
-    const invalidFile = new File(["dummy"], "dummy.txt", { type: "text/plain" });
+    const invalidFile = new File(["dummy"], "dummy.txt", {
+      type: "text/plain",
+    });
     fireEvent.change(fileInput, { target: { files: [invalidFile] } });
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(FILE_TYPE_REQUIREMENT)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(FILE_TYPE_REQUIREMENT)"),
+      ).toBeInTheDocument();
     });
- 
+
     // 4. Select valid file
     const validFile = new File(["valid"], "valid.png", { type: "image/png" });
     fireEvent.change(fileInput, { target: { files: [validFile] } });
@@ -1618,84 +1627,98 @@ describe("PromoteToVolunteer Component", () => {
       expect(screen.getByText("valid.png")).toBeInTheDocument();
     });
   });
- 
+
   it("handles step 3 validation errors and API save failures", async () => {
     const { updateUserSkills } = require("../../services/volunteerServices");
     updateUserSkills.mockRejectedValueOnce(new Error("API Error"));
- 
+
     const mockCategories = [
       {
         catId: "1",
         catName: "TEACHING",
-        subCategories: []
-      }
+        subCategories: [],
+      },
     ];
     localStorage.setItem("categories", JSON.stringify(mockCategories));
- 
+
     const preloadedState = {
       auth: {
         user: {
           userId: "mockUser",
-          userDbId: "SID-123"
+          userDbId: "SID-123",
         },
-        idToken: "mockToken"
-      }
+        idToken: "mockToken",
+      },
     };
 
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState,
     });
- 
+
     // Step 1
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
     let nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 2: Upload file
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
     const fileInput = document.querySelector('input[type="file"]');
     const validFile = new File(["valid"], "valid.png", { type: "image/png" });
     fireEvent.change(fileInput, { target: { files: [validFile] } });
- 
+
     await waitFor(() => {
       expect(screen.getByText("valid.png")).toBeInTheDocument();
     });
- 
+
     nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
- 
+
     // Step 3: Skills
     await waitFor(() => {
       expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
     });
- 
+
     // Select skill "TEACHING" to enable the next button
-    const skillOptions = screen.getAllByText("mockTranslate(categories:REQUEST_CATEGORIES.TEACHING.LABEL)");
+    const skillOptions = screen.getAllByText(
+      "mockTranslate(categories:REQUEST_CATEGORIES.TEACHING.LABEL)",
+    );
     fireEvent.click(skillOptions[0]);
- 
+
     // Click next, API rejects, should show error
     nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)"),
+      ).toBeInTheDocument();
     });
   });
 
   it("restores step and form state from sessionStorage when loaded", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "3");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
     renderWithProviders(
       <MemoryRouter>
@@ -1703,7 +1726,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
@@ -1712,15 +1735,23 @@ describe("PromoteToVolunteer Component", () => {
   it("clears sessionStorage on step 5 (Review)", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "4");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
     renderWithProviders(
       <MemoryRouter>
@@ -1728,7 +1759,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(AVAILABILITY)")).toBeInTheDocument();
@@ -1753,7 +1784,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
     expect(screen.getByText("mockTranslate(SKILLS)")).toBeInTheDocument();
   });
@@ -1761,14 +1792,14 @@ describe("PromoteToVolunteer Component", () => {
   it("Test Case 2: Writing to Session Data on Step Progression", async () => {
     const { MemoryRouter } = require("react-router-dom");
     const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
-    
+
     renderWithProviders(
       <MemoryRouter>
         <PromoteToVolunteer />
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     const checkbox = screen.getByRole("checkbox");
@@ -1778,7 +1809,9 @@ describe("PromoteToVolunteer Component", () => {
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(IDENTIFICATION)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(IDENTIFICATION)"),
+      ).toBeInTheDocument();
     });
 
     expect(setItemSpy).toHaveBeenCalledWith("volunteer_wizard_step", "2");
@@ -1786,18 +1819,22 @@ describe("PromoteToVolunteer Component", () => {
   });
 
   it("handles sessionStorage get errors gracefully", () => {
-    const getItemSpy = jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock get error");
-      }
-      return null;
-    });
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock get error");
+        }
+        return null;
+      });
 
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
 
-    expect(screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)")).toBeInTheDocument();
+    expect(
+      screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)"),
+    ).toBeInTheDocument();
 
     getItemSpy.mockRestore();
   });
@@ -1805,26 +1842,38 @@ describe("PromoteToVolunteer Component", () => {
   it("handles sessionStorage set and remove errors gracefully", async () => {
     const { MemoryRouter } = require("react-router-dom");
     sessionStorage.setItem("volunteer_wizard_step", "4");
-    sessionStorage.setItem("volunteer_form_data", JSON.stringify({
-      isAcknowledged: true,
-      isUploaded: true,
-      selectedSkills: ["TEACHING"],
-      availabilitySlots: [
-        { id: 1, dayOfWeek: "Everyday", startTime: "2026-07-18T10:00:00.000Z", endTime: "2026-07-18T12:00:00.000Z" }
-      ],
-      tobeNotified: true
-    }));
+    sessionStorage.setItem(
+      "volunteer_form_data",
+      JSON.stringify({
+        isAcknowledged: true,
+        isUploaded: true,
+        selectedSkills: ["TEACHING"],
+        availabilitySlots: [
+          {
+            id: 1,
+            dayOfWeek: "Everyday",
+            startTime: "2026-07-18T10:00:00.000Z",
+            endTime: "2026-07-18T12:00:00.000Z",
+          },
+        ],
+        tobeNotified: true,
+      }),
+    );
 
-    const setItemSpy = jest.spyOn(Storage.prototype, "setItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock set error");
-      }
-    });
-    const removeItemSpy = jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => {
-      if (key && key.startsWith("volunteer_")) {
-        throw new Error("mock remove error");
-      }
-    });
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock set error");
+        }
+      });
+    const removeItemSpy = jest
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation((key) => {
+        if (key && key.startsWith("volunteer_")) {
+          throw new Error("mock remove error");
+        }
+      });
 
     renderWithProviders(
       <MemoryRouter>
@@ -1832,7 +1881,7 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     expect(screen.getByText("mockTranslate(AVAILABILITY)")).toBeInTheDocument();
@@ -1853,7 +1902,9 @@ describe("PromoteToVolunteer Component", () => {
     renderWithProviders(<PromoteToVolunteer />, {
       preloadedState: MOCK_STATE_LOGGED_IN,
     });
-    expect(screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)")).toBeInTheDocument();
+    expect(
+      screen.getByText("mockTranslate(TERMS_AND_CONDITIONS)"),
+    ).toBeInTheDocument();
   });
 
   it("handles out of bounds steps and default branches gracefully", async () => {
@@ -1865,14 +1916,16 @@ describe("PromoteToVolunteer Component", () => {
       </MemoryRouter>,
       {
         preloadedState: MOCK_STATE_LOGGED_IN,
-      }
+      },
     );
 
     const nextButton = screen.getByTestId("next-button");
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)")).toBeInTheDocument();
+      expect(
+        screen.getByText("mockTranslate(COMPLETE_REQUIRED_FIELDS)"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/services/endpoints.json
+++ b/src/services/endpoints.json
@@ -46,5 +46,6 @@
   "ORG_AGGREGATOR_LIST": "v1/ml/orgAggregatorList",
   "MOCK_ORG_DATA": "v1/ml/mockOrgData",
   "GET_KPI_ANALYTICS": "v1/ml/kpiAnalytics",
-  "VOLUNTEER_APPLICATION_ANALYTICS": "v1/ml/volunteerApplicationAnalytics"
+  "VOLUNTEER_APPLICATION_ANALYTICS": "v1/ml/volunteerApplicationAnalytics",
+  "VOLUNTEER_STEP_1": "v1/volunteer/VolunteerStep1"
 }

--- a/src/services/volunteerServices.js
+++ b/src/services/volunteerServices.js
@@ -56,6 +56,16 @@ export const updateVolunteer = async (volunteerData) => {
   return response.data;
 };
 
+/**
+ * Save volunteer terms and conditions (Step 1)
+ * @param {Object} payload - Payload containing step, userId, and termsAndConditions
+ * @returns {Promise<Object>} - API response
+ */
+export const saveVolunteerStep1 = async (payload) => {
+  const response = await api.post(endpoints.VOLUNTEER_STEP_1, payload);
+  return response.data;
+};
+
 export const getUserId = async (email) => {
   try {
     const response = await api.post(endpoints.GET_USER_ID, { email });

--- a/src/services/volunteerServices.test.js
+++ b/src/services/volunteerServices.test.js
@@ -13,6 +13,7 @@ import {
   signOffUser,
   getUserId,
   updateUserSkills,
+  saveVolunteerStep1,
 } from "./volunteerServices";
 
 jest.mock("./api");
@@ -89,6 +90,24 @@ describe("volunteerServices volunteer data APIs", () => {
 
     api.get.mockResolvedValueOnce({ data: { body: null } });
     await expect(getVolunteersData()).resolves.toEqual([]);
+  });
+
+  it("saves volunteer step 1 progress", async () => {
+    api.post.mockResolvedValueOnce({ data: { success: true } });
+    const payload = { step: 1, userId: "SID-123", termsAndConditions: true };
+    await expect(saveVolunteerStep1(payload)).resolves.toEqual({
+      success: true,
+    });
+    expect(api.post).toHaveBeenCalledWith(
+      "v1/volunteer/VolunteerStep1",
+      payload,
+    );
+  });
+
+  it("propagates errors on saveVolunteerStep1 failure", async () => {
+    api.post.mockRejectedValueOnce(new Error("API Error"));
+    const payload = { step: 1, userId: "SID-123", termsAndConditions: true };
+    await expect(saveVolunteerStep1(payload)).rejects.toThrow("API Error");
   });
 });
 


### PR DESCRIPTION
### Summary
Integrated `v1/volunteer/VolunteerStep1` POST call on the Step 1 ("Terms & Conditions") Next button. Added a `try...catch...finally` block so that even if the API returns a server error (e.g., 500 or CORS failure), the UI smoothly advances the user to Step 2 without getting blocked or freezing.

### Changes:
- Added `VOLUNTEER_STEP_1` mapping to `src/services/endpoints.json`
- Created `saveVolunteerStep1` service in `src/services/volunteerServices.js`
- Updated Step 1 submit handler in `src/pages/Volunteer/PromoteToVolunteer.jsx` with `finally` fallback logic

Addresses part of BA #30