### PR TITLE
Fix: Prevent browser autofill from populating navbar search bar with saved email on Change Password page

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "#components/*": ["./src/common/components/*"],

--- a/src/common/components/Navbar/NavBar.css
+++ b/src/common/components/Navbar/NavBar.css
@@ -1,3 +1,15 @@
+/* Override Chrome's blue :-webkit-autofill highlight on the navbar search bar.
+   Chrome ignores `background-color` on autofilled inputs, so we paint over it
+   with an inset box-shadow and delay the transition for 5000s so it never fires. */
+input[name="navbar-search"]:-webkit-autofill,
+input[name="navbar-search"]:-webkit-autofill:hover,
+input[name="navbar-search"]:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px #fff inset !important;
+  box-shadow: 0 0 0 1000px #fff inset !important;
+  -webkit-text-fill-color: transparent !important;
+  transition: background-color 5000s ease-in-out 0s !important;
+}
+
 .navbar-gradient-bg {
   background: linear-gradient(
     90deg,

--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { NavLink, useNavigate } from "react-router-dom";
 import LOGO from "../../../assets/logo.svg";
+import "./NavBar.css";
 
 // Individual imports for outlined icons
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
@@ -79,6 +80,13 @@ const Navbar = () => {
 
   const handleSearchChange = (e) => {
     const value = e.target.value ?? "";
+    // Chrome credential autofill fires an InputEvent with no inputType and fills
+    // the field with the saved email. Genuine user interactions (typing, paste,
+    // cut, delete) always carry a non-empty inputType. Reject only when both
+    // conditions hold so legitimate programmatic updates are unaffected.
+    if (!e.nativeEvent?.inputType && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      return;
+    }
     setSearchText(value.slice(0, 80)); // hard limit 80 chars
   };
 
@@ -88,6 +96,7 @@ const Navbar = () => {
       // later: call API / navigate to search results
     }
   };
+
   const [volunteerOpenMenu, setVolunteerOpenMenu] = useState(false);
   const [aboutUsOpenMenu, setAboutUsOpenMenu] = useState(false);
   const [profileOpenMenu, setProfileOpenMenu] = useState(false);
@@ -439,7 +448,7 @@ const Navbar = () => {
               placeholder={t("SEARCH_PLACEHOLDER")}
               size="small"
               fullWidth
-              inputProps={{ maxLength: 80 }}
+              inputProps={{ maxLength: 80, autoComplete: "off" }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
@@ -504,7 +513,7 @@ const Navbar = () => {
                 placeholder={t("SEARCH_PLACEHOLDER")}
                 size="small"
                 fullWidth
-                inputProps={{ maxLength: 80 }}
+                inputProps={{ maxLength: 80, autoComplete: "off" }}
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">

--- a/src/common/components/Navbar/navbar.test.js
+++ b/src/common/components/Navbar/navbar.test.js
@@ -43,6 +43,23 @@ describe("Navbar", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("does not populate search text when an autofill-like event with an email value fires", () => {
+    renderWithProviders(<Navbar />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    const searchInput = screen.getAllByRole("textbox")[0];
+
+    // Simulate a Chrome credential-autofill event: no inputType + email value.
+    // The handler should reject this and leave searchText empty.
+    fireEvent.change(searchInput, {
+      target: { value: "user@example.com" },
+      nativeEvent: { inputType: undefined },
+    });
+
+    expect(searchInput.value).toBe("");
+  });
+
   it("clears the navbar search text when the user logs out and logs back in", async () => {
     const { store } = renderWithProviders(<Navbar />, {
       preloadedState: MOCK_STATE_LOGGED_IN,

--- a/src/pages/Profile/ChangePassword.jsx
+++ b/src/pages/Profile/ChangePassword.jsx
@@ -14,8 +14,13 @@ function ChangePassword({ setHasUnsavedChanges }) {
   const [showPassword, setShowPassword] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [passwordMatchError, setPasswordMatchError] = useState("");
+  // Starts readOnly so Chrome's autofill does not populate the navbar search bar;
+  // flipped to false on first user interaction with any password field.
+  const [passwordFieldsReadOnly, setPasswordFieldsReadOnly] = useState(true);
 
   const currentPasswordRef = useRef(null);
+
+  const handlePasswordFocus = () => setPasswordFieldsReadOnly(false);
 
   const handleSaveClick = async () => {
     let valid = true;
@@ -48,6 +53,7 @@ function ChangePassword({ setHasUnsavedChanges }) {
         setCurrentPassword("");
         setNewPassword("");
         setConfirmPassword("");
+        setPasswordFieldsReadOnly(true);
         alert(t("PASSWORD_CHANGE_SUCCESS"));
       } catch (error) {
         alert(error.message);
@@ -66,6 +72,7 @@ function ChangePassword({ setHasUnsavedChanges }) {
     setCurrentPassword("");
     setNewPassword("");
     setConfirmPassword("");
+    setPasswordFieldsReadOnly(true);
     setHasUnsavedChanges(false);
   };
 
@@ -82,6 +89,9 @@ function ChangePassword({ setHasUnsavedChanges }) {
               type={showPassword ? "text" : "password"}
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="new-password"
+              readOnly={passwordFieldsReadOnly}
+              onFocus={handlePasswordFocus}
               className="appearance-none block w-full bg-white-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
             />
             <div
@@ -101,6 +111,9 @@ function ChangePassword({ setHasUnsavedChanges }) {
               type={showPassword ? "text" : "password"}
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              readOnly={passwordFieldsReadOnly}
+              onFocus={handlePasswordFocus}
               className={`appearance-none block w-full bg-white-200 text-gray-700 border ${
                 errorMessage ? "border-red-500" : "border-gray-200"
               } rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500`}
@@ -126,6 +139,9 @@ function ChangePassword({ setHasUnsavedChanges }) {
               type={showPassword ? "text" : "password"}
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              readOnly={passwordFieldsReadOnly}
+              onFocus={handlePasswordFocus}
               className={`appearance-none block w-full bg-white-200 text-gray-700 border ${
                 passwordMatchError ? "border-red-500" : "border-gray-200"
               } rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500`}

--- a/src/pages/Profile/ChangePassword.test.jsx
+++ b/src/pages/Profile/ChangePassword.test.jsx
@@ -1,0 +1,300 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import ChangePassword from "./ChangePassword";
+import { updatePassword } from "aws-amplify/auth";
+
+// --- Mocks ---
+
+jest.mock("aws-amplify/auth", () => ({
+  updatePassword: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+jest.mock("react-icons/ai", () => ({
+  AiOutlineEye: () => <span data-testid="eye-icon" />,
+  AiOutlineEyeInvisible: () => <span data-testid="eye-invisible-icon" />,
+}));
+
+jest.mock("../../common/components/Loading/Loading", () => {
+  return function LoadingIndicator() {
+    return <div data-testid="loading-indicator" />;
+  };
+});
+
+// --- Helpers ---
+
+const mockSetHasUnsavedChanges = jest.fn();
+
+const renderComponent = () =>
+  render(<ChangePassword setHasUnsavedChanges={mockSetHasUnsavedChanges} />);
+
+// Helper: focus all three password inputs so they become editable
+const activateFields = () => {
+  const inputs = screen.getAllByRole("textbox", { hidden: true });
+  // password inputs are not "textbox" role; query by type
+  const passwordInputs = document.querySelectorAll(
+    'input[type="password"], input[type="text"]',
+  );
+  passwordInputs.forEach((input) => fireEvent.focus(input));
+};
+
+// --- Tests ---
+
+describe("ChangePassword", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.alert.mockRestore?.();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it("renders all three password field labels", () => {
+    renderComponent();
+    expect(screen.getByText("CURRENT_PASSWORD")).toBeInTheDocument();
+    expect(screen.getByText("NEW_PASSWORD")).toBeInTheDocument();
+    expect(screen.getByText("CONFIRM_PASSWORD")).toBeInTheDocument();
+  });
+
+  it("renders Save and Cancel buttons", () => {
+    renderComponent();
+    expect(screen.getByRole("button", { name: /SAVE/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /CANCEL/i })).toBeInTheDocument();
+  });
+
+  it("renders password requirement hint text", () => {
+    renderComponent();
+    expect(screen.getByText("PASSWORD_REQUIREMENTS")).toBeInTheDocument();
+  });
+
+  // ── Autofill protection: readOnly ──────────────────────────────────────────
+
+  it("all password inputs start as readOnly to prevent browser autofill", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute("readOnly");
+    });
+  });
+
+  it("all password inputs have autoComplete set to new-password", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute("autoComplete", "new-password");
+    });
+  });
+
+  it("password inputs become editable after the user focuses them", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    // Verify initially readOnly
+    inputs.forEach((input) => expect(input).toHaveAttribute("readOnly"));
+
+    // Focus the first input — all three should become editable
+    fireEvent.focus(inputs[0]);
+
+    inputs.forEach((input) => expect(input).not.toHaveAttribute("readOnly"));
+  });
+
+  it("password inputs return to readOnly after Cancel is clicked", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    // Activate fields and type something
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[0], { target: { value: "SomePass1!" } });
+
+    // Cancel resets readOnly
+    fireEvent.click(screen.getByRole("button", { name: /CANCEL/i }));
+
+    const freshInputs = document.querySelectorAll("input");
+    freshInputs.forEach((input) => expect(input).toHaveAttribute("readOnly"));
+  });
+
+  // ── Password visibility toggle ─────────────────────────────────────────────
+
+  it("password inputs default to type=password (hidden)", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute("type", "password");
+    });
+  });
+
+  it("toggles all inputs to type=text when the eye icon is clicked", () => {
+    renderComponent();
+
+    // Click any eye icon (they all share the same toggle)
+    const eyeIcons = screen.getAllByTestId("eye-icon");
+    fireEvent.click(eyeIcons[0]);
+
+    const inputs = document.querySelectorAll("input");
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute("type", "text");
+    });
+  });
+
+  it("toggles back to type=password when eye icon is clicked a second time", () => {
+    renderComponent();
+    const eyeIcons = screen.getAllByTestId("eye-icon");
+    fireEvent.click(eyeIcons[0]); // show
+    fireEvent.click(screen.getAllByTestId("eye-invisible-icon")[0]); // hide
+
+    const inputs = document.querySelectorAll("input");
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute("type", "password");
+    });
+  });
+
+  // ── Cancel ─────────────────────────────────────────────────────────────────
+
+  it("Cancel clears all three fields", () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[0], { target: { value: "CurrentPass1!" } });
+    fireEvent.change(inputs[1], { target: { value: "NewPass1!" } });
+    fireEvent.change(inputs[2], { target: { value: "NewPass1!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /CANCEL/i }));
+
+    document
+      .querySelectorAll("input")
+      .forEach((input) => expect(input.value).toBe(""));
+  });
+
+  it("Cancel calls setHasUnsavedChanges(false)", () => {
+    renderComponent();
+    fireEvent.click(screen.getByRole("button", { name: /CANCEL/i }));
+    expect(mockSetHasUnsavedChanges).toHaveBeenCalledWith(false);
+  });
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  it("shows a password requirements error when new password is too weak", async () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[1], { target: { value: "weak" } });
+    fireEvent.change(inputs[2], { target: { value: "weak" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("PASSWORD_REQUIREMENTS_ERROR"),
+      ).toBeInTheDocument();
+    });
+    expect(updatePassword).not.toHaveBeenCalled();
+  });
+
+  it("shows a mismatch error when new and confirm passwords differ", async () => {
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[1], { target: { value: "ValidPass1!" } });
+    fireEvent.change(inputs[2], { target: { value: "DifferentPass1!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("PASSWORD_MISMATCH_ERROR")).toBeInTheDocument();
+    });
+    expect(updatePassword).not.toHaveBeenCalled();
+  });
+
+  // ── Successful save ────────────────────────────────────────────────────────
+
+  it("calls updatePassword with correct args and clears fields on success", async () => {
+    updatePassword.mockResolvedValueOnce({});
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[0], { target: { value: "CurrentPass1!" } });
+    fireEvent.change(inputs[1], { target: { value: "NewPass1@" } });
+    fireEvent.change(inputs[2], { target: { value: "NewPass1@" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(updatePassword).toHaveBeenCalledWith({
+        oldPassword: "CurrentPass1!",
+        newPassword: "NewPass1@",
+      });
+    });
+
+    await waitFor(() => {
+      document
+        .querySelectorAll("input")
+        .forEach((input) => expect(input.value).toBe(""));
+    });
+
+    // Fields should be readOnly again after a successful save
+    document
+      .querySelectorAll("input")
+      .forEach((input) => expect(input).toHaveAttribute("readOnly"));
+  });
+
+  it("shows an alert on successful password change", async () => {
+    updatePassword.mockResolvedValueOnce({});
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[1], { target: { value: "NewPass1@" } });
+    fireEvent.change(inputs[2], { target: { value: "NewPass1@" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("PASSWORD_CHANGE_SUCCESS");
+    });
+  });
+
+  it("calls setHasUnsavedChanges(false) after a successful save", async () => {
+    updatePassword.mockResolvedValueOnce({});
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[1], { target: { value: "NewPass1@" } });
+    fireEvent.change(inputs[2], { target: { value: "NewPass1@" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(mockSetHasUnsavedChanges).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows an alert with the error message when updatePassword throws", async () => {
+    updatePassword.mockRejectedValueOnce(new Error("Incorrect password"));
+    renderComponent();
+    const inputs = document.querySelectorAll("input");
+
+    fireEvent.focus(inputs[0]);
+    fireEvent.change(inputs[1], { target: { value: "NewPass1@" } });
+    fireEvent.change(inputs[2], { target: { value: "NewPass1@" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /SAVE/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Incorrect password");
+    });
+  });
+});

--- a/src/pages/Volunteer/promote-to-volunteer.test.js
+++ b/src/pages/Volunteer/promote-to-volunteer.test.js
@@ -1814,7 +1814,9 @@ describe("PromoteToVolunteer Component", () => {
       ).toBeInTheDocument();
     });
 
-    expect(setItemSpy).toHaveBeenCalledWith("volunteer_wizard_step", "2");
+    await waitFor(() => {
+      expect(setItemSpy).toHaveBeenCalledWith("volunteer_wizard_step", "2");
+    });
     setItemSpy.mockRestore();
   });
 


### PR DESCRIPTION


### Summary

Fixes a bug where Chrome's credential autofill was populating the Navbar search bar with the user's saved email address when visiting the **Change Password** section of the Profile page.

---

### Problem

When a user navigated to **Profile → Change Password**, Chrome's credential autofill detected `type="password"` inputs on the page and heuristically filled the nearest visible text input — the Navbar search bar — with the saved email address. The email persisted in the search bar even after navigating away to other pages, because React state (`searchText`) had already been updated by the autofill event. Setting `autoComplete="off"` alone was insufficient as Chrome ignores this attribute for credential fields.

---

### Changes Made

#### `src/pages/Profile/ChangePassword.jsx`
- All three password inputs (`Current Password`, `New Password`, `Confirm Password`) now start with `readOnly={true}`. This prevents Chrome from recognizing them as active credential fields and triggering autofill on page load or credential-dropdown selection.
- A `handlePasswordFocus` handler flips `readOnly` to `false` the moment the user clicks any field, so typing works normally with no UX disruption.
- `readOnly` is reset to `true` after a successful Save or Cancel, restoring protection for the next visit to the tab.
- Added `autoComplete="new-password"` to all three inputs as an additional signal to the browser.

#### `src/common/components/Navbar/Navbar.jsx`
- `handleSearchChange` now guards against autofill events: Chrome credential autofill fires an `InputEvent` with no `inputType`, while all genuine user interactions (typing, paste, cut, delete) always carry a non-empty `inputType`. When both conditions hold — no `inputType` and the value matches an email pattern — the event is rejected and `searchText` is not updated.
- Added `import "./NavBar.css"` — the CSS file was only imported in the legacy `Navbarold.jsx` and was not applying to the active Navbar component.

#### `src/common/components/Navbar/NavBar.css`
- Added a `:-webkit-autofill` CSS override for `input[name="navbar-search"]` using the standard inset `box-shadow` trick. This suppresses Chrome's blue autofill highlight glow on the search bar even in cases where Chrome applies the visual state before React can reset the DOM value.

#### `jsconfig.json`
- Added `"ignoreDeprecations": "6.0"` to silence the TypeScript language-server warning about the deprecated `baseUrl` compiler option (no functional change).

---

### Tests Added / Updated

#### `src/pages/Profile/ChangePassword.test.jsx` *(new — 18 tests)*
Covers:
- All three fields render with correct labels
- All inputs start as `readOnly` (autofill protection)
- All inputs have `autoComplete="new-password"`
- Inputs become editable after user focuses them
- `readOnly` is restored after Cancel and successful Save
- Password visibility toggle (eye icon) shows/hides all inputs
- Cancel clears all fields and calls `setHasUnsavedChanges(false)`
- Validation: weak password error, password mismatch error
- Successful save: `updatePassword` called with correct args, fields cleared, alert shown, `setHasUnsavedChanges(false)` called
- Failed save: error alert shown from thrown exception

#### `src/common/components/Navbar/navbar.test.js` *(1 test added)*
- Verifies that a `change` event with no `inputType` and an email-formatted value does not update `searchText` (autofill rejection guard).

---

### How to Test

1. Log in and navigate to **Profile → Change Password**
2. Click the **Current Password** field and use Chrome's saved-password autofill dropdown to select credentials
3. **Before fix:** The saved email appeared in the Navbar search bar and persisted on navigation
4. **After fix:** The search bar remains empty; the password field accepts input normally after the first click
