### PR TITLE
Update Vishal Sikka title in French

### DIFF
--- a/src/common/i18n/locales/fr/news.json
+++ b/src/common/i18n/locales/fr/news.json
@@ -16,7 +16,7 @@
   "STORY_3_TITLE": "Avec Jensen Huang, PDG de NVIDIA",
   "STORY_3_DESC": "Rao avec Jensen Huang, PDG de NVIDIA, lors de la conférence IIT Bay Area.",
 
-  "STORY_4_TITLE": "Avec Vishal Sikka, fondateur et PDG de Vianai Systems",
+  "STORY_4_TITLE": "Avec Vishal Sikka, fondateur et PDG de Hang Ten Systems",
   "STORY_4_DESC": "Un échange enrichissant avec Vishal Sikka sur le leadership, l’innovation axée sur un objectif et la création d’organisations ayant un impact durable.",
 
   "STORY_5_TITLE": "Avec Ramesh Maturu et Ramana Yerneni sur la plage de Carmel-by-the-Sea, Californie",


### PR DESCRIPTION
## Description
Updated the French translation for Vishal Sikka’s title to match the English version.
### Change
* Updated the title to:  "Avec Vishal Sikka, fondateur et PDG de Hang Ten Systems",
* Modified the French `news.json` file only.
### Testing
* Verified that the JSON format is valid.
* Confirmed that the updated title displays correctly in French.
