### PR TITLE
fix(auth): prevent phone autofill in login email (#1774)

### DIFF
--- a/src/common/components/PhoneNumberInputWithCountry.jsx
+++ b/src/common/components/PhoneNumberInputWithCountry.jsx
@@ -15,6 +15,8 @@ const PhoneNumberInputWithCountry = ({
   hideLabel = false,
   required = false,
   t = (x) => x,
+  name,
+  autoComplete,
 }) => {
   // Manual length checks for specific countries
   const getExpectedLength = (countryCode) => {
@@ -154,11 +156,13 @@ const PhoneNumberInputWithCountry = ({
         </select>
         <input
           id="phone"
+          name={name}
           value={phone}
           onChange={handlePhoneChange}
           onBlur={handleBlur}
           placeholder={t("YOUR_PHONE_NUMBER")}
           type="text"
+          autoComplete={autoComplete}
           className={`w-2/3 px-4 py-2 border rounded-xl ${
             error ? "border-red-500" : "border-gray-300"
           }`}
@@ -181,6 +185,8 @@ PhoneNumberInputWithCountry.propTypes = {
   required: PropTypes.bool,
   t: PropTypes.func,
   hideLabel: PropTypes.bool,
+  name: PropTypes.string,
+  autoComplete: PropTypes.string,
 };
 
 export default PhoneNumberInputWithCountry;

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -168,8 +168,8 @@ const LoginPage = () => {
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
             placeholder={t("common:EMAIL")}
-            type="text"
-            autoComplete="off"
+            type="email"
+            autoComplete="username"
             className="px-4 py-2 border border-gray-300 rounded-xl"
             required={true}
           />
@@ -192,7 +192,7 @@ const LoginPage = () => {
               placeholder={t("common:PASSWORD")}
               value={passwordValue}
               type={passwordVisible ? "text" : "password"}
-              autoComplete="off"
+              autoComplete="current-password"
               onChange={(e) => setPasswordValue(e.target.value)}
               onFocus={() => setPasswordFocus(true)}
               onBlur={() => setPasswordFocus(false)}

--- a/src/pages/Auth/Login.test.jsx
+++ b/src/pages/Auth/Login.test.jsx
@@ -59,15 +59,14 @@ describe("LoginPage", () => {
     expect(screen.getByLabelText(/PASSWORD/i)).toBeInTheDocument();
   });
 
-  it("disables browser auto-fill for the login fields", () => {
+  it("identifies the login fields correctly to browser auto-fill", () => {
     renderLogin();
-    expect(screen.getByLabelText(/EMAIL/i)).toHaveAttribute(
-      "autocomplete",
-      "off",
-    );
+    const emailInput = screen.getByLabelText(/EMAIL/i);
+    expect(emailInput).toHaveAttribute("type", "email");
+    expect(emailInput).toHaveAttribute("autocomplete", "username");
     expect(screen.getByLabelText(/PASSWORD/i)).toHaveAttribute(
       "autocomplete",
-      "off",
+      "current-password",
     );
   });
 

--- a/src/pages/Auth/Signup.jsx
+++ b/src/pages/Auth/Signup.jsx
@@ -184,10 +184,12 @@ const SignUp = () => {
             <label htmlFor="firstName">{t("FIRST_NAME")}</label>
             <input
               id="firstName"
+              name="given-name"
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
               placeholder={t("FIRST_NAME")}
               type="text"
+              autoComplete="given-name"
               className={`w-full px-4 py-2 border rounded-xl ${errors.firstName ? "border-red-500" : "border-gray-300"}`}
               required={true}
             />
@@ -201,10 +203,12 @@ const SignUp = () => {
             <label htmlFor="lastName">{t("LAST_NAME")}</label>
             <input
               id="lastName"
+              name="family-name"
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
               placeholder={t("LAST_NAME")}
               type="text"
+              autoComplete="family-name"
               className={`w-full px-4 py-2 border rounded-xl ${errors.lastName ? "border-red-500" : "border-gray-300"}`}
               required={true}
             />
@@ -219,10 +223,12 @@ const SignUp = () => {
           <label htmlFor="email">{t("EMAIL")}</label>
           <input
             id="email"
+            name="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
             placeholder={t("EMAIL")}
-            type="text"
+            type="email"
+            autoComplete="username"
             className={`px-4 py-2 border rounded-xl ${errors.email ? "border-red-500" : "border-gray-300"}`}
             required={true}
           />
@@ -243,6 +249,8 @@ const SignUp = () => {
             label={t("PHONE_NUMBER")}
             required={true}
             t={t}
+            name="phone"
+            autoComplete="tel-national"
           />
         </div>
 
@@ -251,8 +259,10 @@ const SignUp = () => {
           <label htmlFor="country">{t("COUNTRY")}</label>
           <select
             id="country"
+            name="country"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
+            autoComplete="country"
             className="px-4 py-2 border border-gray-300 rounded-xl"
           >
             {countries.map((c) => (
@@ -277,9 +287,11 @@ const SignUp = () => {
           >
             <input
               id="password"
+              name="password"
               placeholder={t("PASSWORD")}
               value={passwordValue}
               type={passwordVisible ? "text" : "password"}
+              autoComplete="new-password"
               onChange={(e) => {
                 setPasswordValue(e.target.value);
                 setShowPasswordValidation(true);
@@ -347,9 +359,11 @@ const SignUp = () => {
           >
             <input
               id="confirmPassword"
+              name="confirmPassword"
               placeholder={t("CONFIRM_PASSWORD")}
               value={confirmPasswordValue}
               type={confirmPasswordVisible ? "text" : "password"}
+              autoComplete="new-password"
               onChange={(e) => setConfirmPasswordValue(e.target.value)}
               onFocus={() => setConfirmPasswordFocus(true)}
               onBlur={() => setConfirmPasswordFocus(false)}

--- a/src/pages/Auth/Signup.test.jsx
+++ b/src/pages/Auth/Signup.test.jsx
@@ -27,13 +27,16 @@ jest.mock("react-phone-number-input", () => ({
   isValidPhoneNumber: jest.fn(() => true),
 }));
 
+const mockPhoneInputProps = {};
+
 jest.mock("../../common/components/PhoneNumberInputWithCountry", () => {
   const React = require("react");
   return function PhoneInputMock(props) {
+    Object.assign(mockPhoneInputProps, props);
     React.useLayoutEffect(() => {
-      props.setCountryCode?.("US");
-      props.setPhone?.("2345678901");
-      props.setError?.("");
+      mockPhoneInputProps.setCountryCode?.("US");
+      mockPhoneInputProps.setPhone?.("2345678901");
+      mockPhoneInputProps.setError?.("");
     }, []);
     return <div data-testid="phone-input-mock" />;
   };
@@ -72,6 +75,25 @@ describe("SignUp", () => {
     const select = screen.getByRole("combobox", { name: /country/i });
     fireEvent.change(select, { target: { value: "AR" } });
     expect(select.value).toBe("AR");
+  });
+
+  it("identifies signup fields correctly to browser auto-fill", () => {
+    render(<SignUp />);
+
+    expect(screen.getByLabelText("EMAIL")).toHaveAttribute(
+      "autocomplete",
+      "username",
+    );
+    expect(mockPhoneInputProps.name).toBe("phone");
+    expect(mockPhoneInputProps.autoComplete).toBe("tel-national");
+    expect(screen.getByLabelText("PASSWORD")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
+    expect(screen.getByLabelText("CONFIRM_PASSWORD")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
   });
 
   const fillValidForm = () => {


### PR DESCRIPTION
Fixes #1774

## Summary

The browser was treating the phone field on Sign Up as the account username, then filling that value into the Email field on Login. This change adds the correct autofill hints for email, phone, and password fields so saved credentials use the email address.

- Mark the signup email as the username and phone as a telephone field
- Distinguish new-password fields from the current-password login field
- Use the email input type on Sign Up and Login
- Add regression tests for the autofill attributes

## Testing

- `npm test -- --runInBand src/pages/Auth/Login.test.jsx src/pages/Auth/Signup.test.jsx src/pages/Auth/VerifyOtp.test.jsx` — 20 tests passed
- Prettier check passed for all changed files

## Note

The local production build currently stops because the installed dependencies are missing `howler`, which is already declared in `package.json`. This is unrelated to these changes.