### PR TITLE
 configure volunteer geospatial polling

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,7 @@ VITE_BASE_API_URL= https://api.help-for-everyone.org/
 VITE_METRICS_CDN_URL=https://test.help-for-everyone.org/api/stats
 
 VITE_RECAPTCHA_SITE_KEY=6LdWJAYtAAAAADJFr97I-3p4pGHasY8ub_tXH_xO
+
+# Fallback geospatial configuration
+VITE_SPATIAL_INTERVAL_MS=300000
+VITE_MIN_DISTANCE_METERS=50

--- a/src/redux/features/authentication/authActions.js
+++ b/src/redux/features/authentication/authActions.js
@@ -127,22 +127,61 @@ export const checkAuthStatus = () => async (dispatch) => {
       localStorage.setItem("environment", JSON.stringify("production"));
     }
 
-    // getAppEnv Fetching — stores notification polling interval (ms)
-    // so the webapp can change it without a code deploy.
+    // Fetch configurable polling values after login.
+    // Geospatial values fall back to .env values when unavailable.
     try {
       const appEnvData = await getAppEnv();
-      const intervalMs =
-        appEnvData?.notification_interval_ms ??
-        appEnvData?.body?.notification_interval_ms;
-      if (intervalMs) {
+      const appEnvBody = appEnvData?.body ?? appEnvData;
+
+      const notificationInterval = Number(appEnvBody?.notification_interval_ms);
+      const spatialInterval = Number(appEnvBody?.spatial_interval_ms);
+      const minimumDistance = Number(appEnvBody?.min_distance_meters);
+
+      if (Number.isFinite(notificationInterval) && notificationInterval > 0) {
         localStorage.setItem(
           "notification_interval_ms",
-          JSON.stringify(intervalMs),
+          JSON.stringify(notificationInterval),
         );
       }
-      console.log("App env fetched, notification interval:", intervalMs);
+
+      const resolvedSpatialInterval =
+        Number.isFinite(spatialInterval) && spatialInterval > 0
+          ? spatialInterval
+          : Number(import.meta.env.VITE_SPATIAL_INTERVAL_MS) || 300000;
+
+      const resolvedMinimumDistance =
+        Number.isFinite(minimumDistance) && minimumDistance > 0
+          ? minimumDistance
+          : Number(import.meta.env.VITE_MIN_DISTANCE_METERS) || 50;
+
+      localStorage.setItem(
+        "spatial_interval_ms",
+        JSON.stringify(resolvedSpatialInterval),
+      );
+
+      localStorage.setItem(
+        "min_distance_meters",
+        JSON.stringify(resolvedMinimumDistance),
+      );
+
+      console.log("App environment fetched successfully");
     } catch (appEnvError) {
-      console.warn("Failed to fetch app env after login:", appEnvError.message);
+      console.warn(
+        "Failed to fetch app environment. Using geospatial fallback values:",
+        appEnvError.message,
+      );
+
+      localStorage.setItem(
+        "spatial_interval_ms",
+        JSON.stringify(
+          Number(import.meta.env.VITE_SPATIAL_INTERVAL_MS) || 300000,
+        ),
+      );
+
+      localStorage.setItem(
+        "min_distance_meters",
+        JSON.stringify(Number(import.meta.env.VITE_MIN_DISTANCE_METERS) || 50),
+      );
     }
 
     let userDbId = null;

--- a/src/redux/features/authentication/authActions.test.js
+++ b/src/redux/features/authentication/authActions.test.js
@@ -18,6 +18,7 @@ jest.mock("../../../services/requestServices", () => ({
   getEnums: jest.fn(),
   getCategories: jest.fn(),
   getEnvironment: jest.fn(),
+  getAppEnv: jest.fn(),
   getMetadata: jest.fn(),
 }));
 
@@ -44,7 +45,10 @@ const localStorageMock = {
   removeItem: jest.fn(),
   clear: jest.fn(),
 };
-Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
 
 describe("authActions", () => {
   let dispatch;
@@ -82,25 +86,151 @@ describe("authActions", () => {
         fetchUserAttributes,
         fetchAuthSession,
       } = require("aws-amplify/auth");
+
       const {
         getEnums,
         getCategories,
         getEnvironment,
+        getAppEnv,
         getMetadata,
       } = require("../../../services/requestServices");
+
+      const { getUserId } = require("../../../services/volunteerServices");
 
       getCurrentUser.mockResolvedValue({ userId: "user-123" });
       fetchUserAttributes.mockResolvedValue(mockUserAttributes);
       fetchAuthSession.mockResolvedValue(mockSession);
+
       getEnums.mockResolvedValue({ enum1: "value1" });
-      getCategories.mockResolvedValue([{ catId: "1", catName: "Category 1" }]);
-      getEnvironment.mockResolvedValue({ environment: "test" });
-      getMetadata.mockResolvedValue({ body: { key: "value" } });
+      getCategories.mockResolvedValue([
+        {
+          catId: "1",
+          catName: "Category 1",
+        },
+      ]);
+
+      getEnvironment.mockResolvedValue({
+        environment: "test",
+      });
+
+      getAppEnv.mockResolvedValue({
+        notification_interval_ms: 300000,
+        spatial_interval_ms: 300000,
+        min_distance_meters: 50,
+      });
+
+      getMetadata.mockResolvedValue({
+        body: {
+          key: "value",
+        },
+      });
+
+      getUserId.mockResolvedValue({
+        data: {
+          user_id: "SID-00-000-001",
+        },
+      });
+    });
+
+    it("stores geospatial values returned by getAppEnv", async () => {
+      const { getAppEnv } = require("../../../services/requestServices");
+
+      getAppEnv.mockResolvedValue({
+        notification_interval_ms: 300000,
+        spatial_interval_ms: 600000,
+        min_distance_meters: 100,
+      });
+
+      await checkAuthStatus()(dispatch);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "spatial_interval_ms",
+        JSON.stringify(600000),
+      );
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "min_distance_meters",
+        JSON.stringify(100),
+      );
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "notification_interval_ms",
+        JSON.stringify(300000),
+      );
+    });
+
+    it("supports geospatial values inside the API body", async () => {
+      const { getAppEnv } = require("../../../services/requestServices");
+
+      getAppEnv.mockResolvedValue({
+        body: {
+          notification_interval_ms: 300000,
+          spatial_interval_ms: 900000,
+          min_distance_meters: 150,
+        },
+      });
+
+      await checkAuthStatus()(dispatch);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "spatial_interval_ms",
+        JSON.stringify(900000),
+      );
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "min_distance_meters",
+        JSON.stringify(150),
+      );
+    });
+
+    it("stores fallback geospatial values when getAppEnv fails", async () => {
+      const { getAppEnv } = require("../../../services/requestServices");
+
+      getAppEnv.mockRejectedValue(new Error("App environment API failed"));
+
+      await checkAuthStatus()(dispatch);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "spatial_interval_ms",
+        JSON.stringify(300000),
+      );
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "min_distance_meters",
+        JSON.stringify(50),
+      );
+    });
+
+    it("uses fallback values when getAppEnv returns invalid geospatial values", async () => {
+      const { getAppEnv } = require("../../../services/requestServices");
+
+      getAppEnv.mockResolvedValue({
+        notification_interval_ms: 300000,
+        spatial_interval_ms: 0,
+        min_distance_meters: -10,
+      });
+
+      await checkAuthStatus()(dispatch);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "spatial_interval_ms",
+        JSON.stringify(300000),
+      );
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "min_distance_meters",
+        JSON.stringify(50),
+      );
     });
 
     it("stores userDbId in localStorage when getUserId returns user_id", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { user_id: "SID-00-000-002-622" } });
+
+      getUserId.mockResolvedValue({
+        data: {
+          user_id: "SID-00-000-002-622",
+        },
+      });
 
       await checkAuthStatus()(dispatch);
 
@@ -112,7 +242,12 @@ describe("authActions", () => {
 
     it("falls back to data.id when data.user_id is not present", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { id: "SID-00-000-001" } });
+
+      getUserId.mockResolvedValue({
+        data: {
+          id: "SID-00-000-001",
+        },
+      });
 
       await checkAuthStatus()(dispatch);
 
@@ -124,7 +259,12 @@ describe("authActions", () => {
 
     it("does not store userDbId in localStorage when getUserId returns null", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { user_id: null } });
+
+      getUserId.mockResolvedValue({
+        data: {
+          user_id: null,
+        },
+      });
 
       await checkAuthStatus()(dispatch);
 
@@ -136,6 +276,7 @@ describe("authActions", () => {
 
     it("does not store userDbId when getUserId throws error", async () => {
       const { getUserId } = require("../../../services/volunteerServices");
+
       getUserId.mockRejectedValue(new Error("User not found"));
 
       await checkAuthStatus()(dispatch);
@@ -144,7 +285,7 @@ describe("authActions", () => {
         "userDbId",
         expect.anything(),
       );
-      // Should still dispatch loginSuccess
+
       expect(dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
           type: loginSuccess.type,
@@ -153,9 +294,6 @@ describe("authActions", () => {
     });
 
     it("dispatches loginRequest at start", async () => {
-      const { getUserId } = require("../../../services/volunteerServices");
-      getUserId.mockResolvedValue({ data: { user_id: "SID-00-000-001" } });
-
       await checkAuthStatus()(dispatch);
 
       expect(dispatch).toHaveBeenCalledWith(loginRequest());

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -43,9 +43,7 @@ const ProtectedRoute = () => {
       return;
     }
 
-    startVolunteerLocationTracking({
-      intervalMs: 5 * 60 * 1000,
-    });
+    startVolunteerLocationTracking();
 
     const onPersonalInfoUpdated = async () => {
       await syncVolunteerLocationNow();

--- a/src/services/volunteerLocationTracker.js
+++ b/src/services/volunteerLocationTracker.js
@@ -6,8 +6,33 @@ let intervalId = null;
 let inFlight = false;
 
 const LOCAL_KEY = "latestVolunteerLocation";
-const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
-const MIN_DISTANCE_METERS = 50;
+const SPATIAL_INTERVAL_KEY = "spatial_interval_ms";
+const MIN_DISTANCE_KEY = "min_distance_meters";
+
+const DEFAULT_INTERVAL_MS =
+  Number(import.meta.env.VITE_SPATIAL_INTERVAL_MS) || 300000;
+
+const DEFAULT_MIN_DISTANCE_METERS =
+  Number(import.meta.env.VITE_MIN_DISTANCE_METERS) || 50;
+
+const getStoredPositiveNumber = (key, fallbackValue) => {
+  try {
+    const storedValue = JSON.parse(localStorage.getItem(key));
+    const numericValue = Number(storedValue);
+
+    return Number.isFinite(numericValue) && numericValue > 0
+      ? numericValue
+      : fallbackValue;
+  } catch {
+    return fallbackValue;
+  }
+};
+
+const getSpatialIntervalMs = () =>
+  getStoredPositiveNumber(SPATIAL_INTERVAL_KEY, DEFAULT_INTERVAL_MS);
+
+const getMinimumDistanceMeters = () =>
+  getStoredPositiveNumber(MIN_DISTANCE_KEY, DEFAULT_MIN_DISTANCE_METERS);
 
 const formatCoordinate = (value) => Number(Number(value).toFixed(4));
 
@@ -58,7 +83,7 @@ const getDistanceMeters = (lat1, lon1, lat2, lon2) => {
 const hasLocationChanged = (
   oldLoc,
   newLoc,
-  thresholdMeters = MIN_DISTANCE_METERS,
+  thresholdMeters = getMinimumDistanceMeters(),
 ) => {
   if (
     oldLoc?.latitude == null ||
@@ -239,15 +264,18 @@ const checkAndSyncLocation = async () => {
   }
 };
 
-export const startVolunteerLocationTracking = async ({
-  intervalMs = DEFAULT_INTERVAL_MS,
-} = {}) => {
+export const startVolunteerLocationTracking = async ({ intervalMs } = {}) => {
   if (!isVolunteerUser()) return;
   if (intervalId) return;
 
+  const configuredInterval =
+    Number.isFinite(Number(intervalMs)) && Number(intervalMs) > 0
+      ? Number(intervalMs)
+      : getSpatialIntervalMs();
+
   await checkAndSyncLocation();
 
-  intervalId = window.setInterval(checkAndSyncLocation, intervalMs);
+  intervalId = window.setInterval(checkAndSyncLocation, configuredInterval);
 };
 
 export const stopVolunteerLocationTracking = () => {


### PR DESCRIPTION

- Uses spatial_interval_ms and min_distance_meters from the existing getAppEnv API.
- Stores the values locally after login.
- Uses .env fallbacks of 5 minutes and 50 meters if the API fails or returns invalid values.
- Removes hard-coded values from volunteer location tracking.
- Adds tests for API values and fallback behavior.
