### PR TITLE
Added loading indicator to Sign Up button #1778

### DIFF
--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 import CountryList from "react-select-country-list";
 import PhoneNumberInputWithCountry from "../../common/components/PhoneNumberInputWithCountry";
+import LoadingIndicator from "../../common/components/Loading/Loading.jsx";
 import PHONECODESEN from "../../utils/phone-codes-en";
 import "./Login.css";
 const signUpSchema = z.object({
@@ -56,6 +57,7 @@ const SignUp = () => {
   const [confirmPasswordValue, setConfirmPasswordValue] = useState("");
   const [countryCode, setCountryCode] = useState("US");
   const [acceptedTOS, setAcceptedTOS] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   //Password variables
   const [passwordVisible, setPasswordVisible] = useState(false);
@@ -89,6 +91,8 @@ const SignUp = () => {
     );
 
   const handleSignUp = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       setErrors({});
       setPhoneEmptyError("");
@@ -161,6 +165,8 @@ const SignUp = () => {
         setErrors({ email: t("USER_ALREADY_EXISTS") });
       }
       console.log("Sign up error:", error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -389,13 +395,14 @@ const SignUp = () => {
           </label>
         </div>
         <button
-          className={`my-4 py-2 rounded-xl text-white 
-    ${acceptedTOS ? "bg-blue-400 hover:bg-blue-500 cursor-pointer" : "bg-blue-400 opacity-50 cursor-not-allowed"}
+          className={`my-4 py-2 rounded-xl text-white flex items-center justify-center gap-2
+    ${acceptedTOS && !isSubmitting ? "bg-blue-400 hover:bg-blue-500 cursor-pointer" : "bg-blue-400 opacity-50 cursor-not-allowed"}
   `}
           onClick={handleSignUp}
-          disabled={!acceptedTOS}
+          disabled={!acceptedTOS || isSubmitting}
         >
-          Sign up
+          <span>{isSubmitting ? "Signing up..." : "Sign up"}</span>
+          {isSubmitting && <LoadingIndicator size="20px" />}
         </button>
 
         {/* Uncomment this snippet when the signup functionality is fully developed  */}


### PR DESCRIPTION
Added `isSubmitting` state to disable the Sign Up button and show a loading spinner while the signup request is in flight, preventing accidental double submissions.

<img width="746" height="622" alt="Screenshot 2026-08-19 at 11 28 00 AM" src="https://github.com/user-attachments/assets/0154fd34-2e54-4e0b-bb0b-86c34f0f13fa" />
