### PR TITLE
fix: rename Volunteers tab to Review Volunteers

### DIFF
--- a/src/pages/Dashboard/views/DashboardViews.test.jsx
+++ b/src/pages/Dashboard/views/DashboardViews.test.jsx
@@ -181,7 +181,7 @@ describe("Dashboard Views", () => {
     it("renders steward dashboard with tabs", () => {
       const { getByText } = render(<StewardDashboard {...defaultProps} />);
       expect(getByText("Review Requests")).toBeInTheDocument();
-      expect(getByText("Volunteers")).toBeInTheDocument();
+      expect(getByText("Review Volunteers")).toBeInTheDocument();
     });
 
     it("renders table when activeTab is allRequests", () => {

--- a/src/pages/Dashboard/views/StewardDashboard.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.jsx
@@ -83,7 +83,7 @@ const StewardDashboard = (props) => {
           }`}
           onClick={() => setActiveTab("volunteers")}
         >
-          Volunteers
+          Review Volunteers
         </button>
       </div>
 

--- a/src/pages/Dashboard/views/StewardDashboard.test.jsx
+++ b/src/pages/Dashboard/views/StewardDashboard.test.jsx
@@ -37,11 +37,11 @@ describe("StewardDashboard Component", () => {
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
     expect(screen.getByText("Review Requests")).toBeInTheDocument();
-    expect(screen.getByText("Volunteers")).toBeInTheDocument();
+    expect(screen.getByText("Review Volunteers")).toBeInTheDocument();
     expect(screen.getByText("Search Filters")).toBeInTheDocument();
   });
 
-  it("switches to Volunteers tab when clicked", async () => {
+  it("switches to Review Volunteers tab when clicked", async () => {
     const {
       getMockVolunteersData,
     } = require("../../../services/volunteerServices");
@@ -55,7 +55,7 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
+    const volunteersTab = screen.getByText("Review Volunteers");
     fireEvent.click(volunteersTab);
 
     await waitFor(() => {
@@ -85,7 +85,7 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
+    const volunteersTab = screen.getByText("Review Volunteers");
     fireEvent.click(volunteersTab);
 
     await waitFor(() => {
@@ -110,7 +110,7 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
+    const volunteersTab = screen.getByText("Review Volunteers");
     fireEvent.click(volunteersTab);
 
     await waitFor(() => {
@@ -143,7 +143,7 @@ describe("StewardDashboard Component", () => {
     );
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
-    fireEvent.click(screen.getByText("Volunteers"));
+    fireEvent.click(screen.getByText("Review Volunteers"));
 
     expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     expect(screen.queryByTestId("mock-table")).not.toBeInTheDocument();
@@ -181,7 +181,7 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
+    const volunteersTab = screen.getByText("Review Volunteers");
     fireEvent.click(volunteersTab);
 
     await waitFor(() => {
@@ -204,7 +204,7 @@ describe("StewardDashboard Component", () => {
 
     renderWithProviders(<StewardDashboard {...mockProps} />);
 
-    const volunteersTab = screen.getByText("Volunteers");
+    const volunteersTab = screen.getByText("Review Volunteers");
     fireEvent.click(volunteersTab);
 
     await waitFor(() => {


### PR DESCRIPTION
Renamed the Steward Dashboard tab from “Volunteers” to “Review Volunteers”.