### PR TITLE
Fix request type translations not showing on dashboard

### DIFF
--- a/src/common/components/DataTable/Table.jsx
+++ b/src/common/components/DataTable/Table.jsx
@@ -279,8 +279,16 @@ const Table = ({
                     const value = getCellValue(row, header);
 
                     const path = getLinkPath ? getLinkPath(row, header) : null;
-                    const cellContent =
-                      header === "requestId" ? renderRequestId(value) : value;
+
+                    let cellContent = value;
+
+                    if (header === "requestId") {
+                      cellContent = renderRequestId(value);
+                    }
+
+                    if (header === "type") {
+                      cellContent = t(cellContent);
+                    }
 
                     return (
                       <td


### PR DESCRIPTION
Request type column was showing internal IDs instead of translated strings for all languages including English. 

Before:
<img width="160" height="395" alt="image" src="https://github.com/user-attachments/assets/876a525d-2c22-4eb6-952c-606495c06724" />

<br/>

After:

<img width="125" height="392" alt="image" src="https://github.com/user-attachments/assets/4ae3b649-28e7-4ecc-b286-69ea99bb9f79" />

<img width="125" height="392" alt="image" src="https://github.com/user-attachments/assets/60481196-55c2-4fae-9da9-7d2ffad1d9bb" />
