### PR TITLE
fix(contact): improve form validation and accessibility (#1706)

### DIFF
--- a/src/common/components/PhoneNumberInputWithCountry.jsx
+++ b/src/common/components/PhoneNumberInputWithCountry.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useId } from "react";
 import PropTypes from "prop-types";
 import PHONECODESEN from "../../utils/phone-codes-en";
 import { getPhoneCodeslist } from "../../utils/utils";
@@ -81,6 +81,8 @@ const PhoneNumberInputWithCountry = ({
     return lengthMap[countryCode] || null;
   };
 
+  const errorId = useId();
+
   const handlePhoneChange = (e) => {
     const value = e.target.value;
     if (/^\d*$/.test(value)) {
@@ -142,8 +144,10 @@ const PhoneNumberInputWithCountry = ({
       <div className="flex space-x-2">
         <select
           id="countryCode"
+          name="countryCode"
           value={countryCode}
           onChange={handleCountryCodeChange}
+          aria-label={t("COUNTRY")}
           className="w-1/3 px-4 py-2 border border-gray-300 rounded-xl"
         >
           {getPhoneCodeslist(PHONECODESEN).map((option) => (
@@ -154,18 +158,28 @@ const PhoneNumberInputWithCountry = ({
         </select>
         <input
           id="phone"
+          name="phone"
           value={phone}
           onChange={handlePhoneChange}
           onBlur={handleBlur}
           placeholder={t("YOUR_PHONE_NUMBER")}
-          type="text"
+          type="tel"
+          inputMode="tel"
+          autoComplete="tel-national"
+          aria-label={hideLabel ? t("YOUR_PHONE_NUMBER") : undefined}
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? errorId : undefined}
           className={`w-2/3 px-4 py-2 border rounded-xl ${
             error ? "border-red-500" : "border-gray-300"
           }`}
           required={required}
         />
       </div>
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {error && (
+        <p id={errorId} role="alert" className="text-sm text-red-500">
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/common/components/PhoneNumberInputWithCountry.test.jsx
+++ b/src/common/components/PhoneNumberInputWithCountry.test.jsx
@@ -8,11 +8,16 @@ jest.mock("libphonenumber-js/max", () => ({
 
 jest.mock("../../utils/phone-codes-en", () => ({
   US: { primary: "United States", secondary: "+1" },
+  CA: { primary: "Canada", secondary: "+1" },
 }));
 
 const translate = (key) => key;
 
 describe("PhoneNumberInputWithCountry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("exposes accessible names and associates the phone error", () => {
     render(
       <PhoneNumberInputWithCountry
@@ -67,6 +72,73 @@ describe("PhoneNumberInputWithCountry", () => {
 
     expect(setPhone).toHaveBeenCalledWith("2025550125");
     expect(parsePhoneNumberFromString).toHaveBeenCalledWith("+12025550125");
+    expect(setError).toHaveBeenCalledWith(undefined);
+  });
+
+  it("ignores non-numeric input without changing consumer state", () => {
+    const setPhone = jest.fn();
+    const setError = jest.fn();
+
+    render(
+      <PhoneNumberInputWithCountry
+        phone=""
+        setPhone={setPhone}
+        countryCode="US"
+        setCountryCode={jest.fn()}
+        setError={setError}
+        t={translate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Phone Number"), {
+      target: { value: "202-abc" },
+    });
+
+    expect(setPhone).not.toHaveBeenCalled();
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("keeps required-field validation behavior on blur", () => {
+    const setError = jest.fn();
+
+    render(
+      <PhoneNumberInputWithCountry
+        phone=""
+        setPhone={jest.fn()}
+        countryCode="US"
+        setCountryCode={jest.fn()}
+        setError={setError}
+        required
+        t={translate}
+      />,
+    );
+
+    fireEvent.blur(screen.getByLabelText("Phone Number"));
+
+    expect(setError).toHaveBeenCalledWith("Phone number is required");
+  });
+
+  it("preserves country selection callbacks and clears stale errors", () => {
+    const setCountryCode = jest.fn();
+    const setError = jest.fn();
+
+    render(
+      <PhoneNumberInputWithCountry
+        phone="2025550125"
+        setPhone={jest.fn()}
+        countryCode="US"
+        setCountryCode={setCountryCode}
+        error="Please enter a valid phone number"
+        setError={setError}
+        t={translate}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "COUNTRY" }), {
+      target: { value: "CA" },
+    });
+
+    expect(setCountryCode).toHaveBeenCalledWith("CA");
     expect(setError).toHaveBeenCalledWith(undefined);
   });
 });

--- a/src/common/components/PhoneNumberInputWithCountry.test.jsx
+++ b/src/common/components/PhoneNumberInputWithCountry.test.jsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { parsePhoneNumberFromString } from "libphonenumber-js/max";
+import PhoneNumberInputWithCountry from "./PhoneNumberInputWithCountry";
+
+jest.mock("libphonenumber-js/max", () => ({
+  parsePhoneNumberFromString: jest.fn(),
+}));
+
+jest.mock("../../utils/phone-codes-en", () => ({
+  US: { primary: "United States", secondary: "+1" },
+}));
+
+const translate = (key) => key;
+
+describe("PhoneNumberInputWithCountry", () => {
+  it("exposes accessible names and associates the phone error", () => {
+    render(
+      <PhoneNumberInputWithCountry
+        phone="123"
+        setPhone={jest.fn()}
+        countryCode="US"
+        setCountryCode={jest.fn()}
+        error="Please enter a valid phone number"
+        setError={jest.fn()}
+        hideLabel
+        required
+        t={translate}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "COUNTRY" })).toBeTruthy();
+
+    const phoneInput = screen.getByRole("textbox", {
+      name: "YOUR_PHONE_NUMBER",
+    });
+    const error = screen.getByRole("alert");
+
+    expect(phoneInput.type).toBe("tel");
+    expect(phoneInput.inputMode).toBe("tel");
+    expect(phoneInput.autocomplete).toBe("tel-national");
+    expect(phoneInput.getAttribute("aria-invalid")).toBe("true");
+    expect(phoneInput.getAttribute("aria-describedby")).toBe(error.id);
+  });
+
+  it("clears the error after a valid phone number is entered", () => {
+    const setPhone = jest.fn();
+    const setError = jest.fn();
+    parsePhoneNumberFromString.mockReturnValue({
+      isPossible: () => true,
+      isValid: () => true,
+    });
+
+    render(
+      <PhoneNumberInputWithCountry
+        phone=""
+        setPhone={setPhone}
+        countryCode="US"
+        setCountryCode={jest.fn()}
+        setError={setError}
+        t={translate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Phone Number"), {
+      target: { value: "2025550125" },
+    });
+
+    expect(setPhone).toHaveBeenCalledWith("2025550125");
+    expect(parsePhoneNumberFromString).toHaveBeenCalledWith("+12025550125");
+    expect(setError).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/pages/Contact/ContactUs.jsx
+++ b/src/pages/Contact/ContactUs.jsx
@@ -40,6 +40,9 @@ const REASON_MAP = {
   DONATION_GRANT: "Donation",
 };
 
+const NAME_MAX_LENGTH = 100;
+const MESSAGE_MAX_LENGTH = 2000;
+
 const ContactUs = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -127,7 +130,7 @@ const ContactUs = () => {
     if (!formData.reason) {
       newErrors.reason = t("Please select a reason for contacting");
     }
-    if (!formData.message) {
+    if (!formData.message.trim()) {
       newErrors.message = t("Message is required");
     }
 
@@ -155,8 +158,8 @@ const ContactUs = () => {
           email: formData.email.trim(),
           phone: fullPhoneNumber,
           reason: REASON_MAP[formData.reason],
-          message: formData.message,
-          recaptchaToken: recaptchaToken,
+          message: formData.message.trim(),
+          recaptchaToken,
         });
 
         navigate("/thanks");
@@ -248,6 +251,8 @@ const ContactUs = () => {
                   margin="dense"
                   value={formData.firstName}
                   onChange={handleChange}
+                  autoComplete="given-name"
+                  inputProps={{ maxLength: NAME_MAX_LENGTH }}
                   required
                   error={!!errors.firstName}
                   helperText={errors.firstName}
@@ -272,6 +277,8 @@ const ContactUs = () => {
                   margin="dense"
                   value={formData.lastName}
                   onChange={handleChange}
+                  autoComplete="family-name"
+                  inputProps={{ maxLength: NAME_MAX_LENGTH }}
                   required
                   error={!!errors.lastName}
                   helperText={errors.lastName}
@@ -317,6 +324,8 @@ const ContactUs = () => {
                   margin="dense"
                   value={formData.email}
                   onChange={handleChange}
+                  type="email"
+                  autoComplete="email"
                   required
                   error={!!errors.email}
                   helperText={errors.email}
@@ -411,6 +420,7 @@ const ContactUs = () => {
                   rows={4}
                   value={formData.message}
                   onChange={handleChange}
+                  inputProps={{ maxLength: MESSAGE_MAX_LENGTH }}
                   required
                   error={!!errors.message}
                   helperText={errors.message}

--- a/src/pages/Contact/ContactUs.jsx
+++ b/src/pages/Contact/ContactUs.jsx
@@ -159,7 +159,7 @@ const ContactUs = () => {
           phone: fullPhoneNumber,
           reason: REASON_MAP[formData.reason],
           message: formData.message.trim(),
-          recaptchaToken,
+          recaptchaToken: recaptchaToken,
         });
 
         navigate("/thanks");

--- a/src/pages/Contact/ContactUs.test.js
+++ b/src/pages/Contact/ContactUs.test.js
@@ -35,27 +35,39 @@ jest.mock("../../utils/phone-codes-en", () => ({
 }));
 
 // Mock child components that have heavy dependencies
-jest.mock(
-  "../../common/components/PhoneNumberInputWithCountry",
-  () =>
-    function PhoneNumberInputWithCountryMock({ phone, setPhone, error }) {
-      return (
-        <div>
-          <input
-            aria-label="Phone Number"
-            data-testid="phone-input-mock"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-          />
-          {error ? <p>{error}</p> : null}
-        </div>
-      );
-    },
-);
+jest.mock("../../common/components/PhoneNumberInputWithCountry", () => {
+  const PropTypes = jest.requireActual("prop-types");
 
-jest.mock("#components/Ads/HorizontalAd", () => () => (
-  <div data-testid="horizontal-ad-mock" />
-));
+  function PhoneNumberInputWithCountryMock({ phone, setPhone, error }) {
+    return (
+      <div>
+        <input
+          aria-label="Phone Number"
+          data-testid="phone-input-mock"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        />
+        {error ? <p>{error}</p> : null}
+      </div>
+    );
+  }
+
+  PhoneNumberInputWithCountryMock.propTypes = {
+    phone: PropTypes.string.isRequired,
+    setPhone: PropTypes.func.isRequired,
+    error: PropTypes.string,
+  };
+
+  return PhoneNumberInputWithCountryMock;
+});
+
+jest.mock("#components/Ads/HorizontalAd", () => {
+  function HorizontalAdMock() {
+    return <div data-testid="horizontal-ad-mock" />;
+  }
+
+  return HorizontalAdMock;
+});
 
 jest.mock("react-phone-number-input", () => ({
   isValidPhoneNumber: jest.fn(),
@@ -97,7 +109,7 @@ const fillValidForm = () => {
     target: { name: "email", value: "  john@example.com  " },
   });
   fireEvent.change(screen.getByLabelText(/Message/i), {
-    target: { name: "message", value: "Need support" },
+    target: { name: "message", value: "  Need support  " },
   });
   fireEvent.change(screen.getByLabelText("Phone Number"), {
     target: { value: "2025550125" },
@@ -159,6 +171,26 @@ describe("ContactUs", () => {
       screen.getByText("Last Name should contain only letters"),
     ).toBeTruthy();
     expect(screen.getByText("Email is invalid")).toBeTruthy();
+  });
+
+  it("caps name and message inputs at the Lambda's limits", () => {
+    render(<ContactUs />);
+
+    expect(screen.getByLabelText(/First Name/i).maxLength).toBe(100);
+    expect(screen.getByLabelText(/Last Name/i).maxLength).toBe(100);
+    expect(screen.getByLabelText(/Message/i).maxLength).toBe(2000);
+  });
+
+  it("rejects a whitespace-only message", () => {
+    render(<ContactUs />);
+
+    fireEvent.change(screen.getByLabelText(/Message/i), {
+      target: { name: "message", value: "   " },
+    });
+    submitForm();
+
+    expect(screen.getByText("Message is required")).toBeTruthy();
+    expect(sendContactEmail).not.toHaveBeenCalled();
   });
 
   it("allows selecting a reason from the dropdown", () => {

--- a/src/pages/Contact/ContactUs.test.js
+++ b/src/pages/Contact/ContactUs.test.js
@@ -243,7 +243,7 @@ describe("ContactUs", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("submits successfully and navigates to thanks page", async () => {
+  it("preserves the Lambda payload contract and navigates to thanks page", async () => {
     mockExecuteRecaptcha.mockResolvedValue("captcha-token");
     sendContactEmail.mockResolvedValue({ ok: true });
     render(<ContactUs />);
@@ -266,6 +266,9 @@ describe("ContactUs", () => {
       message: "Need support",
       recaptchaToken: "captcha-token",
     });
+    expect(sendContactEmail.mock.calls[0][0]).not.toHaveProperty(
+      "recaptcha_token",
+    );
     expect(mockNavigate).toHaveBeenCalledWith("/thanks");
   });
 


### PR DESCRIPTION
## Description

Closes #1706

This follow-up now targets the current `test` branch and addresses the Contact Us validation and accessibility gaps found during verification.

## Changes

- Reject whitespace-only messages and trim message content before submission
- Limit first and last names to 100 characters
- Limit the message field to 2,000 characters to match the backend API
- Add browser autofill semantics for first name, last name, email, and phone
- Use the semantic telephone input type and mobile telephone input mode
- Give the country selector and hidden-label phone input accessible names
- Associate phone validation errors with the input for screen readers
- Add focused regression coverage

## Testing

- `npm test -- --runInBand src/common/components/PhoneNumberInputWithCountry.test.jsx src/pages/Contact/ContactUs.test.js src/services/contactServices.test.js` — 18 tests passed
- Targeted ESLint passed with zero warnings
- Prettier check passed
- `git diff --check` passed

## Notes

The branch was rebuilt on the latest `test` branch so the PR contains only the four Contact Us files related to this follow-up.