### PR TITLE
fix: localize dashboard filter labels

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1237,7 +1237,7 @@ const Dashboard = ({ userRole }) => {
             tabIndex={0}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600 flex items-center gap-2">
-              {t("FILTER_BY")}
+              {t("CATEGORY")}
               {getSelectedCategoryCount() > 0 && (
                 <span className="bg-blue-500 text-white px-2 py-0.5 rounded-full text-sm font-semibold">
                   {getSelectedCategoryCount()}
@@ -1274,7 +1274,7 @@ const Dashboard = ({ userRole }) => {
             tabIndex={0}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Status")}
+              {t("STATUS")}
               {getFilterBadgeCount(statusFilter, statusOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(statusFilter, statusOptions.length)}
@@ -1322,7 +1322,7 @@ const Dashboard = ({ userRole }) => {
             tabIndex={0}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Type")}
+              {t("TYPE")}
               {getFilterBadgeCount(typeFilter, typeOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(typeFilter, typeOptions.length)}
@@ -1357,7 +1357,7 @@ const Dashboard = ({ userRole }) => {
             onClick={togglePriorityDropdown}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Priority")}
+              {t("PRIORITY")}
               {getFilterBadgeCount(priorityFilter, priorityOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(priorityFilter, priorityOptions.length)}
@@ -1392,7 +1392,7 @@ const Dashboard = ({ userRole }) => {
             onClick={toggleCalamityDropdown}
           >
             <button className="py-2 px-4 p-2 font-light text-gray-600">
-              {t("Calamity")}
+              {t("IS_CALAMITY")}
               {getFilterBadgeCount(calamityFilter, calamityOptions.length) && (
                 <span className="ml-1 bg-blue-500 text-white rounded-full px-2 py-0.5 text-xs">
                   {getFilterBadgeCount(calamityFilter, calamityOptions.length)}

--- a/src/pages/Dashboard/Dashboard.test.jsx
+++ b/src/pages/Dashboard/Dashboard.test.jsx
@@ -249,6 +249,25 @@ describe("Dashboard", () => {
     ]);
   });
 
+  it("translates dashboard filter labels when the language changes", async () => {
+    localStorage.setItem("environment", JSON.stringify("dev"));
+    const { findByText, getByText } = renderWithProviders(<Dashboard />, {
+      preloadedState: adminAuthState,
+    });
+
+    fireEvent.click(getByText("Click All Requests"));
+
+    await act(async () => {
+      await mockI18n.changeLanguage("es");
+    });
+
+    expect(await findByText("Categoría")).toBeInTheDocument();
+    expect(getByText("Estado")).toBeInTheDocument();
+    expect(getByText("tipo")).toBeInTheDocument();
+    expect(getByText("prioridad")).toBeInTheDocument();
+    expect(getByText("¿es una calamidad?")).toBeInTheDocument();
+  });
+
   it("falls back to English dashboard labels for an unsupported language", async () => {
     localStorage.setItem("environment", JSON.stringify("dev"));
     const { getByRole } = renderWithProviders(<Dashboard />, {


### PR DESCRIPTION
Fixes item 2 of #1748 by updating the dashboard filter labels so they display correctly in different languages. I also added a localization test and verified the changes manually in Hindi. All 40 Dashboard tests are passing. 