### PR TITLE
fix 1778: Added loading indicator to Sign Up button 

### DIFF
--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 import CountryList from "react-select-country-list";
 import PhoneNumberInputWithCountry from "../../common/components/PhoneNumberInputWithCountry";
+import LoadingIndicator from "../../common/components/Loading/Loading.jsx";
 import PHONECODESEN from "../../utils/phone-codes-en";
 import "./Login.css";
 const signUpSchema = z.object({
@@ -56,6 +57,7 @@ const SignUp = () => {
   const [confirmPasswordValue, setConfirmPasswordValue] = useState("");
   const [countryCode, setCountryCode] = useState("US");
   const [acceptedTOS, setAcceptedTOS] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   //Password variables
   const [passwordVisible, setPasswordVisible] = useState(false);
@@ -89,6 +91,8 @@ const SignUp = () => {
     );
 
   const handleSignUp = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       setErrors({});
       setPhoneEmptyError("");
@@ -161,6 +165,8 @@ const SignUp = () => {
         setErrors({ email: t("USER_ALREADY_EXISTS") });
       }
       console.log("Sign up error:", error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -389,13 +395,14 @@ const SignUp = () => {
           </label>
         </div>
         <button
-          className={`my-4 py-2 rounded-xl text-white 
-    ${acceptedTOS ? "bg-blue-400 hover:bg-blue-500 cursor-pointer" : "bg-blue-400 opacity-50 cursor-not-allowed"}
+          className={`my-4 py-2 rounded-xl text-white flex items-center justify-center gap-2
+    ${acceptedTOS && !isSubmitting ? "bg-blue-400 hover:bg-blue-500 cursor-pointer" : "bg-blue-400 opacity-50 cursor-not-allowed"}
   `}
           onClick={handleSignUp}
-          disabled={!acceptedTOS}
+          disabled={!acceptedTOS || isSubmitting}
         >
-          Sign up
+          <span>{isSubmitting ? "Signing up..." : "Sign up"}</span>
+          {isSubmitting && <LoadingIndicator size="20px" />}
         </button>
 
         {/* Uncomment this snippet when the signup functionality is fully developed  */}

--- a/src/pages/Auth/Signup.test.jsx
+++ b/src/pages/Auth/Signup.test.jsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { signUp } from "aws-amplify/auth";
 import SignUp from "./Signup";
 
 jest.mock("aws-amplify/auth", () => ({ signUp: jest.fn() }));
@@ -43,6 +44,10 @@ jest.mock("../../utils/phone-codes-en", () => ({
 }));
 
 describe("SignUp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders the country dropdown with ISO Alpha-2 options", () => {
     render(<SignUp />);
     const select = screen.getByRole("combobox", { name: /country/i });
@@ -67,5 +72,94 @@ describe("SignUp", () => {
     const select = screen.getByRole("combobox", { name: /country/i });
     fireEvent.change(select, { target: { value: "AR" } });
     expect(select.value).toBe("AR");
+  });
+
+  const fillValidForm = () => {
+    fireEvent.change(screen.getByLabelText("FIRST_NAME"), {
+      target: { value: "Jane" },
+    });
+    fireEvent.change(screen.getByLabelText("LAST_NAME"), {
+      target: { value: "Doe" },
+    });
+    fireEvent.change(screen.getByLabelText("EMAIL"), {
+      target: { value: "jane.doe@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("PASSWORD"), {
+      target: { value: "Passw0rd!" },
+    });
+    fireEvent.change(screen.getByLabelText("CONFIRM_PASSWORD"), {
+      target: { value: "Passw0rd!" },
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+  };
+
+  it("disables the button and shows a loading state while sign up is in progress", async () => {
+    let resolveSignUp;
+    signUp.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignUp = resolve;
+      }),
+    );
+
+    render(<SignUp />);
+    fillValidForm();
+
+    const button = screen.getByRole("button", { name: "Sign up" });
+    fireEvent.click(button);
+
+    const submittingButton = await screen.findByRole("button", {
+      name: /Signing up.../,
+    });
+    expect(submittingButton).toBeDisabled();
+
+    resolveSignUp({ isSignUpComplete: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign up" }),
+      ).not.toBeDisabled();
+    });
+  });
+
+  it("does not trigger a second sign up call while one is already in progress", async () => {
+    let resolveSignUp;
+    signUp.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignUp = resolve;
+      }),
+    );
+
+    render(<SignUp />);
+    fillValidForm();
+
+    const button = screen.getByRole("button", { name: "Sign up" });
+    fireEvent.click(button);
+    await screen.findByRole("button", { name: /Signing up.../ });
+
+    fireEvent.click(screen.getByRole("button", { name: /Signing up.../ }));
+
+    expect(signUp).toHaveBeenCalledTimes(1);
+
+    resolveSignUp({ isSignUpComplete: false });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign up" }),
+      ).not.toBeDisabled();
+    });
+  });
+
+  it("re-enables the button after a failed sign up", async () => {
+    signUp.mockRejectedValue(new Error("network error"));
+
+    render(<SignUp />);
+    fillValidForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign up" }),
+      ).not.toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
Added `isSubmitting` state to disable the Sign Up button and show a loading spinner while the signup request is in flight, preventing double submissions.
<img width="746" height="622" alt="Screenshot 2026-08-19 at 11 28 00 AM" src="https://github.com/user-attachments/assets/c4f7f754-bdb6-40a7-a24f-aebb32a67592" />
