### PR TITLE
fix: category translation lookup and dropdown scroll clipping

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -521,7 +521,26 @@ const Dashboard = ({ userRole }) => {
         .filter(Boolean),
     );
 
-    if (categories && Array.isArray(categories) && dataCategoryNames.size > 0) {
+    if (categories && Array.isArray(categories) && categories.length > 0) {
+      const transformCategories = (cats) => {
+        return cats.map((cat) => ({
+          category: cat.catName,
+          label: t(
+            `categories:REQUEST_CATEGORIES.${cat.catName}.LABEL`,
+            cat.catName,
+          ),
+          subCategories:
+            cat.subCategories && cat.subCategories.length > 0
+              ? transformCategories(cat.subCategories)
+              : undefined,
+        }));
+      };
+
+      // If there's no request data yet, just use all API categories directly
+      if (dataCategoryNames.size === 0) {
+        return transformCategories(categories);
+      }
+
       // Check if API categories match the data categories
       const getAllCategoryNames = (cats) => {
         const names = [];
@@ -545,20 +564,6 @@ const Dashboard = ({ userRole }) => {
         matchCount >=
         Math.min(dataCategoryNames.size, apiCategoryNames.length) * 0.5
       ) {
-        const transformCategories = (cats) => {
-          return cats.map((cat) => ({
-            category: cat.catName,
-            label: t(
-              `categories:REQUEST_CATEGORIES.${cat.catId}.LABEL`,
-              cat.catName,
-            ),
-            subCategories:
-              cat.subCategories && cat.subCategories.length > 0
-                ? transformCategories(cat.subCategories)
-                : undefined,
-          }));
-        };
-
         return transformCategories(categories);
       }
 
@@ -1247,7 +1252,14 @@ const Dashboard = ({ userRole }) => {
             <IoIosArrowDown className="m-2" />
           </div>
           {isCategoryDropdownOpen && (
-            <div className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-50 min-w-64 max-h-64 overflow-y-auto">
+            <div
+              className="absolute bg-white border mt-1 p-2 rounded shadow-lg z-50 min-w-64"
+              style={{
+                maxHeight: "320px",
+                overflowY: "auto",
+                overflowX: "hidden",
+              }}
+            >
               <label className="flex items-center gap-2 p-1 hover:bg-gray-50 rounded cursor-pointer">
                 <input
                   type="checkbox"
@@ -1634,7 +1646,7 @@ const Dashboard = ({ userRole }) => {
 
       <div className="border">
         {selectedDashboard && canAccessDashboard(groups, selectedDashboard) ? (
-          <div className="requests-section overflow-hidden table-height-fix">
+          <div className="requests-section overflow-visible table-height-fix">
             {selectedDashboard === DASHBOARDS.SUPER_ADMIN && (
               <SuperAdminDashboard
                 activeTab={activeTab}

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -32,6 +32,7 @@ import {
   getPriorityOptions,
   getTypeOptions,
   getCategoriesFromStorage,
+  getDashboardCategoryOptions,
   normalizeTypeValue,
   normalizeStatusValue,
   normalizePriorityValue,
@@ -511,83 +512,7 @@ const Dashboard = ({ userRole }) => {
   }, [data, t]);
 
   const categoryOptions = useMemo(() => {
-    // Get categories from Categories API with hierarchical structure
-    const categories = getCategoriesFromStorage();
-
-    // Get all category names from actual data
-    const dataCategoryNames = new Set(
-      getRequestRows(data)
-        .map((r) => r.category)
-        .filter(Boolean),
-    );
-
-    if (categories && Array.isArray(categories) && categories.length > 0) {
-      const transformCategories = (cats) => {
-        return cats.map((cat) => ({
-          category: cat.catName,
-          label: t(
-            `categories:REQUEST_CATEGORIES.${cat.catName}.LABEL`,
-            cat.catName,
-          ),
-          subCategories:
-            cat.subCategories && cat.subCategories.length > 0
-              ? transformCategories(cat.subCategories)
-              : undefined,
-        }));
-      };
-
-      // If there's no request data yet, just use all API categories directly
-      if (dataCategoryNames.size === 0) {
-        return transformCategories(categories);
-      }
-
-      // Check if API categories match the data categories
-      const getAllCategoryNames = (cats) => {
-        const names = [];
-        cats.forEach((cat) => {
-          names.push(cat.catName);
-          if (cat.subCategories && cat.subCategories.length > 0) {
-            names.push(...getAllCategoryNames(cat.subCategories));
-          }
-        });
-        return names;
-      };
-
-      const apiCategoryNames = getAllCategoryNames(categories);
-      const matchCount = apiCategoryNames.filter((apiCat) =>
-        dataCategoryNames.has(apiCat),
-      ).length;
-
-      // Only use API categories if at least 50% match the data
-      // This ensures we use API categories for real data, but fall back for mock data
-      if (
-        matchCount >=
-        Math.min(dataCategoryNames.size, apiCategoryNames.length) * 0.5
-      ) {
-        return transformCategories(categories);
-      }
-
-      // API categories don't match data - use data categories instead
-      console.warn(
-        "API categories don't match data categories (matched " +
-          matchCount +
-          " out of " +
-          dataCategoryNames.size +
-          "), using data categories instead",
-      );
-    }
-
-    // Fallback: use categories from actual data
-    const backendValues = new Set(
-      getRequestRows(data)
-        .map((r) => r.category)
-        .filter(Boolean),
-    );
-    const combined = Array.from(backendValues);
-    return combined.sort().map((cat) => ({
-      category: cat,
-      label: cat,
-    }));
+    return getDashboardCategoryOptions(getRequestRows(data), t);
   }, [data, t]);
 
   const typeOptions = useMemo(() => {

--- a/src/utils/filterHelpers.js
+++ b/src/utils/filterHelpers.js
@@ -174,7 +174,10 @@ export const getCategoryOptions = (t) => {
     return categories.map((cat) => ({
       id: cat.catId,
       name: cat.catName,
-      label: t(`categories:REQUEST_CATEGORIES.${cat.catId}.LABEL`, cat.catName),
+      label: t(
+        `categories:REQUEST_CATEGORIES.${cat.catName}.LABEL`,
+        cat.catName,
+      ),
       subcategories: cat.subcategories || [],
     }));
   }
@@ -200,7 +203,7 @@ export const flattenCategories = (categories, t, depth = 0) => {
       label:
         cat.label ||
         t(
-          `categories:REQUEST_CATEGORIES.${cat.id || cat.catId}.LABEL`,
+          `categories:REQUEST_CATEGORIES.${cat.name || cat.catName}.LABEL`,
           cat.name || cat.catName,
         ),
       depth: depth,

--- a/src/utils/filterHelpers.js
+++ b/src/utils/filterHelpers.js
@@ -219,6 +219,70 @@ export const flattenCategories = (categories, t, depth = 0) => {
 };
 
 /**
+ * Build category filter options from API categories, matched against
+ * category names actually present in the current request data.
+ * @param {Array} dataRows - Current request rows (used to build dataCategoryNames)
+ * @param {Function} t - Translation function
+ * @returns {Array} Category option objects with category, label, subCategories
+ */
+export const getDashboardCategoryOptions = (dataRows, t) => {
+  const categories = getCategoriesFromStorage();
+
+  const dataCategoryNames = new Set(
+    dataRows.map((r) => r.category).filter(Boolean),
+  );
+
+  if (categories && Array.isArray(categories) && categories.length > 0) {
+    const transformCategories = (cats) => {
+      return cats.map((cat) => ({
+        category: cat.catName,
+        label: t(
+          `categories:REQUEST_CATEGORIES.${cat.catName}.LABEL`,
+          cat.catName,
+        ),
+        subCategories:
+          cat.subCategories && cat.subCategories.length > 0
+            ? transformCategories(cat.subCategories)
+            : undefined,
+      }));
+    };
+
+    if (dataCategoryNames.size === 0) {
+      return transformCategories(categories);
+    }
+
+    const getAllCategoryNames = (cats) => {
+      const names = [];
+      cats.forEach((cat) => {
+        names.push(cat.catName);
+        if (cat.subCategories && cat.subCategories.length > 0) {
+          names.push(...getAllCategoryNames(cat.subCategories));
+        }
+      });
+      return names;
+    };
+
+    const apiCategoryNames = getAllCategoryNames(categories);
+    const matchCount = apiCategoryNames.filter((apiCat) =>
+      dataCategoryNames.has(apiCat),
+    ).length;
+
+    if (
+      matchCount >=
+      Math.min(dataCategoryNames.size, apiCategoryNames.length) * 0.5
+    ) {
+      return transformCategories(categories);
+    }
+  }
+
+  const combined = Array.from(dataCategoryNames);
+  return combined.sort().map((cat) => ({
+    category: cat,
+    label: cat,
+  }));
+};
+
+/**
  * Normalize type value for comparison
  * Used to match backend values with enum keys
  */

--- a/src/utils/filterHelpers.test.js
+++ b/src/utils/filterHelpers.test.js
@@ -4,6 +4,8 @@ import {
   getStatusOptions,
   getPriorityOptions,
   getTypeOptions,
+  getCategoryOptions,
+  flattenCategories,
   normalizeTypeValue,
   normalizeStatusValue,
   normalizePriorityValue,
@@ -155,6 +157,68 @@ describe("filterHelpers", () => {
   describe("normalizePriorityValue", () => {
     it("uppercases and replaces spaces with underscores", () => {
       expect(normalizePriorityValue("medium")).toBe("MEDIUM");
+    });
+  });
+
+  describe("getCategoryOptions", () => {
+    it("translates using category name, not catId (regression test)", () => {
+      localStorage.setItem(
+        "categories",
+        JSON.stringify([
+          {
+            catId: "0.0.0.0.0",
+            catName: "GENERAL_CATEGORY",
+            subcategories: [],
+          },
+        ]),
+      );
+      const translateSpy = jest.fn((key) => key);
+      getCategoryOptions(translateSpy);
+
+      expect(translateSpy).toHaveBeenCalledWith(
+        "categories:REQUEST_CATEGORIES.GENERAL_CATEGORY.LABEL",
+        "GENERAL_CATEGORY",
+      );
+      expect(translateSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("0.0.0.0.0"),
+        expect.anything(),
+      );
+    });
+
+    it("returns empty array when categories missing", () => {
+      expect(getCategoryOptions(mockT)).toEqual([]);
+    });
+  });
+
+  describe("flattenCategories", () => {
+    it("translates using category name, not catId (regression test)", () => {
+      const translateSpy = jest.fn((key) => key);
+      flattenCategories(
+        [{ catId: "0.0.0.0.0", catName: "GENERAL_CATEGORY" }],
+        translateSpy,
+      );
+
+      expect(translateSpy).toHaveBeenCalledWith(
+        "categories:REQUEST_CATEGORIES.GENERAL_CATEGORY.LABEL",
+        "GENERAL_CATEGORY",
+      );
+    });
+
+    it("flattens nested subcategories with correct depth", () => {
+      const result = flattenCategories(
+        [
+          {
+            catId: "1",
+            catName: "PARENT",
+            subcategories: [{ catId: "1.1", catName: "CHILD" }],
+          },
+        ],
+        mockT,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].depth).toBe(0);
+      expect(result[1].depth).toBe(1);
     });
   });
 });

--- a/src/utils/filterHelpers.test.js
+++ b/src/utils/filterHelpers.test.js
@@ -5,6 +5,7 @@ import {
   getPriorityOptions,
   getTypeOptions,
   getCategoryOptions,
+  getDashboardCategoryOptions,
   flattenCategories,
   normalizeTypeValue,
   normalizeStatusValue,
@@ -219,6 +220,80 @@ describe("filterHelpers", () => {
       expect(result).toHaveLength(2);
       expect(result[0].depth).toBe(0);
       expect(result[1].depth).toBe(1);
+    });
+  });
+
+  describe("getDashboardCategoryOptions", () => {
+    const apiCategories = [
+      {
+        catId: "0.0.0.0.0",
+        catName: "GENERAL_CATEGORY",
+        subCategories: [],
+      },
+      {
+        catId: "1",
+        catName: "FOOD_AND_ESSENTIALS",
+        subCategories: [
+          { catId: "1.1", catName: "FOOD_ASSISTANCE", subCategories: [] },
+        ],
+      },
+    ];
+
+    it("returns all API categories when there is no request data yet", () => {
+      localStorage.setItem("categories", JSON.stringify(apiCategories));
+      const result = getDashboardCategoryOptions([], mockT);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].category).toBe("GENERAL_CATEGORY");
+      expect(result[1].subCategories).toHaveLength(1);
+    });
+
+    it("translates using catName, not catId (regression test)", () => {
+      localStorage.setItem("categories", JSON.stringify(apiCategories));
+      const translateSpy = jest.fn((key) => key);
+
+      getDashboardCategoryOptions([], translateSpy);
+
+      expect(translateSpy).toHaveBeenCalledWith(
+        "categories:REQUEST_CATEGORIES.GENERAL_CATEGORY.LABEL",
+        "GENERAL_CATEGORY",
+      );
+    });
+
+    it("uses API categories when they sufficiently match request data", () => {
+      localStorage.setItem("categories", JSON.stringify(apiCategories));
+      const dataRows = [
+        { category: "GENERAL_CATEGORY" },
+        { category: "FOOD_AND_ESSENTIALS" },
+      ];
+
+      const result = getDashboardCategoryOptions(dataRows, mockT);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((c) => c.category)).toEqual([
+        "GENERAL_CATEGORY",
+        "FOOD_AND_ESSENTIALS",
+      ]);
+    });
+
+    it("falls back to data-derived categories when API categories don't match", () => {
+      localStorage.setItem("categories", JSON.stringify(apiCategories));
+      const dataRows = [
+        { category: "SOME_UNRELATED_CATEGORY" },
+        { category: "ANOTHER_UNRELATED_CATEGORY" },
+      ];
+
+      const result = getDashboardCategoryOptions(dataRows, mockT);
+
+      expect(result.map((c) => c.category)).toEqual([
+        "ANOTHER_UNRELATED_CATEGORY",
+        "SOME_UNRELATED_CATEGORY",
+      ]);
+    });
+
+    it("returns empty array when no categories and no data exist", () => {
+      const result = getDashboardCategoryOptions([], mockT);
+      expect(result).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
- Fix category translation lookup using catName instead of catId (categories.json is keyed by catName like GENERAL_CATEGORY, not catId like 0.0.0.0.0, so lookups by catId silently fell back to raw names)
- Fix categoryOptions logic requiring existing request data before showing API categories - now shows full category list even with zero requests
- Fix Categories dropdown being clipped by parent overflow-hidden, preventing scroll from revealing categories beyond the visible area
- Add 4 regression tests for category name-based translation lookup