### PR TITLE
Make notification polling interval configurable via getAppEnv

### DIFF
--- a/src/common/components/Navbar/Navbar.jsx
+++ b/src/common/components/Navbar/Navbar.jsx
@@ -314,7 +314,17 @@ const Navbar = () => {
 
     fetchNotifications(); // Comment it after call ing the funciton below
 
-    const interval = setInterval(fetchNotifications, 5 * 60 * 1000); // fetch every 5 min
+    // Use the interval fetched from getAppEnv (stored on login),
+    // falling back to 5 min (300000 ms) if it isn't available.
+    const storedInterval = Number(
+      JSON.parse(localStorage.getItem("notification_interval_ms")),
+    );
+    const pollInterval =
+      Number.isFinite(storedInterval) && storedInterval > 0
+        ? storedInterval
+        : 5 * 60 * 1000;
+
+    const interval = setInterval(fetchNotifications, pollInterval); // fetch every pollInterval ms
 
     return () => clearInterval(interval);
   }, [notificationDispatch, user]);

--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -12,6 +12,7 @@ import {
   getEnums,
   getCategories,
   getEnvironment,
+  getAppEnv,
   getMetadata,
 } from "../../../services/requestServices";
 
@@ -124,6 +125,24 @@ export const checkAuthStatus = () => async (dispatch) => {
       );
       // Setting default to production if fetch fails
       localStorage.setItem("environment", JSON.stringify("production"));
+    }
+
+    // getAppEnv Fetching — stores notification polling interval (ms)
+    // so the webapp can change it without a code deploy.
+    try {
+      const appEnvData = await getAppEnv();
+      const intervalMs =
+        appEnvData?.notification_interval_ms ??
+        appEnvData?.body?.notification_interval_ms;
+      if (intervalMs) {
+        localStorage.setItem(
+          "notification_interval_ms",
+          JSON.stringify(intervalMs),
+        );
+      }
+      console.log("App env fetched, notification interval:", intervalMs);
+    } catch (appEnvError) {
+      console.warn("Failed to fetch app env after login:", appEnvError.message);
     }
 
     let userDbId = null;

--- a/src/services/endpoints.json
+++ b/src/services/endpoints.json
@@ -33,6 +33,7 @@
   "GET_ENUMS": "v1/request/mockEnums",
   "UPLOAD_REQUEST_FILE": "/requests/v0.0.1/file-upload",
   "GET_ENVIRONMENT": "v1/request/getEnvironment",
+  "GET_APP_ENV": "v1/request/getAppEnv",
   "UPLOAD_AUDIO_TO_S3": "/audio/v0.0.1/upload-to-s3",
   "TRANSCRIBE_AUDIO": "/audio/v0.0.1/transcribe",
   "UPLOAD_AUDIO": "/requests/v0.0.1/upload-audio",

--- a/src/services/requestServices.js
+++ b/src/services/requestServices.js
@@ -132,6 +132,11 @@ export const getEnvironment = async () => {
   return response.data;
 };
 
+export const getAppEnv = async () => {
+  const response = await api.get(endpoints.GET_APP_ENV);
+  return response.data;
+};
+
 export const uploadRequestFile = async (file) => {
   const formData = new FormData();
   formData.append("file", file);


### PR DESCRIPTION
### What
Fetches the notification polling interval from the backend instead of hardcoding it, so it can be changed without a code deploy.

### Changes
- Add GET_APP_ENV endpoint and a getAppEnv() service call.
- On login, fetch getAppEnv and store notification_interval_ms in localStorage.
- Navbar uses the stored interval for notification polling, falling back to 5 minutes (300000 ms) if it's unavailable.

### Notes
- Falls back safely to 5 min if the value isn't present, so notifications keep working regardless.
- Full end-to-end verification pending the real getAppEnv API returning notification_interval_ms.