### PR TITLE
Fix flaky CI test: mock MediaRecorder.stop() sets state to inactive

### DIFF
--- a/src/common/components/VoiceRecordingComponent.test.jsx
+++ b/src/common/components/VoiceRecordingComponent.test.jsx
@@ -104,6 +104,12 @@ function setupMediaMocks() {
   mockMediaRecorderInstance = {
     start: jest.fn(),
     stop: jest.fn().mockImplementation(() => {
+      // Mirror the real MediaRecorder API: state becomes "inactive" after stop().
+      // Without this, the component's unmount cleanup calls stopRecording() again,
+      // sees state="recording", and fires mr.stop() a second time — launching a
+      // duplicate async onstop handler that can call uploadAudioAndTranscribe after
+      // jest.clearAllMocks() has run, polluting the next test's call counts.
+      mockMediaRecorderInstance.state = "inactive";
       if (capturedOnStop) capturedOnStop();
     }),
     pause: jest.fn(),


### PR DESCRIPTION
The mock never transitioned to inactive after stop(). On unmount, useEffect cleanup calls stopRecording() again; seeing state=recording it fires stop() a second time, launching a duplicate async onstop handler that called uploadAudioAndTranscribe after clearAllMocks(). The spurious call failed the background-noise test only with CI=true.

Fix: set state=inactive in stop() mock, mirroring the real API.