### PR TITLE
Fixed login page bug

### DIFF
--- a/src/common/components/PhoneNumberInputWithCountry.jsx
+++ b/src/common/components/PhoneNumberInputWithCountry.jsx
@@ -55,10 +55,12 @@ const PhoneNumberInputWithCountry = ({
         </select>
         <input
           id="phone"
+          name="phone"
           value={phone}
           onChange={handlePhoneChange}
           placeholder={t("YOUR_PHONE_NUMBER")}
           type="text"
+          autoComplete="tel"
           className={`w-2/3 px-4 py-2 border rounded-xl ${
             error ? "border-red-500" : "border-gray-300"
           }`}

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -77,10 +77,12 @@ const LoginPage = () => {
           <label htmlFor="email">{t("EMAIL")}</label>
           <input
             id="email"
+            name="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
             placeholder={t("Email")}
             type="text"
+            autoComplete="username"
             className="px-4 py-2 border border-gray-300 rounded-xl"
             required={true}
           />
@@ -99,9 +101,11 @@ const LoginPage = () => {
           >
             <input
               id="password"
+              name="password"
               placeholder={t("Password")}
               value={passwordValue}
               type={passwordVisible ? "text" : "password"}
+              autoComplete="current-password"
               onChange={(e) => setPasswordValue(e.target.value)}
               onFocus={() => setPasswordFocus(true)}
               onBlur={() => setPasswordFocus(false)}

--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -211,10 +211,12 @@ const SignUp = () => {
           <label htmlFor="email">{t("EMAIL")}</label>
           <input
             id="email"
+            name="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
             placeholder={t("EMAIL")}
             type="text"
+            autoComplete="username"
             className={`px-4 py-2 border rounded-xl ${errors.email ? "border-red-500" : "border-gray-300"}`}
             required={true}
           />
@@ -252,9 +254,11 @@ const SignUp = () => {
           >
             <input
               id="password"
+              name="password"
               placeholder={t("PASSWORD")}
               value={passwordValue}
               type={passwordVisible ? "text" : "password"}
+              autoComplete="new-password"
               onChange={(e) => {
                 setPasswordValue(e.target.value);
                 setShowPasswordValidation(true);
@@ -322,9 +326,11 @@ const SignUp = () => {
           >
             <input
               id="confirmPassword"
+              name="confirmPassword"
               placeholder={t("CONFIRM_PASSWORD")}
               value={confirmPasswordValue}
               type={confirmPasswordVisible ? "text" : "password"}
+              autoComplete="new-password"
               onChange={(e) => setConfirmPasswordValue(e.target.value)}
               onFocus={() => setConfirmPasswordFocus(true)}
               onBlur={() => setConfirmPasswordFocus(false)}


### PR DESCRIPTION
## What 

Fixes issue #1774 

Adds proper `name` and `autocomplete` attributes to the Login and Signup form fields so the browser's password manager stops saving the user's phone number as their account username.

## Why

After signing up, users landing on the Login page saw their **phone number pre-filled in the Email field** (the password field was pre-filled too).

The Signup form field order is: First name → Last name → Email → **Phone** → Password. Because no field carried an `autocomplete` attribute, Chrome fell back to its heuristic of treating the text input immediately preceding the password field as the username, which is the phone field. When Chrome offered to save the credential, it stored `phone number + password` for the origin, and the Login page then faithfully replayed it.

Two things confirm the cause is the browser rather than our code:

- The Login component already initialises both fields to `""` and clears them again in a mount effect, yet they still appear populated.
- The password field is filled, and no code path in the app ever prefills a password.

It only reproduced on deployed environments, never on localhost, because Chrome scopes saved credentials by origin.