### PR TITLE
fix: align home page image tops

### DIFF
--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -74,7 +74,7 @@ export default function Home() {
         </div>
         <MetricsTicker />
       </div>
-      <div className="w-full flex flex-row justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0">
+      <div className="w-full flex flex-row items-start justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0">
         <div className="w-1/3 md:w-[22%] flex flex-col justify-center items-center">
           <img
             src={bannerImageOne}

--- a/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
+++ b/src/pages/LandingPage/__snapshots__/landing-page.test.js.snap
@@ -35,7 +35,7 @@ exports[`LandingPage renders correctly 1`] = `
           />
         </div>
         <div
-          class="w-full flex flex-row justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0"
+          class="w-full flex flex-row items-start justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0"
         >
           <div
             class="w-1/3 md:w-[22%] flex flex-col justify-center items-center"
@@ -351,7 +351,7 @@ exports[`LandingPage renders correctly 1`] = `
         />
       </div>
       <div
-        class="w-full flex flex-row justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0"
+        class="w-full flex flex-row items-start justify-center mt-8 gap-2 md:gap-0 px-2 md:px-0"
       >
         <div
           class="w-1/3 md:w-[22%] flex flex-col justify-center items-center"


### PR DESCRIPTION
Related to #1806
This is a follow-up fix for the Home page image alignment.
The three images now start on the same horizontal line while keeping the existing image sizes and responsive layout unchanged.
The LandingPage snapshot test has also been updated.

