### PR TITLE
Fix/dashboard filter localization 1748

### DIFF
--- a/src/common/i18n/locales/ar/common.json
+++ b/src/common/i18n/locales/ar/common.json
@@ -792,5 +792,7 @@
   "volunteers.": "المتطوعين.",
   "where the ethos of \"Manava Sevaye Madhava": "حيث تعكس فلسفة \"مانافا سيفا مادهافا\"",
   "without desecrating any beliefs.": "دون الإساءة لأي معتقد.",
-  "writeComment": "اكتب تعليقا"
+  "writeComment": "اكتب تعليقا",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ar/enums.json
+++ b/src/common/i18n/locales/ar/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "تم الإلغاء",
     "DELETED": "تم الحذف",
     "RATED_BY_REQUESTER": "تم التقييم من قبل مقدم الطلب",
-    "RATED_BY_VOLUNTEER": "تم التقييم من قبل المتطوع"
+    "RATED_BY_VOLUNTEER": "تم التقييم من قبل المتطوع",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "شخصياً",

--- a/src/common/i18n/locales/as/common.json
+++ b/src/common/i18n/locales/as/common.json
@@ -51,5 +51,7 @@
   "ENTER_VOLUNTEER_PHONE": "স্বেচ্ছাসেৱকৰ ফোন দিয়ক",
   "DELETE": "ডিলিট কৰক",
   "CHANGE_VOLUNTEER": "স্বেচ্ছাসেবক সলনি কৰক",
-  "DELETE_ACTION": "মচি পেলাওক"
+  "DELETE_ACTION": "মচি পেলাওক",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/as/enums.json
+++ b/src/common/i18n/locales/as/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "পৰিচালিত",
     "RESOLVED": "সমাধান কৰা হৈছে",
     "CANCELLED": "বাতিল কৰা হৈছে",
-    "DELETED": "মচি পেলোৱা হৈছে"
+    "DELETED": "মচি পেলোৱা হৈছে",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "ব্যক্তিগতভাৱে",

--- a/src/common/i18n/locales/bn/common.json
+++ b/src/common/i18n/locales/bn/common.json
@@ -792,5 +792,7 @@
   "voluntary organizations without": "স্বেচ্ছাসেবী সংস্থার সাথে মিলান",
   "volunteers.": "সায়াম ডলার ব্যবহার করুন।",
   "where the ethos of \"Manava Sevaye Madhava": "যেখানে \"মানব সেবায়ে মাধব",
-  "without desecrating any beliefs.": "কোনো বিশ্বাসের অবমাননা ছাড়াই।"
+  "without desecrating any beliefs.": "কোনো বিশ্বাসের অবমাননা ছাড়াই।",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/bn/enums.json
+++ b/src/common/i18n/locales/bn/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "বাতিল করা হয়েছে",
     "DELETED": "মুছে ফেলা হয়েছে",
     "RATED_BY_REQUESTER": "অনুরোধকারী দ্বারা মূল্যায়িত",
-    "RATED_BY_VOLUNTEER": "স্বেচ্ছাসেবক দ্বারা মূল্যায়িত"
+    "RATED_BY_VOLUNTEER": "স্বেচ্ছাসেবক দ্বারা মূল্যায়িত",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "সরাসরি",

--- a/src/common/i18n/locales/de/common.json
+++ b/src/common/i18n/locales/de/common.json
@@ -792,5 +792,7 @@
   "volunteers.": "Freiwillige zu motivieren.",
   "where the ethos of \"Manava Sevaye Madhava": "wo der Ethos von „Manava Sevaye Madhava",
   "without desecrating any beliefs.": "ohne Glaubensrichtungen zu verletzen.",
-  "writeComment": "schreibe einen Kommentar"
+  "writeComment": "schreibe einen Kommentar",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/de/enums.json
+++ b/src/common/i18n/locales/de/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Abgebrochen",
     "DELETED": "Gelöscht",
     "RATED_BY_REQUESTER": "Vom Antragsteller bewertet",
-    "RATED_BY_VOLUNTEER": "Vom Freiwilligen bewertet"
+    "RATED_BY_VOLUNTEER": "Vom Freiwilligen bewertet",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "Persönlich",

--- a/src/common/i18n/locales/doi/common.json
+++ b/src/common/i18n/locales/doi/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवक दा फोन दर्ज करो",
   "CHANGE_VOLUNTEER": "स्वयंसेवक बदलो",
   "DELETE": "हटाओ",
-  "DELETE_ACTION": "मिटाओ"
+  "DELETE_ACTION": "मिटाओ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/doi/enums.json
+++ b/src/common/i18n/locales/doi/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "प्रबंधत",
     "RESOLVED": "हल होया",
     "CANCELLED": "रद्द होया",
-    "DELETED": "मिटाया गेया"
+    "DELETED": "मिटाया गेया",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "खुद मिलीकरी",

--- a/src/common/i18n/locales/en/common.json
+++ b/src/common/i18n/locales/en/common.json
@@ -673,7 +673,7 @@
   "Want to join us?": "Want to join us?",
   "Watch our 5 minute video to understand how Saayam for All works and how we make a difference.": "Watch our 5 minute video to understand how Saayam for All works and how we make a difference.",
   "We don't just match-you get the smartest match possible.Our AI/ML engine find the right volunteer for you faster and more accuately, just like a ride share app- but smarter, more human, built for community care .": "We don't just match-you get the smartest match possible. Our AI/ML engine finds the right volunteer for you faster and more accurately, just like a rideshare app-but smarter, more human, built for community care.",
-  "We don't just match\u2014you get the smartest match possible. Our AI/ML engines find the right volunteer for you faster and more accurately, just like a ride share app\u2014but smarter, more human, and built for community care.": "We don't just match\u2014you get the smartest match possible.\nOur AI/ML engines find the right volunteer for you faster and more accurately, just like a ride share app\u2014but smarter, more human, and built for community care.",
+  "We don't just match—you get the smartest match possible. Our AI/ML engines find the right volunteer for you faster and more accurately, just like a ride share app—but smarter, more human, and built for community care.": "We don't just match—you get the smartest match possible.\nOur AI/ML engines find the right volunteer for you faster and more accurately, just like a ride share app—but smarter, more human, and built for community care.",
   "We offer a platform to connect volunteers with people who need help in areas like education, food, and healthcare.": "We offer a platform to connect volunteers with people who need help in areas like education, food, and healthcare.",
   "What services does Saayam for All offer?": "What services does Saayam for All offer?",
   "YES": "Yes",
@@ -798,8 +798,6 @@
   "ENTER_VOLUNTEER_EMAIL": "Enter volunteer email",
   "ENTER_VOLUNTEER_PHONE": "Enter volunteer phone",
   "SEARCH_TAGLINE": "google with human touch*",
-  "CREATION_DATE": "Creation Date",
-  "UPDATED_DATE": "Updated Date",
   "CREATED": "Created",
   "MATCHING_VOLUNTEER": "Matching Volunteer",
   "IN_PROGRESS": "In Progress",
@@ -820,5 +818,7 @@
   "STEP_NUMBER_4": "4",
   "STEP_NUMBER_5": "5",
   "DELETE_ACTION": "Delete",
-  "VOICE_NO_SPEECH_DETECTED": "No speech detected. Please try again and speak into your microphone while recording."
+  "VOICE_NO_SPEECH_DETECTED": "No speech detected. Please try again and speak into your microphone while recording.",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/en/enums.json
+++ b/src/common/i18n/locales/en/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Cancelled",
     "DELETED": "Deleted",
     "RATED_BY_REQUESTER": "Rated by Requester",
-    "RATED_BY_VOLUNTEER": "Rated by Volunteer"
+    "RATED_BY_VOLUNTEER": "Rated by Volunteer",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "In Person",

--- a/src/common/i18n/locales/es/common.json
+++ b/src/common/i18n/locales/es/common.json
@@ -791,5 +791,7 @@
   "volunteers.": "voluntarios.",
   "where the ethos of \"Manava Sevaye Madhava": "donde la ética de \"Manava Sevaye Madhava",
   "without desecrating any beliefs.": "sin profanar ninguna creencia.",
-  "writeComment": "escribe un comentario"
+  "writeComment": "escribe un comentario",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/es/enums.json
+++ b/src/common/i18n/locales/es/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Cancelado",
     "DELETED": "Eliminado",
     "RATED_BY_REQUESTER": "Calificado por el solicitante",
-    "RATED_BY_VOLUNTEER": "Calificado por el voluntario"
+    "RATED_BY_VOLUNTEER": "Calificado por el voluntario",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "En persona",

--- a/src/common/i18n/locales/fil/common.json
+++ b/src/common/i18n/locales/fil/common.json
@@ -47,5 +47,7 @@
   "FIND_BY_PHONE": "Hanapin sa telepono",
   "ENTER_VOLUNTEER_EMAIL": "Ilagay ang email ng boluntaryo",
   "ENTER_VOLUNTEER_PHONE": "Ilagay ang telepono ng boluntaryo",
-  "DELETE_ACTION": "Tanggalin"
+  "DELETE_ACTION": "Tanggalin",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/fil/enums.json
+++ b/src/common/i18n/locales/fil/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "Pinamamahalaan",
     "RESOLVED": "Nalutas",
     "CANCELLED": "Kinansela",
-    "DELETED": "Tinanggal"
+    "DELETED": "Tinanggal",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "Personal",

--- a/src/common/i18n/locales/fr/common.json
+++ b/src/common/i18n/locales/fr/common.json
@@ -792,5 +792,7 @@
   "volunteers.": "les bénévoles.",
   "where the ethos of \"Manava Sevaye Madhava": "où l'éthos de \"Manava Sevaye Madhava",
   "without desecrating any beliefs.": "sans profaner aucune croyance.",
-  "writeComment": "écrire un commentaire"
+  "writeComment": "écrire un commentaire",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/fr/enums.json
+++ b/src/common/i18n/locales/fr/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Annulé",
     "DELETED": "Supprimé",
     "RATED_BY_REQUESTER": "Évalué par le demandeur",
-    "RATED_BY_VOLUNTEER": "Évalué par le bénévole"
+    "RATED_BY_VOLUNTEER": "Évalué par le bénévole",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "En personne",

--- a/src/common/i18n/locales/gu/common.json
+++ b/src/common/i18n/locales/gu/common.json
@@ -52,5 +52,7 @@
   "ENTER_VOLUNTEER_PHONE": "સ્વયંસેવકનો ફોન દાખલ કરો",
   "CHANGE_VOLUNTEER": "સ્વયંસેવક બદલો",
   "DELETE": "કાઢી નાખો",
-  "DELETE_ACTION": "કાઢી નાખો"
+  "DELETE_ACTION": "કાઢી નાખો",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/gu/enums.json
+++ b/src/common/i18n/locales/gu/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "સંચાલિત",
     "RESOLVED": "ઉકેલાયું",
     "CANCELLED": "રદ કર્યું",
-    "DELETED": "કાઢી નાખ્યું"
+    "DELETED": "કાઢી નાખ્યું",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "રૂબરૂ",

--- a/src/common/i18n/locales/hi/common.json
+++ b/src/common/i18n/locales/hi/common.json
@@ -792,5 +792,7 @@
   "volunteers.": "सायम डॉलर का उपयोग करें।",
   "where the ethos of \"Manava Sevaye Madhava": "जहाँ \"मानव सेवाये माधव",
   "without desecrating any beliefs.": "बिना किसी मान्यता का अपमान किए।",
-  "writeComment": "एक टिप्पणी लिखें"
+  "writeComment": "एक टिप्पणी लिखें",
+  "CALAMITY": "विपत्ति",
+  "ALL_CATEGORIES": "सभी श्रेणियाँ"
 }

--- a/src/common/i18n/locales/hi/enums.json
+++ b/src/common/i18n/locales/hi/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "रद्द किया गया",
     "DELETED": "हटाया गया",
     "RATED_BY_REQUESTER": "अनुरोधकर्ता द्वारा रेट किया गया",
-    "RATED_BY_VOLUNTEER": "स्वयंसेवक द्वारा रेट किया गया"
+    "RATED_BY_VOLUNTEER": "स्वयंसेवक द्वारा रेट किया गया",
+    "IN_PROGRESS": "प्रगति में",
+    "VOLUNTEER_NOT_FOUND": "स्वयंसेवक नहीं मिला"
   },
   "requestType": {
     "IN_PERSON": "व्यक्तिगत रूप से",

--- a/src/common/i18n/locales/id/common.json
+++ b/src/common/i18n/locales/id/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "Masukkan telepon sukarelawan",
   "CHANGE_VOLUNTEER": "Tukar Sukarelawan",
   "DELETE": "Padam",
-  "DELETE_ACTION": "Hapus"
+  "DELETE_ACTION": "Hapus",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/id/enums.json
+++ b/src/common/i18n/locales/id/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "Dikelola",
     "RESOLVED": "Diselesaikan",
     "CANCELLED": "Dibatalkan",
-    "DELETED": "Dihapus"
+    "DELETED": "Dihapus",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "Langsung",

--- a/src/common/i18n/locales/ja/common.json
+++ b/src/common/i18n/locales/ja/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "ボランティアの電話番号を入力",
   "CHANGE_VOLUNTEER": "ボランティアを変更",
   "DELETE": "削除",
-  "DELETE_ACTION": "削除"
+  "DELETE_ACTION": "削除",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ja/enums.json
+++ b/src/common/i18n/locales/ja/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "管理中",
     "RESOLVED": "解決済み",
     "CANCELLED": "キャンセル済み",
-    "DELETED": "削除済み"
+    "DELETED": "削除済み",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "対面",

--- a/src/common/i18n/locales/kn/common.json
+++ b/src/common/i18n/locales/kn/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "ಸ್ವಯಂಸೇವಕರ ಫೋನ್ ನಮೂದಿಸಿ",
   "CHANGE_VOLUNTEER": "ಸ್ವಯಂಸೇವಕರನ್ನು ಬದಲಾಯಿಸಿ",
   "DELETE": "ಅಳಿಸಿ",
-  "DELETE_ACTION": "ಅಳಿಸಿ"
+  "DELETE_ACTION": "ಅಳಿಸಿ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/kn/enums.json
+++ b/src/common/i18n/locales/kn/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "ನಿರ್ವಹಿಸಲಾಗಿದೆ",
     "RESOLVED": "ಪರಿಹರಿಸಲಾಗಿದೆ",
     "CANCELLED": "ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ",
-    "DELETED": "ಅಳಿಸಲಾಗಿದೆ"
+    "DELETED": "ಅಳಿಸಲಾಗಿದೆ",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "ವೈಯಕ್ತಿಕವಾಗಿ",

--- a/src/common/i18n/locales/ko/common.json
+++ b/src/common/i18n/locales/ko/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "자원봉사자 전화번호 입력",
   "CHANGE_VOLUNTEER": "자원봉사자 변경",
   "DELETE": "삭제",
-  "DELETE_ACTION": "삭제"
+  "DELETE_ACTION": "삭제",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ko/enums.json
+++ b/src/common/i18n/locales/ko/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "관리 중",
     "RESOLVED": "해결됨",
     "CANCELLED": "취소됨",
-    "DELETED": "삭제됨"
+    "DELETED": "삭제됨",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "대면",

--- a/src/common/i18n/locales/mai/common.json
+++ b/src/common/i18n/locales/mai/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवकक फोन दर्ज करू",
   "CHANGE_VOLUNTEER": "स्वयंसेवक बदलू",
   "DELETE": "हटाऊ",
-  "DELETE_ACTION": "हटाउ"
+  "DELETE_ACTION": "हटाउ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/mai/enums.json
+++ b/src/common/i18n/locales/mai/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "प्रबंधित",
     "RESOLVED": "हल कएल गेल",
     "CANCELLED": "रद्द कएल गेल",
-    "DELETED": "मिटाओल गेल"
+    "DELETED": "मिटाओल गेल",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "व्यक्तिगत रूप सँ",

--- a/src/common/i18n/locales/ml/common.json
+++ b/src/common/i18n/locales/ml/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "സന്നദ്ധസേവകന്റെ ഫോൺ നൽകുക",
   "CHANGE_VOLUNTEER": "സന്നദ്ധസേവകനെ മാറ്റുക",
   "DELETE": "ഒഴിവാക്കുക",
-  "DELETE_ACTION": "ഇല്ലാതാക്കുക"
+  "DELETE_ACTION": "ഇല്ലാതാക്കുക",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ml/enums.json
+++ b/src/common/i18n/locales/ml/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "കൈകാര്യം ചെയ്തു",
     "RESOLVED": "പരിഹരിച്ചു",
     "CANCELLED": "റദ്ദാക്കി",
-    "DELETED": "ഇല്ലാതാക്കി"
+    "DELETED": "ഇല്ലാതാക്കി",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "നേരിട്ട്",

--- a/src/common/i18n/locales/mr/common.json
+++ b/src/common/i18n/locales/mr/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवकाचा फोन प्रविष्ट करा",
   "CHANGE_VOLUNTEER": "स्वयंसेवक बदला",
   "DELETE": "हटवा",
-  "DELETE_ACTION": "हटवा"
+  "DELETE_ACTION": "हटवा",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/mr/enums.json
+++ b/src/common/i18n/locales/mr/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "व्यवस्थापित",
     "RESOLVED": "निराकरण केले",
     "CANCELLED": "रद्द केले",
-    "DELETED": "हटवले"
+    "DELETED": "हटवले",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "वैयक्तिकरित्या",

--- a/src/common/i18n/locales/ne/common.json
+++ b/src/common/i18n/locales/ne/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवकको फोन प्रविष्ट गर्नुहोस्",
   "CHANGE_VOLUNTEER": "स्वयंसेवक परिवर्तन गर्नुहोस्",
   "DELETE": "हटाउनुहोस्",
-  "DELETE_ACTION": "मेटाउनुहोस्"
+  "DELETE_ACTION": "मेटाउनुहोस्",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ne/enums.json
+++ b/src/common/i18n/locales/ne/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "व्यवस्थित",
     "RESOLVED": "समाधान गरियो",
     "CANCELLED": "रद्द गरियो",
-    "DELETED": "मेटाइयो"
+    "DELETED": "मेटाइयो",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "व्यक्तिगत रूपमा",

--- a/src/common/i18n/locales/or/common.json
+++ b/src/common/i18n/locales/or/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "ସ୍ୱେଚ୍ଛାସେବୀଙ୍କ ଫୋନ ପ୍ରବିଷ୍ଟ କରନ୍ତୁ",
   "CHANGE_VOLUNTEER": "ସ୍ୱେଚ୍ଛାସେବୀ ପରିବର୍ତ୍ତନ କରନ୍ତୁ",
   "DELETE": "ବିଲୋପ କରନ୍ତୁ",
-  "DELETE_ACTION": "ବିଲୋପ କରନ୍ତୁ"
+  "DELETE_ACTION": "ବିଲୋପ କରନ୍ତୁ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/or/enums.json
+++ b/src/common/i18n/locales/or/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "ପରିଚାଳିତ",
     "RESOLVED": "ସମାଧାନ ହୋଇଛି",
     "CANCELLED": "ବାତିଲ ହୋଇଛି",
-    "DELETED": "ବିଲୋପ ହୋଇଛି"
+    "DELETED": "ବିଲୋପ ହୋଇଛି",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "ବ୍ୟକ୍ତିଗତଭାବେ",

--- a/src/common/i18n/locales/pa/common.json
+++ b/src/common/i18n/locales/pa/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "ਵਲੰਟੀਅਰ ਦਾ ਫ਼ੋਨ ਦਰਜ ਕਰੋ",
   "CHANGE_VOLUNTEER": "ਵਲੰਟੀਅਰ ਬਦਲੋ",
   "DELETE": "ਮਿਟਾਓ",
-  "DELETE_ACTION": "ਮਿਟਾਓ"
+  "DELETE_ACTION": "ਮਿਟਾਓ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/pa/enums.json
+++ b/src/common/i18n/locales/pa/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "ਪ੍ਰਬੰਧਿਤ",
     "RESOLVED": "ਹੱਲ ਕੀਤਾ ਗਿਆ",
     "CANCELLED": "ਰੱਦ ਕੀਤਾ ਗਿਆ",
-    "DELETED": "ਮਿਟਾਇਆ ਗਿਆ"
+    "DELETED": "ਮਿਟਾਇਆ ਗਿਆ",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "ਵਿਅਕਤੀਗਤ ਤੌਰ 'ਤੇ",

--- a/src/common/i18n/locales/pt/common.json
+++ b/src/common/i18n/locales/pt/common.json
@@ -800,5 +800,7 @@
   "volunteers.": "voluntários.",
   "where the ethos of \"Manava Sevaye Madhava": "onde o ethos de \"Manava Sevaye Madhava",
   "without desecrating any beliefs.": "sem desrespeitar quaisquer crenças.",
-  "writeComment": "escreva um comentário"
+  "writeComment": "escreva um comentário",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/pt/enums.json
+++ b/src/common/i18n/locales/pt/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Cancelado",
     "DELETED": "Excluído",
     "RATED_BY_REQUESTER": "Avaliado pelo solicitante",
-    "RATED_BY_VOLUNTEER": "Avaliado pelo voluntário"
+    "RATED_BY_VOLUNTEER": "Avaliado pelo voluntário",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "Presencial",

--- a/src/common/i18n/locales/ru/common.json
+++ b/src/common/i18n/locales/ru/common.json
@@ -792,5 +792,7 @@
   "voluntary organizations without": "волонтерскими организациями без",
   "volunteers.": "волонтеров.",
   "where the ethos of \"Manava Sevaye Madhava": "где этос \"Manava Sevaye Madhava",
-  "without desecrating any beliefs.": "без осквернения каких-либо убеждений."
+  "without desecrating any beliefs.": "без осквернения каких-либо убеждений.",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ru/enums.json
+++ b/src/common/i18n/locales/ru/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "Отменено",
     "DELETED": "Удалено",
     "RATED_BY_REQUESTER": "Оценено запросившим",
-    "RATED_BY_VOLUNTEER": "Оценено волонтёром"
+    "RATED_BY_VOLUNTEER": "Оценено волонтёром",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "Лично",

--- a/src/common/i18n/locales/sa/common.json
+++ b/src/common/i18n/locales/sa/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "स्वयंसेवकस्य फोन प्रविष्टं करोतु",
   "CHANGE_VOLUNTEER": "स्वयंसेवकं परिवर्तयतु",
   "DELETE": "विलोपयतु",
-  "DELETE_ACTION": "विलोपय"
+  "DELETE_ACTION": "विलोपय",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/sa/enums.json
+++ b/src/common/i18n/locales/sa/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "प्रबन्धितम्",
     "RESOLVED": "समाधितम्",
     "CANCELLED": "निरस्तम्",
-    "DELETED": "विलोपितम्"
+    "DELETED": "विलोपितम्",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "प्रत्यक्षम्",

--- a/src/common/i18n/locales/sd/common.json
+++ b/src/common/i18n/locales/sd/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "رضاڪار جو فون داخل ڪريو",
   "CHANGE_VOLUNTEER": "رضاڪار تبديل ڪريو",
   "DELETE": "ختਮ ڪريو",
-  "DELETE_ACTION": "حذف ڪريو"
+  "DELETE_ACTION": "حذف ڪريو",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/sd/enums.json
+++ b/src/common/i18n/locales/sd/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "منظم ٿيل",
     "RESOLVED": "حل ٿيو",
     "CANCELLED": "منسوخ ٿيو",
-    "DELETED": "ڊاٺو ويو"
+    "DELETED": "ڊاٺو ويو",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "ذاتي طور تي",

--- a/src/common/i18n/locales/ta/common.json
+++ b/src/common/i18n/locales/ta/common.json
@@ -52,5 +52,7 @@
   "ENTER_VOLUNTEER_PHONE": "தன்னார்வலர் தொலைபேசியை உள்ளிடுக",
   "CHANGE_VOLUNTEER": "தன்னார்வலரை மாற்றவும்",
   "DELETE": "நீக்கவும்",
-  "DELETE_ACTION": "நீக்கு"
+  "DELETE_ACTION": "நீக்கு",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ta/enums.json
+++ b/src/common/i18n/locales/ta/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "நிர்வகிக்கப்படுகிறது",
     "RESOLVED": "தீர்க்கப்பட்டது",
     "CANCELLED": "ரத்து செய்யப்பட்டது",
-    "DELETED": "நீக்கப்பட்டது"
+    "DELETED": "நீக்கப்பட்டது",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "நேரடியாக",

--- a/src/common/i18n/locales/te/common.json
+++ b/src/common/i18n/locales/te/common.json
@@ -791,5 +791,7 @@
   "volunteers.": "సాయం డాలర్లను ఉపయోగించండి.",
   "where the ethos of \"Manava Sevaye Madhava": "ఇక్కడ \"మానవ సేవయే మాధవ",
   "without desecrating any beliefs.": "ఎవరి నమ్మకాలను కూడా దూషించకుండా.",
-  "writeComment": "వ్యాఖ్య వ్రాయండి"
+  "writeComment": "వ్యాఖ్య వ్రాయండి",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/te/enums.json
+++ b/src/common/i18n/locales/te/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "రద్దు చేయబడింది",
     "DELETED": "తొలగించబడింది",
     "RATED_BY_REQUESTER": "అభ్యర్థి రేటింగ్ ఇచ్చారు",
-    "RATED_BY_VOLUNTEER": "స్వచ్ఛంద సేవకుడు రేటింగ్ ఇచ్చారు"
+    "RATED_BY_VOLUNTEER": "స్వచ్ఛంద సేవకుడు రేటింగ్ ఇచ్చారు",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "వ్యక్తిగతంగా",

--- a/src/common/i18n/locales/th/common.json
+++ b/src/common/i18n/locales/th/common.json
@@ -50,5 +50,7 @@
   "ENTER_VOLUNTEER_PHONE": "ป้อนเบอร์โทรอาสาสมัคร",
   "CHANGE_VOLUNTEER": "เปลี่ยนอาสาสมัคร",
   "DELETE": "ลบ",
-  "DELETE_ACTION": "ลบ"
+  "DELETE_ACTION": "ลบ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/th/enums.json
+++ b/src/common/i18n/locales/th/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "จัดการแล้ว",
     "RESOLVED": "แก้ไขแล้ว",
     "CANCELLED": "ยกเลิกแล้ว",
-    "DELETED": "ลบแล้ว"
+    "DELETED": "ลบแล้ว",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "พบตัว",

--- a/src/common/i18n/locales/tl/common.json
+++ b/src/common/i18n/locales/tl/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "Ilagay ang telepono ng boluntaryo",
   "CHANGE_VOLUNTEER": "Palitan ang Boluntaryo",
   "DELETE": "Burahin",
-  "DELETE_ACTION": "Tanggalin"
+  "DELETE_ACTION": "Tanggalin",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/tl/enums.json
+++ b/src/common/i18n/locales/tl/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "Pinamamahalaan",
     "RESOLVED": "Nalutas",
     "CANCELLED": "Kinansela",
-    "DELETED": "Tinanggal"
+    "DELETED": "Tinanggal",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "Personal",

--- a/src/common/i18n/locales/ur/common.json
+++ b/src/common/i18n/locales/ur/common.json
@@ -451,5 +451,7 @@
   "STEP_NUMBER_4": "۴",
   "STEP_NUMBER_5": "۵",
   "DELETE_ACTION": "حذف کریں",
-  "DONATION_GRANT": "عطیہ/گرانٹ"
+  "DONATION_GRANT": "عطیہ/گرانٹ",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/ur/enums.json
+++ b/src/common/i18n/locales/ur/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "منسوخ کیا گیا",
     "DELETED": "حذف کیا گیا",
     "RATED_BY_REQUESTER": "درخواست گزار نے درجہ بندی کی",
-    "RATED_BY_VOLUNTEER": "رضاکار نے درجہ بندی کی"
+    "RATED_BY_VOLUNTEER": "رضاکار نے درجہ بندی کی",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "ذاتی طور پر",

--- a/src/common/i18n/locales/vi/common.json
+++ b/src/common/i18n/locales/vi/common.json
@@ -49,5 +49,7 @@
   "ENTER_VOLUNTEER_PHONE": "Nhập số điện thoại tình nguyện viên",
   "CHANGE_VOLUNTEER": "Thay đổi tình nguyện viên",
   "DELETE": "Xóa",
-  "DELETE_ACTION": "Xóa"
+  "DELETE_ACTION": "Xóa",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/vi/enums.json
+++ b/src/common/i18n/locales/vi/enums.json
@@ -15,7 +15,9 @@
     "MANAGED": "Đã quản lý",
     "RESOLVED": "Đã giải quyết",
     "CANCELLED": "Đã hủy",
-    "DELETED": "Đã xóa"
+    "DELETED": "Đã xóa",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "INPERSON": "Trực tiếp",

--- a/src/common/i18n/locales/zh/common.json
+++ b/src/common/i18n/locales/zh/common.json
@@ -787,5 +787,7 @@
   "voluntary organizations without": "志愿组织匹配，而不",
   "volunteers.": "志愿者。",
   "where the ethos of \"Manava Sevaye Madhava": "其“服务人类即服务神”的理念",
-  "without desecrating any beliefs.": "不亵渎任何信仰。"
+  "without desecrating any beliefs.": "不亵渎任何信仰。",
+  "CALAMITY": "Calamity",
+  "ALL_CATEGORIES": "All Categories"
 }

--- a/src/common/i18n/locales/zh/enums.json
+++ b/src/common/i18n/locales/zh/enums.json
@@ -17,7 +17,9 @@
     "CANCELLED": "已取消",
     "DELETED": "已删除",
     "RATED_BY_REQUESTER": "由求助者评分",
-    "RATED_BY_VOLUNTEER": "由志愿者评分"
+    "RATED_BY_VOLUNTEER": "由志愿者评分",
+    "IN_PROGRESS": "In Progress",
+    "VOLUNTEER_NOT_FOUND": "Volunteer Not Found"
   },
   "requestType": {
     "IN_PERSON": "亲自",

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -502,7 +502,7 @@ const Dashboard = ({ userRole }) => {
         statusMap.set(normalized, {
           key: normalized,
           value: status,
-          label: status,
+          label: t(`enums:requestStatus.${normalized}`, status),
         });
       }
     });
@@ -595,11 +595,14 @@ const Dashboard = ({ userRole }) => {
     return getPriorityOptions(t);
   }, [t]);
 
-  const calamityOptions = [
-    { key: "All", value: "All", label: "All" },
-    { key: "Yes", value: "Yes", label: "Yes" },
-    { key: "No", value: "No", label: "No" },
-  ];
+  const calamityOptions = useMemo(
+    () => [
+      { key: "All", value: "All", label: t("ALL") },
+      { key: "Yes", value: "Yes", label: t("Yes") },
+      { key: "No", value: "No", label: t("No") },
+    ],
+    [t],
+  );
 
   // Helper function to get checked status for hierarchical categories
   const getCategoryCheckedStatus = (categoryPath, filterState) => {
@@ -1258,7 +1261,7 @@ const Dashboard = ({ userRole }) => {
                   onChange={() => handleCategoryChange("All")}
                   className="cursor-pointer"
                 />
-                <span className="font-semibold">{t("All Categories")}</span>
+                <span className="font-semibold">{t("ALL_CATEGORIES")}</span>
               </label>
               <div className="mt-2">
                 {categoryOptions.length > 0 &&
@@ -1274,7 +1277,7 @@ const Dashboard = ({ userRole }) => {
             tabIndex={0}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Status")}
+              {t("STATUS")}
               {getFilterBadgeCount(statusFilter, statusOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(statusFilter, statusOptions.length)}
@@ -1284,7 +1287,7 @@ const Dashboard = ({ userRole }) => {
             <IoIosArrowDown className="m-2" />
           </div>
           {isStatusDropdownOpen && (
-            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10 min-w-64">
+            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-10 min-w-64 max-h-64 overflow-y-auto">
               <label className="flex items-center gap-2 p-1 hover:bg-gray-50 rounded cursor-pointer">
                 <input
                   type="checkbox"
@@ -1295,7 +1298,7 @@ const Dashboard = ({ userRole }) => {
                   onChange={() => handleStatusChange("All")}
                   className="cursor-pointer"
                 />
-                <span>{t("All")}</span>
+                <span>{t("ALL")}</span>
               </label>
               {statusOptions.map((status) => (
                 <label
@@ -1308,7 +1311,7 @@ const Dashboard = ({ userRole }) => {
                     onChange={() => handleStatusChange(status.key)}
                     className="cursor-pointer"
                   />
-                  <span>{String(status.label).toUpperCase()}</span>
+                  <span>{status.label}</span>
                 </label>
               ))}
             </div>
@@ -1322,7 +1325,7 @@ const Dashboard = ({ userRole }) => {
             tabIndex={0}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Type")}
+              {t("TYPE")}
               {getFilterBadgeCount(typeFilter, typeOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(typeFilter, typeOptions.length)}
@@ -1357,7 +1360,7 @@ const Dashboard = ({ userRole }) => {
             onClick={togglePriorityDropdown}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Priority")}
+              {t("PRIORITY")}
               {getFilterBadgeCount(priorityFilter, priorityOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(priorityFilter, priorityOptions.length)}
@@ -1392,7 +1395,7 @@ const Dashboard = ({ userRole }) => {
             onClick={toggleCalamityDropdown}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Calamity")}
+              {t("CALAMITY")}
               {getFilterBadgeCount(calamityFilter, calamityOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(calamityFilter, calamityOptions.length)}
@@ -1496,7 +1499,7 @@ const Dashboard = ({ userRole }) => {
                 <option value="">Change Status</option>
                 {statusOptions.map((status) => (
                   <option key={status.key} value={status.key}>
-                    {String(status.label).toUpperCase()}
+                    {status.label}
                   </option>
                 ))}
               </select>
@@ -1634,7 +1637,7 @@ const Dashboard = ({ userRole }) => {
 
       <div className="border">
         {selectedDashboard && canAccessDashboard(groups, selectedDashboard) ? (
-          <div className="requests-section overflow-hidden table-height-fix">
+          <div className="requests-section table-height-fix">
             {selectedDashboard === DASHBOARDS.SUPER_ADMIN && (
               <SuperAdminDashboard
                 activeTab={activeTab}

--- a/src/utils/filterHelpers.js
+++ b/src/utils/filterHelpers.js
@@ -39,17 +39,15 @@ export const getCategoriesFromStorage = () => {
 export const getStatusOptions = (t) => {
   const enums = getEnumsFromStorage();
 
-  if (enums && Array.isArray(enums.requestStatus)) {
-    const options = enums.requestStatus.map((status) => ({
-      key: status,
-      value: status,
-      label: t(`enums:requestStatus.${status}`, status),
+  if (enums && enums.requestStatus) {
+    const statusValues = Object.values(enums.requestStatus);
+    const options = statusValues.map((value) => ({
+      key: value,
+      value: value,
+      label: t(`enums:requestStatus.${value}`, value),
     }));
 
-    return [
-      { key: "All", value: "All", label: t("common.All", "All") },
-      ...options,
-    ];
+    return options;
   }
 
   // Fallback to default values
@@ -89,18 +87,14 @@ export const getStatusOptions = (t) => {
  */
 export const getPriorityOptions = (t) => {
   const enums = getEnumsFromStorage();
-
   if (enums && enums.requestPriority) {
-    const priorityKeys = Object.keys(enums.requestPriority);
-    const options = priorityKeys.map((key) => ({
-      key: key,
-      value: enums.requestPriority[key],
-      label: t(`enums:requestPriority.${key}`, enums.requestPriority[key]),
+    const priorityValues = Object.values(enums.requestPriority);
+    const options = priorityValues.map((value) => ({
+      key: value,
+      value: value,
+      label: t(`enums:requestPriority.${value}`, value),
     }));
-    return [
-      { key: "All", value: "All", label: t("common.All", "All") },
-      ...options,
-    ];
+    return [{ key: "All", value: "All", label: t("ALL", "All") }, ...options];
   }
 
   // Fallback to default values
@@ -131,24 +125,19 @@ export const getPriorityOptions = (t) => {
  */
 export const getTypeOptions = (t) => {
   const enums = getEnumsFromStorage();
-
   if (enums && enums.requestType) {
-    const typeKeys = Object.keys(enums.requestType);
-    const options = typeKeys.map((key) => ({
-      key: key,
-      value: enums.requestType[key],
-      label: t(`enums:requestType.${key}`, enums.requestType[key]),
+    const typeValues = Object.values(enums.requestType);
+    const options = typeValues.map((value) => ({
+      key: value,
+      value: value,
+      label: t(`enums:requestType.${value}`, value),
     }));
-
-    return [
-      { key: "All", value: "All", label: t("common.All", "All") },
-      ...options,
-    ];
+    return [{ key: "All", value: "All", label: t("ALL", "All") }, ...options];
   }
 
   // Fallback
   return [
-    { key: "All", value: "All", label: t("common.All", "All") },
+    { key: "All", value: "All", label: t("ALL", "All") },
     {
       key: "IN_PERSON",
       value: "In Person",


### PR DESCRIPTION
1.Status: removed forced uppercase styling; fixed a bug where it never actually read from the real backend enums (was showing a stale hardcoded list missing 4 real statuses); fixed resulting duplicate "All" and scroll/clipping issues
2.Priority & Type: fixed a data-shape bug (Object.keys() on a numeric-indexed object) that silently broke translation in every non-English language
3.Calamity: added missing translation key; confirmed no backend enum exists for it (boolean field)
4.Category: added missing "All Categories" translation key
5.Filter labels: fixed to use keys that actually exist in all locale files