### PR TITLE
Swap button order in Change Volunteer and Delete dialogs for consiste…

### DIFF
--- a/src/pages/RequestDetails/RequestDetails.jsx
+++ b/src/pages/RequestDetails/RequestDetails.jsx
@@ -455,16 +455,16 @@ const RequestDetails = () => {
 
               <DialogActions>
                 <StandardButton
-                  text={t("CANCEL")}
-                  onClick={() => setDeleteDialogOpen(false)}
-                  variant="secondary"
-                />
-
-                <StandardButton
                   text={isDeleting ? "Deleting..." : t("DELETE_ACTION")}
                   onClick={handleDeleteRequest}
                   variant="primary"
                   disabled={!deleteReason.trim() || isDeleting}
+                />
+
+                <StandardButton
+                  text={t("CANCEL")}
+                  onClick={() => setDeleteDialogOpen(false)}
+                  variant="secondary"
                 />
               </DialogActions>
             </Dialog>
@@ -492,16 +492,16 @@ const RequestDetails = () => {
 
               <DialogActions>
                 <StandardButton
-                  text={t("CANCEL")}
-                  onClick={() => setChangeVolunteerDialogOpen(false)}
-                  variant="secondary"
-                />
-
-                <StandardButton
                   text={t("SAVE")}
                   onClick={handleChangeVolunteer}
                   disabled={!volunteerChangeReason.trim()}
                   variant="primary"
+                />
+
+                <StandardButton
+                  text={t("CANCEL")}
+                  onClick={() => setChangeVolunteerDialogOpen(false)}
+                  variant="secondary"
                 />
               </DialogActions>
             </Dialog>

--- a/src/pages/RequestDetails/RequestDetails.test.jsx
+++ b/src/pages/RequestDetails/RequestDetails.test.jsx
@@ -158,3 +158,114 @@ describe("RequestDetails - Edit onClose refreshes data", () => {
     expect(screen.queryByTestId("help-request-form")).not.toBeInTheDocument();
   });
 });
+
+describe("RequestDetails - Delete dialog button order and behavior", () => {
+  beforeEach(() => {
+    mockLocationState = { id: "123", subject: "Test Request" };
+  });
+
+  it("opens the delete dialog and shows Delete before Cancel", () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    fireEvent.click(screen.getByText("DETAILS"));
+    fireEvent.click(screen.getByRole("button", { name: "DELETE" }));
+
+    const deleteActionButton = screen.getByRole("button", {
+      name: "DELETE_ACTION",
+    });
+    const cancelButton = screen.getByRole("button", { name: "CANCEL" });
+
+    expect(deleteActionButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+    expect(
+      deleteActionButton.compareDocumentPosition(cancelButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("disables Delete until a reason is entered, then enables it", () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    fireEvent.click(screen.getByText("DETAILS"));
+    fireEvent.click(screen.getByRole("button", { name: "DELETE" }));
+
+    const deleteActionButton = screen.getByRole("button", {
+      name: "DELETE_ACTION",
+    });
+    expect(deleteActionButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("REASON"), {
+      target: { value: "No longer needed" },
+    });
+
+    expect(deleteActionButton).not.toBeDisabled();
+  });
+
+  it("Cancel closes the delete dialog", async () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    fireEvent.click(screen.getByText("DETAILS"));
+    fireEvent.click(screen.getByRole("button", { name: "DELETE" }));
+
+    expect(
+      screen.getByRole("button", { name: "DELETE_ACTION" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "CANCEL" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "DELETE_ACTION" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("RequestDetails - Change Volunteer dialog button order and behavior", () => {
+  beforeEach(() => {
+    mockLocationState = { id: "123", subject: "Test Request" };
+  });
+
+  it("opens the change volunteer dialog and shows Save before Cancel", () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    fireEvent.click(screen.getByText("DETAILS"));
+    fireEvent.click(screen.getByRole("button", { name: "CHANGE_VOLUNTEER" }));
+
+    const saveButton = screen.getByRole("button", { name: "SAVE" });
+    const cancelButton = screen.getByRole("button", { name: "CANCEL" });
+
+    expect(saveButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+    expect(
+      saveButton.compareDocumentPosition(cancelButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("disables Save until a reason is entered, then enables it", () => {
+    renderWithProviders(<RequestDetails />, {
+      preloadedState: MOCK_STATE_LOGGED_IN,
+    });
+
+    fireEvent.click(screen.getByText("DETAILS"));
+    fireEvent.click(screen.getByRole("button", { name: "CHANGE_VOLUNTEER" }));
+
+    const saveButton = screen.getByRole("button", { name: "SAVE" });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("REASON"), {
+      target: { value: "Volunteer unavailable" },
+    });
+
+    expect(saveButton).not.toBeDisabled();
+  });
+});

--- a/src/pages/RequestDetails/RequestDetails.test.jsx
+++ b/src/pages/RequestDetails/RequestDetails.test.jsx
@@ -269,3 +269,22 @@ describe("RequestDetails - Change Volunteer dialog button order and behavior", (
     expect(saveButton).not.toBeDisabled();
   });
 });
+
+it("Cancel closes the change volunteer dialog", async () => {
+  renderWithProviders(<RequestDetails />, {
+    preloadedState: MOCK_STATE_LOGGED_IN,
+  });
+
+  fireEvent.click(screen.getByText("DETAILS"));
+  fireEvent.click(screen.getByRole("button", { name: "CHANGE_VOLUNTEER" }));
+
+  expect(screen.getByRole("button", { name: "SAVE" })).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "CANCEL" }));
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("button", { name: "SAVE" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Swap button order in Change Volunteer and Delete dialogs (#1571)

1. Change Volunteer dialog: Save now on left, Cancel on right
2. Delete dialog: Delete now on left, Cancel on right
3. Matches Logout dialog and Create Help Request page pattern
4. Added test coverage for both dialogs (button order, disabled/enabled states, Cancel behavior)
5. No functional changes — only button order and test coverage