### PR TITLE
style: indent additional fields section under its header (#1456)

### DIFF
--- a/src/pages/RequestDetails/AdditionalFieldsDisplay.jsx
+++ b/src/pages/RequestDetails/AdditionalFieldsDisplay.jsx
@@ -157,7 +157,7 @@ const AdditionalFieldsDisplay = ({ requestId, requesterId, category }) => {
 
   return (
     <div
-      className="mt-3 mb-4 space-y-2"
+      className="mt-3 mb-4 ml-4 space-y-2"
       data-testid="additional-fields-display"
     >
       {entries.map(([fieldId, rawValue]) => {


### PR DESCRIPTION
Per feedback: add left margin to the additional fields block so it's visually distinguished as a sub-section under the 'Additional Information' header, rather than sitting flush with it.

All 15 AdditionalFieldsDisplay, 20 RequestDescription, and 5 RequestDetails tests passing.