### PR TITLE
fix: align home page images

### DIFF
--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -91,7 +91,7 @@ export default function Home() {
         <div className="w-1/3 md:w-[33%] flex flex-col justify-center items-center">
           <img
             src={bannerImageTwo}
-            className="aspect-square w-[90%] object-cover object-center rounded-[10px] md:mt-[15%]"
+            className="aspect-[.77] w-2/3 object-cover object-center rounded-[10px]"
             alt={t("JNANAM_VARDHATI_SANCHAYAT_ALT")}
           />
           <h3 className="font-bold text-sm md:text-xl lg:text-2xl tracking-wide m-[10px] text-center leading-tight">

--- a/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
+++ b/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
@@ -61,7 +61,7 @@ exports[`LandingPage renders correctly 1`] = `
           >
             <img
               alt="mockTranslate(JNANAM_VARDHATI_SANCHAYAT_ALT)"
-              class="aspect-square w-[90%] object-cover object-center rounded-[10px] md:mt-[15%]"
+              class="aspect-[.77] w-2/3 object-cover object-center rounded-[10px]"
               src=""
             />
             <h3
@@ -377,7 +377,7 @@ exports[`LandingPage renders correctly 1`] = `
         >
           <img
             alt="mockTranslate(JNANAM_VARDHATI_SANCHAYAT_ALT)"
-            class="aspect-square w-[90%] object-cover object-center rounded-[10px] md:mt-[15%]"
+            class="aspect-[.77] w-2/3 object-cover object-center rounded-[10px]"
             src=""
           />
           <h3


### PR DESCRIPTION
Fixes the alignment issue with the three images on the Home page.
1) Updated the middle image to match the dimensions of the left and right images.
2) Aligned all three images on the same horizontal line.

<img width="475" height="352" alt="image" src="https://github.com/user-attachments/assets/6347f699-68ac-4dd6-9e4f-213caea5c4b1" />
