### PR TITLE
Add Close button to voice recorder, improve background-noise rejection, and refine "no speech" error UX (#1799)

### DIFF
--- a/src/common/components/VoiceRecordingComponent.jsx
+++ b/src/common/components/VoiceRecordingComponent.jsx
@@ -5,20 +5,37 @@ import {
   FiStopCircle,
   FiPlay,
   FiPause,
-  FiAlertTriangle,
+  FiAlertCircle,
   FiTrash2,
+  FiX,
 } from "react-icons/fi";
 import { Howl } from "howler";
 import { uploadAudioAndTranscribe } from "../../services/audioServices";
 
 const DEFAULT_MAX_RECORDING_SECONDS = 60;
+// Audio below this RMS is treated as pure silence (no signal at all)
 const SILENCE_RMS_THRESHOLD = 0.01;
+// Audio below this RMS threshold may still be background noise — checked via temporal variance
+const BACKGROUND_NOISE_RMS_UPPER = 0.06;
+// Coefficient of variation (std/mean of per-frame RMS) below which audio is
+// classified as steady background noise (fan, AC, etc.) rather than speech
+const MIN_SPEECH_VARIATION_CV = 0.25;
 
 /**
- * Analyze audio blob to detect if it contains mostly silence.
- * Uses Web Audio API to decode the audio and compute RMS energy.
+ * Analyze audio blob to detect if it contains mostly silence or steady
+ * background noise (fan, AC, etc.) with no actual speech.
+ *
+ * Strategy:
+ *  1. Compute overall RMS — if below SILENCE_RMS_THRESHOLD it is definitively
+ *     silent.
+ *  2. For audio in the "borderline" range (RMS up to BACKGROUND_NOISE_RMS_UPPER)
+ *     compute the coefficient of variation (CV = stddev / mean) of per-frame
+ *     RMS values.  Speech has high temporal variation; steady background noise
+ *     has very low variation.  If CV < MIN_SPEECH_VARIATION_CV the audio is
+ *     classified as background noise, not speech.
+ *
  * @param {Blob} audioBlob - recorded audio blob
- * @returns {Promise<boolean>} - true if the audio is silent (no speech detected)
+ * @returns {Promise<boolean>} - true if the audio contains no detectable speech
  */
 const isSilentAudio = async (audioBlob) => {
   try {
@@ -27,7 +44,9 @@ const isSilentAudio = async (audioBlob) => {
     const arrayBuffer = await audioBlob.arrayBuffer();
     const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
     const channelData = audioBuffer.getChannelData(0);
+    const sampleRate = audioBuffer.sampleRate;
 
+    // Overall RMS
     let sumSquares = 0;
     for (let i = 0; i < channelData.length; i++) {
       sumSquares += channelData[i] * channelData[i];
@@ -35,7 +54,40 @@ const isSilentAudio = async (audioBlob) => {
     const rms = Math.sqrt(sumSquares / channelData.length);
 
     audioContext.close();
-    return rms < SILENCE_RMS_THRESHOLD;
+
+    // Definitively silent
+    if (rms < SILENCE_RMS_THRESHOLD) return true;
+
+    // For moderate levels check temporal variation to distinguish steady
+    // background noise (fan, AC) from actual speech
+    if (rms < BACKGROUND_NOISE_RMS_UPPER) {
+      const frameSamples = Math.floor(sampleRate * 0.1); // 100 ms frames
+      const frameRMSValues = [];
+      for (
+        let i = 0;
+        i + frameSamples <= channelData.length;
+        i += frameSamples
+      ) {
+        let frameSum = 0;
+        for (let j = i; j < i + frameSamples; j++) {
+          frameSum += channelData[j] * channelData[j];
+        }
+        frameRMSValues.push(Math.sqrt(frameSum / frameSamples));
+      }
+
+      if (frameRMSValues.length > 5) {
+        const meanRMS =
+          frameRMSValues.reduce((a, b) => a + b, 0) / frameRMSValues.length;
+        const variance =
+          frameRMSValues.reduce((a, b) => a + Math.pow(b - meanRMS, 2), 0) /
+          frameRMSValues.length;
+        const cv = Math.sqrt(variance) / (meanRMS || 1);
+        // Very low CV = steady noise (not speech)
+        if (cv < MIN_SPEECH_VARIATION_CV) return true;
+      }
+    }
+
+    return false;
   } catch {
     return false;
   }
@@ -381,6 +433,37 @@ const VoiceRecordingComponent = ({
     if (onTranscriptionUpdate) onTranscriptionUpdate("");
   };
 
+  /**
+   * Dismiss the recorder UI and return to idle state WITHOUT clearing any
+   * transcribed text that was already written to the description field.
+   * Category, Subject, and all other form data in the parent are unaffected.
+   */
+  const dismissRecorder = () => {
+    if (howlRef.current) {
+      howlRef.current.stop();
+      howlRef.current.unload();
+      howlRef.current = null;
+    }
+
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+
+    setAudioUrl(null);
+    setAudioBlob(null);
+    setIsPlaying(false);
+    setError("");
+    setTranscriptionError(false);
+    setDetectedLanguage(null);
+    audioChunksRef.current = [];
+
+    // Notify parent that audio is gone (so it doesn't try to submit stale audio)
+    // but intentionally do NOT call onTranscriptionUpdate — the transcribed text
+    // in the description field is preserved for the user to review/edit.
+    if (onAudioUploaded) onAudioUploaded(null);
+  };
+
   const Tooltip = ({ children, text }) => {
     return (
       <div className="relative group">
@@ -490,16 +573,24 @@ const VoiceRecordingComponent = ({
           </div>
         )}
 
-        {error && (
-          <span className="text-xs text-red-600" role="alert">
-            {error}
-          </span>
-        )}
-
-        {transcriptionError && !isProcessing && (
-          <Tooltip text="Transcription unavailable. You can type the description manually.">
-            <div className="flex items-center justify-center w-10 h-10 bg-yellow-500 text-white rounded-full cursor-help shadow-md">
-              <FiAlertTriangle size={20} />
+        {/* Compact error icon with tooltip — replaces the inline error text and
+            yellow triangle alert so the recorder stays small even on failure. */}
+        {(error || transcriptionError) && !isProcessing && (
+          <Tooltip
+            text={
+              error ||
+              "Transcription unavailable. You can type the description manually."
+            }
+          >
+            <div
+              className="flex items-center justify-center w-10 h-10 bg-red-500 text-white rounded-full cursor-help shadow-md"
+              role="alert"
+              aria-label={
+                error ||
+                "Transcription unavailable. You can type the description manually."
+              }
+            >
+              <FiAlertCircle size={20} />
             </div>
           </Tooltip>
         )}
@@ -529,6 +620,26 @@ const VoiceRecordingComponent = ({
             </Tooltip>
           </div>
         )}
+
+        {/* Close / Cancel button — visible whenever the recorder has content
+            (audio recorded or in an error state) but is not actively recording
+            or processing.  Dismisses the recorder UI and returns the user to
+            the plain text Description field while preserving any transcribed
+            text and all other form data (Category, Subject, Details). */}
+        {!isRecording &&
+          !isProcessing &&
+          (audioUrl || error || transcriptionError) && (
+            <Tooltip text="Close recorder (keeps transcribed text)">
+              <button
+                type="button"
+                onClick={dismissRecorder}
+                className="flex items-center justify-center w-10 h-10 bg-gray-500 text-white rounded-full hover:bg-gray-600 transition-colors shadow-md"
+                aria-label="Close recorder"
+              >
+                <FiX size={20} />
+              </button>
+            </Tooltip>
+          )}
       </div>
     </div>
   );

--- a/src/common/components/VoiceRecordingComponent.test.jsx
+++ b/src/common/components/VoiceRecordingComponent.test.jsx
@@ -251,6 +251,45 @@ describe("VoiceRecordingComponent — silence detection", () => {
     expect(onTranscriptionUpdate).not.toHaveBeenCalled();
   });
 
+  it("treats audio as not-silent and proceeds to transcription when isSilentAudio throws internally (catch branch)", async () => {
+    // Force decodeAudioData to reject so that the catch block in isSilentAudio
+    // fires and returns false (audio is assumed to contain speech).
+    const fakeCtx = {
+      decodeAudioData: jest.fn().mockRejectedValue(new Error("decode failed")),
+      close: jest.fn(),
+    };
+    window.AudioContext = jest.fn(() => fakeCtx);
+    window.webkitAudioContext = jest.fn(() => fakeCtx);
+
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "Decoded after catch",
+      detectedLanguage: "en",
+      requestId: "req-catch",
+    });
+
+    const onTranscriptionUpdate = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={jest.fn()}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // isSilentAudio caught the error and returned false → transcription proceeds
+    await waitFor(() => {
+      expect(mockUploadAudioAndTranscribe).toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: /play recording|pause playback/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(onTranscriptionUpdate).toHaveBeenCalledWith("Decoded after catch");
+  });
+
   it("calls transcription API normally when audio contains speech", async () => {
     // RMS = 0.1 → well above the background-noise upper threshold (0.06)
     mockAudioContext(0.1);
@@ -474,6 +513,101 @@ describe("VoiceRecordingComponent — Close / Cancel (X) button", () => {
     ).toBeInTheDocument();
 
     // Transcription text must not be cleared (was never set, so 0 calls)
+    expect(onTranscriptionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("cleans up an active Howl instance when Close is clicked after playback starts", async () => {
+    // This test covers the howlRef.current.stop/unload/null path inside
+    // dismissRecorder (lines 443-445) which is only reached when a Howl
+    // instance has been created via togglePlayback.
+    const { Howl } = require("howler");
+
+    mockAudioContext(0.1);
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "Playback test",
+      detectedLanguage: "en",
+      requestId: "req-howl",
+    });
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={jest.fn()}
+        onAudioUploaded={jest.fn()}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // Wait for the play button to appear (audioUrl is set, processing done)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /play recording/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Click Play — this creates the Howl instance (howlRef.current becomes non-null)
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /play recording/i }));
+    });
+
+    // Verify that a Howl instance was constructed
+    expect(Howl).toHaveBeenCalledTimes(1);
+    const howlInstance = Howl.mock.results[0].value;
+
+    // Click Close — exercises howlRef.current.stop/unload/null (lines 443-445)
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /close recorder/i }));
+    });
+
+    expect(howlInstance.stop).toHaveBeenCalled();
+    expect(howlInstance.unload).toHaveBeenCalled();
+
+    // Recorder should be back to idle state
+    expect(
+      screen.getByRole("button", { name: /start recording/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /close recorder/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows 'Transcription unavailable' fallback tooltip when API returns empty text", async () => {
+    // This test covers lines 582 and 590 — the fallback string inside the
+    // error ||  "Transcription unavailable…" expression.  It is only reached
+    // when transcriptionError is true but error is '' (falsy), which happens
+    // when uploadAudioAndTranscribe resolves with an empty text field.
+    mockAudioContext(0.1);
+
+    // Return an empty transcript — audio passes silence check but has no text
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "",
+      detectedLanguage: "en",
+      requestId: "req-empty",
+    });
+
+    const onTranscriptionUpdate = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={jest.fn()}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // transcriptionError = true, error = "" → fallback string is evaluated
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/transcription unavailable/i),
+      );
+    });
+
+    // No transcription text should be passed to the parent
     expect(onTranscriptionUpdate).not.toHaveBeenCalled();
   });
 

--- a/src/common/components/VoiceRecordingComponent.test.jsx
+++ b/src/common/components/VoiceRecordingComponent.test.jsx
@@ -30,17 +30,56 @@ jest.mock("../../services/audioServices", () => ({
 
 /**
  * Build a minimal mock for window.AudioContext that returns channel data
- * with the given RMS energy level.
+ * with the given constant RMS energy level (all samples at the same amplitude).
+ * This produces a temporal coefficient-of-variation of 0 — mimicking steady
+ * background noise (fan, AC unit, etc.).
  *
- * @param {number} rms - desired RMS value of the fake audio (0 = total silence)
+ * Including `sampleRate` on the fake buffer is required for the temporal
+ * variance check added in isSilentAudio.
+ *
+ * @param {number} rms        - desired RMS value of the fake audio (0 = silence)
+ * @param {number} sampleRate - sample rate used for 100 ms frame computation
  */
-function mockAudioContext(rms) {
-  const sampleCount = 1000;
-  // Each sample value s must satisfy: sqrt(N * s^2 / N) = rms  →  s = rms
-  const amplitude = rms;
-  const channelData = new Float32Array(sampleCount).fill(amplitude);
+function mockAudioContext(rms, sampleRate = 44100) {
+  const durationSeconds = 2;
+  const sampleCount = sampleRate * durationSeconds;
+  // Constant-amplitude signal → RMS == amplitude, temporal CV == 0
+  const channelData = new Float32Array(sampleCount).fill(rms);
 
-  const fakeAudioBuffer = { getChannelData: () => channelData };
+  const fakeAudioBuffer = { getChannelData: () => channelData, sampleRate };
+
+  const fakeCtx = {
+    decodeAudioData: jest.fn().mockResolvedValue(fakeAudioBuffer),
+    close: jest.fn(),
+  };
+
+  window.AudioContext = jest.fn(() => fakeCtx);
+  window.webkitAudioContext = jest.fn(() => fakeCtx);
+  return fakeCtx;
+}
+
+/**
+ * Build a mock for window.AudioContext with alternating frame amplitudes to
+ * simulate variable audio (e.g., actual speech).  Even 100 ms frames use
+ * highRms, odd frames use lowRms.  This produces a high coefficient of
+ * variation, indicating speech rather than steady background noise.
+ *
+ * @param {number} lowRms     - amplitude for odd frames
+ * @param {number} highRms    - amplitude for even frames
+ * @param {number} sampleRate - sample rate used for 100 ms frame computation
+ */
+function mockAudioContextVariableFrames(lowRms, highRms, sampleRate = 44100) {
+  const durationSeconds = 2;
+  const sampleCount = sampleRate * durationSeconds;
+  const frameSamples = Math.floor(sampleRate * 0.1); // 100 ms frames
+  const channelData = new Float32Array(sampleCount);
+
+  for (let i = 0; i < sampleCount; i++) {
+    const frameIdx = Math.floor(i / frameSamples);
+    channelData[i] = frameIdx % 2 === 0 ? highRms : lowRms;
+  }
+
+  const fakeAudioBuffer = { getChannelData: () => channelData, sampleRate };
 
   const fakeCtx = {
     decodeAudioData: jest.fn().mockResolvedValue(fakeAudioBuffer),
@@ -59,6 +98,9 @@ let capturedOnStop;
 let mockMediaRecorderInstance;
 
 function setupMediaMocks() {
+  capturedOnDataAvailable = null;
+  capturedOnStop = null;
+
   mockMediaRecorderInstance = {
     start: jest.fn(),
     stop: jest.fn().mockImplementation(() => {
@@ -100,6 +142,67 @@ function setupMediaMocks() {
   };
 }
 
+/**
+ * Shared helper that flushes the macrotask queue so that any Promise
+ * continuations started by a previous test complete *before* we reset mock
+ * call counts.  Without this flush an async chain from test N can call a mock
+ * during test N+1, causing spurious "unexpected call" failures.
+ */
+async function flushPendingTasks() {
+  // A 0-ms setTimeout fires after all queued microtasks, giving any
+  // in-flight Promise chains from the previous test a chance to settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Shared helper: start a recording, push one data chunk, then stop.
+ * Returns after the stop button is clicked (async processing still pending).
+ */
+async function recordAndStop() {
+  const startBtn = screen.getByRole("button", { name: /start recording/i });
+  await act(async () => {
+    fireEvent.click(startBtn);
+  });
+
+  const audioChunk = new Blob([new ArrayBuffer(100)], { type: "audio/webm" });
+  await act(async () => {
+    capturedOnDataAvailable({ data: audioChunk });
+  });
+
+  const stopBtn = screen.getByRole("button", { name: /stop recording/i });
+  await act(async () => {
+    fireEvent.click(stopBtn);
+  });
+}
+
+/**
+ * Shared common setup applied inside each beforeEach — keeps the three
+ * describe blocks DRY while ensuring isolated state per test.
+ */
+async function commonSetup() {
+  // Let any lingering Promises from the previous test settle before resetting
+  // call counts so we don't see spurious cross-test mock calls.
+  await flushPendingTasks();
+
+  jest.clearAllMocks();
+  setupMediaMocks();
+
+  // Provide Blob.prototype.arrayBuffer for older jsdom environments
+  if (!Blob.prototype.arrayBuffer) {
+    Blob.prototype.arrayBuffer = function () {
+      return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsArrayBuffer(this);
+      });
+    };
+  }
+
+  // Mock URL helpers that jsdom doesn't implement
+  URL.createObjectURL = jest.fn(() => "blob:mock-url");
+  URL.revokeObjectURL = jest.fn();
+}
+
 // ── Import component AFTER mocks are set up ────────────────────────────────
 
 let VoiceRecordingComponent;
@@ -111,29 +214,11 @@ beforeAll(async () => {
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe("VoiceRecordingComponent — silence detection", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    setupMediaMocks();
-    // Provide Blob.prototype.arrayBuffer for jsdom
-    if (!Blob.prototype.arrayBuffer) {
-      Blob.prototype.arrayBuffer = function () {
-        return new Promise((resolve) => {
-          const reader = new FileReader();
-          reader.onloadend = () => resolve(reader.result);
-          reader.readAsArrayBuffer(this);
-        });
-      };
-    }
-    // Mock URL.createObjectURL / revokeObjectURL for jsdom
-    if (!URL.createObjectURL) {
-      URL.createObjectURL = jest.fn(() => "blob:mock-url");
-    }
-    if (!URL.revokeObjectURL) {
-      URL.revokeObjectURL = jest.fn();
-    }
+  beforeEach(async () => {
+    await commonSetup();
   });
 
-  it("shows no-speech error and does NOT call transcription API when audio is silent", async () => {
+  it("shows no-speech error icon and does NOT call transcription API when audio is silent", async () => {
     // RMS = 0 → completely silent
     mockAudioContext(0);
 
@@ -148,30 +233,15 @@ describe("VoiceRecordingComponent — silence detection", () => {
       />,
     );
 
-    // Click start recording
-    const startBtn = screen.getByRole("button", { name: /start recording/i });
-    await act(async () => {
-      fireEvent.click(startBtn);
-    });
+    await recordAndStop();
 
-    // Simulate a data chunk arriving (silent audio)
-    const silentBlob = new Blob([new ArrayBuffer(100)], {
-      type: "audio/webm",
-    });
-    await act(async () => {
-      capturedOnDataAvailable({ data: silentBlob });
-    });
-
-    // Stop recording — triggers onstop handler
-    const stopBtn = screen.getByRole("button", { name: /stop recording/i });
-    await act(async () => {
-      fireEvent.click(stopBtn);
-    });
-
-    // Wait for the silence detection to complete
+    // Wait for the silence detection to complete — compact error icon shown
+    // (error message is now on the aria-label of the icon, not inline text)
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /no speech detected/i,
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/no speech detected/i),
       );
     });
 
@@ -182,7 +252,7 @@ describe("VoiceRecordingComponent — silence detection", () => {
   });
 
   it("calls transcription API normally when audio contains speech", async () => {
-    // RMS = 0.1 → well above threshold (0.01)
+    // RMS = 0.1 → well above the background-noise upper threshold (0.06)
     mockAudioContext(0.1);
 
     mockUploadAudioAndTranscribe.mockResolvedValue({
@@ -202,32 +272,237 @@ describe("VoiceRecordingComponent — silence detection", () => {
       />,
     );
 
+    await recordAndStop();
+
+    // Wait for the FULL async chain to complete — play/delete/X buttons appear
+    // once audioUrl is set and isProcessing is false. Waiting for this (rather
+    // than only the API call) ensures no lingering Promises leak into the next
+    // test.
+    await waitFor(() => {
+      expect(mockUploadAudioAndTranscribe).toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: /play recording|pause playback/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Description should be updated with transcription text
+    expect(onTranscriptionUpdate).toHaveBeenCalledWith("Hello world");
+  });
+});
+
+// ── Background-noise (temporal variance) detection ─────────────────────────
+
+describe("VoiceRecordingComponent — background noise (temporal variance) detection", () => {
+  beforeEach(async () => {
+    await commonSetup();
+  });
+
+  it("treats steady background noise (e.g. fan) as silent — RMS in range but CV too low", async () => {
+    // RMS = 0.02 sits between SILENCE_RMS_THRESHOLD (0.01) and
+    // BACKGROUND_NOISE_RMS_UPPER (0.06).  Constant amplitude → CV = 0 < 0.25
+    // → classified as background noise, not speech.
+    mockAudioContext(0.02);
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // Error icon should appear because audio is classified as background noise
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/no speech detected/i),
+      );
+    });
+
+    // Transcription API must NOT be called for background noise
+    expect(mockUploadAudioAndTranscribe).not.toHaveBeenCalled();
+    expect(onTranscriptionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("passes variable audio as potential speech — RMS in range but CV is high", async () => {
+    // Alternating frame amplitudes: 0.05 (even frames) and 0.01 (odd frames).
+    // Overall RMS ≈ 0.036, which is between 0.01 and 0.06, BUT the
+    // coefficient of variation ≈ 0.67 >> 0.25 → classified as speech.
+    mockAudioContextVariableFrames(0.01, 0.05);
+
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "Variable signal speech",
+      detectedLanguage: "en",
+      requestId: "req-456",
+    });
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // Transcription API SHOULD be called since audio is variable (speech-like)
+    await waitFor(() => {
+      expect(mockUploadAudioAndTranscribe).toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: /play recording|pause playback/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(onTranscriptionUpdate).toHaveBeenCalledWith(
+      "Variable signal speech",
+    );
+  });
+});
+
+// ── Close / Cancel (X) button ─────────────────────────────────────────────
+
+describe("VoiceRecordingComponent — Close / Cancel (X) button", () => {
+  beforeEach(async () => {
+    await commonSetup();
+  });
+
+  it("shows Close button after successful transcription and dismisses WITHOUT clearing transcribed text", async () => {
+    // RMS = 0.1 → above BACKGROUND_NOISE_RMS_UPPER → treated as speech
+    mockAudioContext(0.1);
+
+    mockUploadAudioAndTranscribe.mockResolvedValue({
+      text: "Keep this text",
+      detectedLanguage: "en",
+      requestId: "req-789",
+    });
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // Wait for full processing — play/delete/X buttons should all appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /close recorder/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Transcription text was written to parent
+    expect(onTranscriptionUpdate).toHaveBeenCalledWith("Keep this text");
+    const callsBefore = onTranscriptionUpdate.mock.calls.length;
+
+    // Click the Close (X) button
+    const closeBtn = screen.getByRole("button", { name: /close recorder/i });
+    await act(async () => {
+      fireEvent.click(closeBtn);
+    });
+
+    // onAudioUploaded must be called with null (audio cleaned up)
+    expect(onAudioUploaded).toHaveBeenLastCalledWith(null);
+
+    // onTranscriptionUpdate must NOT be called again — transcribed text preserved
+    expect(onTranscriptionUpdate).toHaveBeenCalledTimes(callsBefore);
+
+    // Recorder should return to idle — mic button visible, Close button gone
+    expect(
+      screen.getByRole("button", { name: /start recording/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /close recorder/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Close button in error state and dismisses cleanly back to idle mic button", async () => {
+    // Silent audio → error state
+    mockAudioContext(0);
+
+    const onTranscriptionUpdate = jest.fn();
+    const onAudioUploaded = jest.fn();
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={onTranscriptionUpdate}
+        onAudioUploaded={onAudioUploaded}
+        maxRecordingSeconds={60}
+      />,
+    );
+
+    await recordAndStop();
+
+    // Wait for error state — error icon and Close button should both appear
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /close recorder/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Click the Close (X) button to dismiss the error
+    const closeBtn = screen.getByRole("button", { name: /close recorder/i });
+    await act(async () => {
+      fireEvent.click(closeBtn);
+    });
+
+    // Error state should be cleared
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /close recorder/i }),
+    ).not.toBeInTheDocument();
+
+    // Recorder returns to idle state — mic button should be visible
+    expect(
+      screen.getByRole("button", { name: /start recording/i }),
+    ).toBeInTheDocument();
+
+    // Transcription text must not be cleared (was never set, so 0 calls)
+    expect(onTranscriptionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT show Close button while a recording is in progress", async () => {
+    mockAudioContext(0.1);
+
+    render(
+      <VoiceRecordingComponent
+        onTranscriptionUpdate={jest.fn()}
+        onAudioUploaded={jest.fn()}
+        maxRecordingSeconds={60}
+      />,
+    );
+
     // Start recording
     const startBtn = screen.getByRole("button", { name: /start recording/i });
     await act(async () => {
       fireEvent.click(startBtn);
     });
 
-    // Simulate a data chunk
-    const speechBlob = new Blob([new ArrayBuffer(100)], {
-      type: "audio/webm",
-    });
-    await act(async () => {
-      capturedOnDataAvailable({ data: speechBlob });
-    });
+    // While recording is active, Close button should NOT be visible
+    expect(
+      screen.queryByRole("button", { name: /close recorder/i }),
+    ).not.toBeInTheDocument();
 
-    // Stop recording
+    // Stop to cleanup (trigger onstop so the component settles before unmount)
     const stopBtn = screen.getByRole("button", { name: /stop recording/i });
     await act(async () => {
       fireEvent.click(stopBtn);
     });
-
-    // Wait for transcription to complete
-    await waitFor(() => {
-      expect(mockUploadAudioAndTranscribe).toHaveBeenCalled();
-    });
-
-    // Description should be updated with transcription text
-    expect(onTranscriptionUpdate).toHaveBeenCalledWith("Hello world");
   });
 });


### PR DESCRIPTION

### Problem

1. **Background noise (fan / AC) producing random text** — The pre-existing silence gate only checked overall RMS energy. A steady fan or air-conditioner comfortably exceeds the threshold, so recordings with no speech were sent to the transcription API, returning garbled or foreign-language text in the Description field.

2. **"No speech detected" error was visually large** — The error was displayed as a wide inline red text block plus a separate yellow triangle icon, causing the recorder toolbar to overflow its compact layout.
<img width="899" height="831" alt="Screenshot 2026-08-30 at 12 39 16 PM" src="https://github.com/user-attachments/assets/64b34c23-a79a-44ad-b652-36139d27b4a2" />


4. **No way to dismiss the recorder** — Once the recorder was in an active state (audio recorded, or in an error state), users had no control to exit back to the plain text Description field without losing their form data.

---

### Changes

#### `VoiceRecordingComponent.jsx`

**Background noise rejection** (`isSilentAudio`)
The silence detection now uses a two-stage algorithm:
1. **Stage 1 – RMS gate** (unchanged): overall RMS < 0.01 → definitely silent.
2. **Stage 2 – Temporal variance gate** (new): for audio with RMS between 0.01–0.06 (the "borderline" range where fan noise lives), the function splits the audio into 100 ms frames and computes the *coefficient of variation* (CV = stddev/mean) of frame-level RMS values. Speech is highly dynamic (CV > 0.25); a fan or AC produces a nearly constant waveform (CV ≈ 0). Audio below the CV threshold is classified as background noise and rejected before the transcription API is ever called.

**Error UX**
Replaced the inline red text + yellow `FiAlertTriangle` button with a single compact red `FiAlertCircle` icon. The full error message is shown in the existing dark hover-tooltip, so the recorder row stays narrow regardless of message length. The icon carries `role="alert"` and an `aria-label` for full screen-reader accessibility.
<img width="1275" height="750" alt="Screenshot 2026-08-30 at 4 25 02 PM" src="https://github.com/user-attachments/assets/56ea3699-5bf6-4c0a-9602-18740eacfa2b" />

<img width="1275" height="771" alt="Screenshot 2026-08-30 at 4 25 22 PM" src="https://github.com/user-attachments/assets/5020a5c9-269f-4ca0-98c8-e36874808c2e" />

**Close / Cancel (X) button**
A new grey `FiX` button appears adjacent to the Play/Delete buttons whenever the recorder has finished (whether successfully or with an error) and is not actively recording or processing. Clicking it calls the new `dismissRecorder` function which:
- Stops playback and releases the audio object URL.
- Calls `onAudioUploaded(null)` so the parent form knows there is no audio to submit.
- **Does NOT call `onTranscriptionUpdate`** — any text already written to the Description field is preserved exactly as-is.
- Has zero effect on Category, Subject, or Details — these live in the parent's `formData` and are untouched.
<img width="1278" height="727" alt="Screenshot 2026-08-30 at 4 25 48 PM" src="https://github.com/user-attachments/assets/046b8cc4-cd58-489f-bf17-7553db1b556b" />



https://github.com/user-attachments/assets/ecdac295-dbc3-4da0-a027-350898d669a9


#### `VoiceRecordingComponent.test.jsx`

- **Infrastructure** — Added `flushPendingTasks()` (0 ms setTimeout yield) and a shared `commonSetup()` helper used by all `beforeEach` blocks. This prevents async Promise chains from one test leaking mock call-counts into the next test.
- **Updated assertion** — The existing "no-speech error" test now checks `aria-label` instead of `textContent`, matching the new icon-only display.
- **4 new tests** added across 2 new describe blocks covering:
  - Steady-noise audio (CV ≈ 0, RMS = 0.02) rejected before calling the transcription API.
  - Variable audio (CV ≈ 0.67) correctly passed through to the transcription API.
  - Close button appearing after successful transcription, dismissing while preserving transcribed text.
  - Close button appearing in error state and dismissing cleanly back to the idle mic button.
  - Close button *not* appearing while a recording is in progress.
- **All 7 tests pass** in < 1 second.
